### PR TITLE
Only allow publishing docs on release branch or tags

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -7,7 +7,7 @@ on:
 jobs: 
   checkBranch:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release')
+    if: startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/release')
     steps:
       - name: Branch validation 
         run: echo "Branch ${{ github.ref_name }} is allowed"


### PR DESCRIPTION
This removes the ability to deploy docs on the main branch and instead only allows docs deployment on either a tag or a release branch. Docs are also built (but not deployed) in the common job run by the build and release pipelines. 