### PR TITLE
[Build] purely-lexical URL operations for resolving symlinks

### DIFF
--- a/Tests/ContainerBuildTests/BuilderExtensionsTests.swift
+++ b/Tests/ContainerBuildTests/BuilderExtensionsTests.swift
@@ -14,8 +14,6 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-//
-
 import Foundation
 import Testing
 
@@ -184,17 +182,6 @@ import Testing
         #expect(false == httpURL.parentOf(fileURL))
         #expect(false == fileURL.parentOf(httpURL))
     }
-
-    @Test func testParentOfRelativePaths() throws {
-        let absoluteChildDir = baseTempURL.appendingPathComponent("someDir")
-        try createDirectory(at: absoluteChildDir)
-        let relativeSelfURL = URL(fileURLWithPath: "a/relative/path")
-        #expect(relativeSelfURL.parentOf(absoluteChildDir))
-        let potentiallyParentRelative = URL(fileURLWithPath: baseTempURL.lastPathComponent)
-        #expect(potentiallyParentRelative.parentOf(absoluteChildDir))
-    }
-
-    // MARK: - relativeChildPath Tests
 
     @Test func testRelativeChildPathDirectChild() throws {
         let parentDir = baseTempURL.appendingPathComponent("dir1")


### PR DESCRIPTION
`BuildFSSync.walk` relied on an implementation detail to skip traversing the path ".", relative to the build context dir.  

Specifically, it assumed that:
 - `URL.parentOf()` would return false when the parent argument was relative.
 - `URL.path(percentEncoded: false)` would preserve the relativity of an input path.
These assumptions held on earlier macOS releases, so the context directory silently remained untouched.

In some versions of macOS , `URL.path(percentEncoded: false)` always returns an absolute path, regardless of how the URL was created. Because of this change, `URL.parentOf()` now returns true for ".", and BuildFSSync.walk begins descending into the context directory—something it was never meant to do.

This solution:
- Remove the hidden dependency on `URL.parentOf()` for context‑directory detection.
- Add an explicit check for "." inside BuildFSSync.walk and bail out early.

Replace fragile calls to `URL.path(percentEncoded: false`) with the stable, documented `URL.relativePath`, which preserves relativity when the original path was relative.