### PR TITLE
Update kernel install UX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,7 @@ _site:
 
 .PHONY: cleancontent
 cleancontent:
+	@bin/container system stop || true
 	@echo Cleaning the content...
 	@rm -rf ~/Library/Application\ Support/com.apple.container
 

--- a/Sources/APIServer/Kernel/KernelService.swift
+++ b/Sources/APIServer/Kernel/KernelService.swift
@@ -42,6 +42,7 @@ actor KernelService {
         let kFile = url.resolvingSymlinksInPath()
         let destPath = self.kernelDirectory.appendingPathComponent(kFile.lastPathComponent)
         try FileManager.default.copyItem(at: kFile, to: destPath)
+        try Task.checkCancellation()
         try self.setDefaultKernel(name: kFile.lastPathComponent, platform: platform)
     }
 

--- a/Sources/CLI/System/Kernel/KernelSet.swift
+++ b/Sources/CLI/System/Kernel/KernelSet.swift
@@ -39,13 +39,14 @@ extension Application {
         @Option(name: .customLong("arch"), help: "The architecture of the kernel binary. One of (amd64, arm64)")
         var architecture: String = ContainerizationOCI.Platform.current.architecture.description
 
-        @Flag(name: .customLong("install-recommended"), help: "Download and install the recommended kernel as the default. This flag ignores any other arguments")
-        var installRecommended: Bool = false
+        @Flag(name: .customLong("recommended"), help: "Download and install the recommended kernel as the default. This flag ignores any other arguments")
+        var recommended: Bool = false
 
         func run() async throws {
-            if installRecommended {
+            if recommended {
                 let url = ClientDefaults.get(key: .defaultKernelURL)
                 let path = ClientDefaults.get(key: .defaultKernelBinaryPath)
+                print("Installing the recommended kernel from \(url)...")
                 try await Self.downloadAndInstallWithProgressBar(tarRemoteURL: url, kernelFilePath: path)
                 return
             }

--- a/Sources/ContainerClient/Core/ClientKernel.swift
+++ b/Sources/ContainerClient/Core/ClientKernel.swift
@@ -80,7 +80,7 @@ extension ClientKernel {
                 throw err
             }
             throw ContainerizationError(
-                .notFound, message: "Default kernel not configured for architecture \(platform.architecture). Please use the `container system kernel` command to configure it")
+                .notFound, message: "Default kernel not configured for architecture \(platform.architecture). Please use the `container system kernel set` command to configure it")
         }
     }
 }

--- a/Sources/ContainerClient/XPC+.swift
+++ b/Sources/ContainerClient/XPC+.swift
@@ -93,9 +93,7 @@ public enum XPCKeys: String {
     case kernel
     case kernelTarURL
     case kernelFilePath
-    case setDefault
     case systemPlatform
-    case kernelName
 }
 
 public enum XPCRoute: String {


### PR DESCRIPTION
This change updates the UX when we install required dependencies at first launch


### Fresh install - respond `y` to prompt
```
➜ bin/container system start
Verifying apiserver is running...
Installing base container filesystem...
No default kernel configured.
Install the recommended default kernel from [https://github.com/kata-containers/kata-containers/releases/download/3.17.0/kata-static-3.17.0-arm64.tar.xz]? [Y/n]: y
Installing kernel...
```


### Fresh install - respond `n` to prompt and then run the provided command
```
➜ bin/container system start
Verifying apiserver is running...
No default kernel configured.
Install the recommended default kernel from [https://github.com/kata-containers/kata-containers/releases/download/3.17.0/kata-static-3.17.0-arm64.tar.xz]? [Y/n]: n
Please use the `container system kernel set --recommended` command to configure the default kernel

➜ bin/container system kernel set --recommended
Installing the recommended kernel from https://github.com/kata-containers/kata-containers/releases/download/3.17.0/kata-static-3.17.0-arm64.tar.xz...
```


### Fresh install - respond `n` to prompt and then run a container
```
➜ bin/container system start
Verifying apiserver is running...
Installing base container filesystem...
No default kernel configured.
Install the recommended default kernel from [https://github.com/kata-containers/kata-containers/releases/download/3.17.0/kata-static-3.17.0-arm64.tar.xz]? [Y/n]: n
Please use the `container system kernel set --recommended` command to configure the default kernel

➜ bin/container run alpine uname
Error: notFound: "Default kernel not configured for architecture arm64. Please use the `container system kernel set` command to configure it
```