### PR TITLE
Publish docs from main

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -7,7 +7,7 @@ on:
 jobs: 
   checkBranch:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/release')
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags') || startsWith(github.ref, 'refs/heads/release')
     steps:
       - name: Branch validation 
         run: echo "Branch ${{ github.ref_name }} is allowed"


### PR DESCRIPTION
We eventually only want to support building docs from release branches and tags, however, while we're working to initially set up the docs, we may have some churn. So we want to be able to publish from main during that churn.