### PR TITLE
docs: let's drop contributors

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,5 +1,0 @@
-This file contains a list of contributors who have made meaningful changes to this repository.   
-Please add your name and GitHub handle to this file as an optional step in the contribution process for attribution.   
-Email is not required.
-
-### Contributors


### PR DESCRIPTION
We'll have original authors on first commit, let's skip having a contributors file for now.