### PR TITLE
Update the names of Xcode and  macOS

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -2,8 +2,8 @@
 
 To build the `container` project, your system needs either:
 
-- macOS 15 or newer and Xcode 26 Beta
-- macOS 26 Beta 1 or newer
+- macOS 15 or newer and Xcode 26 beta
+- macOS 26 beta or newer
 
 ## Compile and test
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The tool consumes and produces OCI-compliant container images, so you can pull a
 
 You need an Apple silicon Mac to run `container`. To build it, see the [BUILDING](./BUILDING.md) document.
 
-`container` relies on the new features and enhancements present in the macOS 26 Beta 1. You can run the tool on macOS 15, but the `container` maintainers typically will not address issues discovered on macOS 15 that cannot be reproduced on the macOS 26 Beta 1.
+`container` relies on the new features and enhancements present in the macOS 26 beta. You can run the tool on macOS 15, but the `container` maintainers typically will not address issues discovered on macOS 15 that cannot be reproduced on the macOS 26 beta.
 
 There are [significant networking limitations](/docs/technical-overview.md#macos-15-limitations) that impact the usability of `container` on macOS 15.
 

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -67,7 +67,7 @@ Currently, memory pages freed to the Linux operating system by processes running
 
 ### macOS 15 limitations
 
-`container` relies on the new features and enhancements present in the macOS 26 Beta 1. You can run `container` on macOS 15, but you will need to be aware of some user experience and functional limitations. There is no plan to address issues found with macOS 15 that cannot be reproduced in the macOS 26 Beta 1.
+`container` relies on the new features and enhancements present in the macOS 26 beta. You can run `container` on macOS 15, but you will need to be aware of some user experience and functional limitations. There is no plan to address issues found with macOS 15 that cannot be reproduced in the macOS 26 beta.
 
 #### Network isolation
 


### PR DESCRIPTION
This PR updates the names of Xcode and macOS to the official names used in https://developer.apple.com/download/applications/.