### PR TITLE
Selectively uncompress kernel binary from archive

### DIFF
--- a/Sources/CLI/System/SystemStart.swift
+++ b/Sources/CLI/System/SystemStart.swift
@@ -85,13 +85,13 @@ extension Application {
                 )
             }
 
-            var kernelConfigured: Bool = false
+            var kernelConfigured: Bool = true
             var missingDependencies: [Dependencies] = []
             if await !initImageExists() {
                 missingDependencies.append(.initFs)
             }
             if await !kernelExists() {
-                kernelConfigured = true
+                kernelConfigured = false
                 missingDependencies.append(.kernel)
             }
             guard missingDependencies.count > 0 else {

--- a/Sources/ContainerClient/XPC+.swift
+++ b/Sources/ContainerClient/XPC+.swift
@@ -94,7 +94,6 @@ public enum XPCKeys: String {
     case kernelTarURL
     case kernelFilePath
     case setDefault
-    case installedKernels
     case systemPlatform
     case kernelName
 }


### PR DESCRIPTION
Prior to this change, when we were asked to setup the default runtime kernel from an archive, we would uncompress the whole archive to get a single file from it.

This change makes it such that only the required kernel binary is extracted from the archive - making the whole process a lot faster.