### PR TITLE
Clear a line with spaces to prevent a race between `stderr` and `stdout`

### DIFF
--- a/Sources/TerminalProgress/ProgressBar+Terminal.swift
+++ b/Sources/TerminalProgress/ProgressBar+Terminal.swift
@@ -20,7 +20,6 @@ import Foundation
 enum EscapeSequence {
     static let hideCursor = "\u{001B}[?25l"
     static let showCursor = "\u{001B}[?25h"
-    static let clearLine = "\u{001B}[2K"
     static let moveUp = "\u{001B}[1A"
 }
 
@@ -38,14 +37,15 @@ extension ProgressBar {
     }
 
     /// Clears the progress bar and resets the cursor.
-    static public func clearAndResetCursor() {
-        ProgressBar.clear()
+    public func clearAndResetCursor() {
+        clear()
         ProgressBar.resetCursor()
     }
 
     /// Clears the progress bar.
-    static public func clear() {
-        ProgressBar.display(EscapeSequence.clearLine)
+    public func clear() {
+        // We can't use "\u{001B}[2K" for clearing the line because this may lead to a race with `stdout` when using `stderr` for progress updates.
+        displayText("")
     }
 
     /// Resets the cursor.

--- a/Sources/TerminalProgress/ProgressBar.swift
+++ b/Sources/TerminalProgress/ProgressBar.swift
@@ -38,7 +38,7 @@ public final class ProgressBar: Sendable {
     }
 
     deinit {
-        ProgressBar.clear()
+        clear()
     }
 
     /// Allows resetting the progress state.
@@ -48,7 +48,7 @@ public final class ProgressBar: Sendable {
 
     /// Allows resetting the progress state of the current task.
     public func resetCurrentTask() {
-        ProgressBar.clear()
+        clear()
         state = State(description: state.description, itemsName: state.itemsName, tasks: state.tasks, totalTasks: state.totalTasks, startTime: state.startTime)
     }
 
@@ -125,7 +125,7 @@ public final class ProgressBar: Sendable {
         }
 
         if config.clearOnFinish {
-            ProgressBar.clearAndResetCursor()
+            clearAndResetCursor()
         } else {
             ProgressBar.resetCursor()
         }


### PR DESCRIPTION
This PR resolves a race with `\u{001B}[2K`, but not with `\r`, which will be addressed in a separate PR by moving progress updates to `stdout`. Please test it in a small window in your terminal application on the `users/a_ramani/install-ux` branch using commands:
```
bin/container system stop
make cleancontent
bin/container system start
```
You should see the prompt:
> Install the recommended default kernel from [https://github.com/kata-containers/kata-containers/releases/download/3.17.0/kata-static-3.17.0-arm64.tar.xz]? [Y/n]: