### PR TITLE
Update protos and add builder shim version in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,7 @@ if let path = ProcessInfo.processInfo.environment["CONTAINERIZATION_PATH"] {
 
 let releaseVersion = ProcessInfo.processInfo.environment["RELEASE_VERSION"] ?? "0.0.0"
 let gitCommit = ProcessInfo.processInfo.environment["GIT_COMMIT"] ?? "unspecified"
+let builderShimVersion = "0.2.0"
 
 let package = Package(
     name: "container",
@@ -309,6 +310,7 @@ let package = Package(
                 .define("CZ_VERSION", to: "\"\(scVersion)\""),
                 .define("GIT_COMMIT", to: "\"\(gitCommit)\""),
                 .define("RELEASE_VERSION", to: "\"\(releaseVersion)\""),
+                .define("BUILDER_SHIM_VERSION", to: "\"\(builderShimVersion)\"")
             ]
         ),
     ]

--- a/Protobuf.Makefile
+++ b/Protobuf.Makefile
@@ -17,7 +17,9 @@ LOCAL_DIR := $(ROOT_DIR)/.local
 LOCALBIN := $(LOCAL_DIR)/bin
 
 BUILDER_SHIM_REPO ?= https://github.com/apple/container-builder-shim.git
+
 ## Versions
+BUILDER_SHIM_VERSION ?= $(shell sed -n 's/let builderShimVersion *= *"\(.*\)"/\1/p' Package.swift)
 PROTOC_VERSION=26.1
 
 # protoc binary installation
@@ -41,7 +43,7 @@ protoc-gen-swift:
 protos: $(PROTOC) protoc-gen-swift protoc_gen_grpc_swift 
 	@echo Generating protocol buffers source code...
 	@mkdir -p $(LOCAL_DIR)
-	@cd $(LOCAL_DIR) && git clone $(BUILDER_SHIM_REPO)
+	@cd $(LOCAL_DIR) && git clone --branch $(BUILDER_SHIM_VERSION) --depth 1 $(BUILDER_SHIM_REPO)
 	@$(PROTOC) $(LOCAL_DIR)/container-builder-shim/pkg/api/Builder.proto \
 		--plugin=protoc-gen-grpc-swift=$(BUILD_BIN_DIR)/protoc-gen-grpc-swift \
 		--plugin=protoc-gen-swift=$(BUILD_BIN_DIR)/protoc-gen-swift \

--- a/Sources/CVersion/Version.c
+++ b/Sources/CVersion/Version.c
@@ -42,3 +42,7 @@ const char* get_release_version() {
 const char* get_swift_containerization_version() {
     return CZ_VERSION;
 }
+
+const char* get_container_builder_shim_version() {
+    return BUILDER_SHIM_VERSION;
+}

--- a/Sources/CVersion/include/Version.h
+++ b/Sources/CVersion/include/Version.h
@@ -40,8 +40,14 @@
 #define RELEASE_VERSION "0.0.0"
 #endif
 
+#ifndef BUILDER_SHIM_VERSION
+#define BUILDER_SHIM_VERSION "0.0.0"
+#endif
+
 const char* get_git_commit();
 
 const char* get_release_version();
 
 const char* get_swift_containerization_version();
+
+const char* get_container_builder_shim_version();

--- a/Sources/ContainerBuild/Builder.grpc.swift
+++ b/Sources/ContainerBuild/Builder.grpc.swift
@@ -33,7 +33,7 @@ import SwiftProtobuf
 /// To perform a build:
 ///
 /// 1. CreateBuild to create a new build
-/// 2. StartBuild to start the build exection where client and server
+/// 2. StartBuild to start the build execution where client and server
 ///    both have a stream for exchanging data during the build.
 ///
 ///    The client may send:
@@ -96,7 +96,7 @@ import SwiftProtobuf
 ///         source path, and empty data
 ///      2. server archives the data at source path, and starts to send chunks to
 ///      the client
-///      3. server coninues to send all chunks until last chunk, which server
+///      3. server continues to send all chunks until last chunk, which server
 ///      will send with
 ///         'complete' set to true
 ///      4. client starts to receive the data and stream to a temporary file
@@ -263,7 +263,7 @@ public struct Com_Apple_Container_Build_V1_BuilderNIOClient: Com_Apple_Container
 /// To perform a build:
 ///
 /// 1. CreateBuild to create a new build
-/// 2. StartBuild to start the build exection where client and server
+/// 2. StartBuild to start the build execution where client and server
 ///    both have a stream for exchanging data during the build.
 ///
 ///    The client may send:
@@ -326,7 +326,7 @@ public struct Com_Apple_Container_Build_V1_BuilderNIOClient: Com_Apple_Container
 ///         source path, and empty data
 ///      2. server archives the data at source path, and starts to send chunks to
 ///      the client
-///      3. server coninues to send all chunks until last chunk, which server
+///      3. server continues to send all chunks until last chunk, which server
 ///      will send with
 ///         'complete' set to true
 ///      4. client starts to receive the data and stream to a temporary file
@@ -526,7 +526,7 @@ public enum Com_Apple_Container_Build_V1_BuilderClientMetadata {
 /// To perform a build:
 ///
 /// 1. CreateBuild to create a new build
-/// 2. StartBuild to start the build exection where client and server
+/// 2. StartBuild to start the build execution where client and server
 ///    both have a stream for exchanging data during the build.
 ///
 ///    The client may send:
@@ -589,7 +589,7 @@ public enum Com_Apple_Container_Build_V1_BuilderClientMetadata {
 ///         source path, and empty data
 ///      2. server archives the data at source path, and starts to send chunks to
 ///      the client
-///      3. server coninues to send all chunks until last chunk, which server
+///      3. server continues to send all chunks until last chunk, which server
 ///      will send with
 ///         'complete' set to true
 ///      4. client starts to receive the data and stream to a temporary file
@@ -673,7 +673,7 @@ extension Com_Apple_Container_Build_V1_BuilderProvider {
 /// To perform a build:
 ///
 /// 1. CreateBuild to create a new build
-/// 2. StartBuild to start the build exection where client and server
+/// 2. StartBuild to start the build execution where client and server
 ///    both have a stream for exchanging data during the build.
 ///
 ///    The client may send:
@@ -736,7 +736,7 @@ extension Com_Apple_Container_Build_V1_BuilderProvider {
 ///         source path, and empty data
 ///      2. server archives the data at source path, and starts to send chunks to
 ///      the client
-///      3. server coninues to send all chunks until last chunk, which server
+///      3. server continues to send all chunks until last chunk, which server
 ///      will send with
 ///         'complete' set to true
 ///      4. client starts to receive the data and stream to a temporary file

--- a/Sources/ContainerClient/Core/ClientDefaults.swift
+++ b/Sources/ContainerClient/Core/ClientDefaults.swift
@@ -63,7 +63,8 @@ extension ClientDefaults.Keys {
         case .defaultKernelBinaryPath:
             return "opt/kata/share/kata-containers/vmlinux-6.12.28-153"
         case .defaultBuilderImage:
-            return "ghcr.io/apple/container-builder-shim/builder:0.1.0"
+            let tag = String(cString: get_container_builder_shim_version())
+            return "ghcr.io/apple/container-builder-shim/builder:\(tag)"
         case .defaultDNSDomain:
             return "test"
         case .defaultRegistryDomain:


### PR DESCRIPTION
This PR updates the protos to match the recent changes in https://github.com/apple/container-builder-shim/pull/15. 

This PR additionally adds the builder shim version as a variable in Package.swift. This allows us to be consistent with the builder tag used for the builder shim image and when building protobuf files. 