### PR TITLE
Add the option to disable progress updates on image CLI calls

### DIFF
--- a/Sources/CLI/Container/ContainerCreate.swift
+++ b/Sources/CLI/Container/ContainerCreate.swift
@@ -48,17 +48,12 @@ extension Application {
         var global: Flags.Global
 
         func run() async throws {
-            var progressConfig: ProgressConfig
-            if managementFlags.disableProgressUpdates {
-                progressConfig = try ProgressConfig(disableProgressUpdates: managementFlags.disableProgressUpdates)
-            } else {
-                progressConfig = try ProgressConfig(
-                    showTasks: true,
-                    showItems: true,
-                    ignoreSmallSize: true,
-                    totalTasks: 3
-                )
-            }
+            let progressConfig = try ProgressConfig(
+                showTasks: true,
+                showItems: true,
+                ignoreSmallSize: true,
+                totalTasks: 3
+            )
             let progress = ProgressBar(config: progressConfig)
             defer {
                 progress.finish()

--- a/Sources/CLI/Image/ImagePush.swift
+++ b/Sources/CLI/Image/ImagePush.swift
@@ -33,6 +33,9 @@ extension Application {
         @OptionGroup
         var registry: Flags.Registry
 
+        @OptionGroup
+        var progressFlags: Flags.Progress
+
         @Option(help: "Platform string in the form 'os/arch/variant'. Example 'linux/arm64/v8', 'linux/amd64'") var platform: String?
 
         @Argument var reference: String
@@ -46,13 +49,18 @@ extension Application {
             let scheme = try RequestScheme(registry.scheme)
             let image = try await ClientImage.get(reference: reference)
 
-            let progressConfig = try ProgressConfig(
-                description: "Pushing image \(image.reference)",
-                itemsName: "blobs",
-                showItems: true,
-                showSpeed: false,
-                ignoreSmallSize: true
-            )
+            var progressConfig: ProgressConfig
+            if progressFlags.disableProgressUpdates {
+                progressConfig = try ProgressConfig(disableProgressUpdates: progressFlags.disableProgressUpdates)
+            } else {
+                progressConfig = try ProgressConfig(
+                    description: "Pushing image \(image.reference)",
+                    itemsName: "blobs",
+                    showItems: true,
+                    showSpeed: false,
+                    ignoreSmallSize: true
+                )
+            }
             let progress = ProgressBar(config: progressConfig)
             defer {
                 progress.finish()

--- a/Sources/CLI/RunCommand.swift
+++ b/Sources/CLI/RunCommand.swift
@@ -45,6 +45,9 @@ extension Application {
         @OptionGroup
         var global: Flags.Global
 
+        @OptionGroup
+        var progressFlags: Flags.Progress
+
         @Argument(help: "Image name")
         var image: String
 
@@ -56,8 +59,8 @@ extension Application {
             let id = Utility.createContainerID(name: self.managementFlags.name)
 
             var progressConfig: ProgressConfig
-            if managementFlags.disableProgressUpdates {
-                progressConfig = try ProgressConfig(disableProgressUpdates: managementFlags.disableProgressUpdates)
+            if progressFlags.disableProgressUpdates {
+                progressConfig = try ProgressConfig(disableProgressUpdates: progressFlags.disableProgressUpdates)
             } else {
                 progressConfig = try ProgressConfig(
                     showTasks: true,

--- a/Sources/ContainerClient/Flags.swift
+++ b/Sources/ContainerClient/Flags.swift
@@ -138,6 +138,14 @@ public struct Flags {
 
         @Option(name: [.customLong("label"), .customShort("l")], help: "Add a key=value label to the container")
         public var labels: [String] = []
+    }
+
+    public struct Progress: ParsableArguments {
+        public init() {}
+
+        public init(disableProgressUpdates: Bool) {
+            self.disableProgressUpdates = disableProgressUpdates
+        }
 
         @Flag(name: .customLong("disable-progress-updates"), help: "Disable progress bar updates")
         public var disableProgressUpdates = false


### PR DESCRIPTION
Closes https://github.com/apple/container/issues/126 

This PR additionally removes the ability to set `disable-progress-updates` for `container create` calls while we investigate why output get jumbled there. 