### PR TITLE
moves intro image to beneath the intro text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-![introductory movie showing some basic commands](./docs/assets/landing-movie.gif)
 
 # `container`
 
@@ -7,6 +6,8 @@
 The application consumes and produces OCI-compliant container images, so you can pull and run images from any standard container registry. You can push images that you build to those registries as well, and run the images in any other OCI-compliant application.
 
 `container` uses the [Containerization](https://github.com/apple/containerization) Swift package for low level container, image and process management.
+
+![introductory movie showing some basic commands](./docs/assets/landing-movie.gif)
 
 ## Get started
 


### PR DESCRIPTION
Moves the introductory animation/image to beneath a title for the README and the initial introductory text. Explains what you're seeing a bit better, while still keeping the image "above the fold" to make it prominent and encourage people to see and understand what this project does.