### PR TITLE
provide suggestion if xpc 'Connection invalid' error encountered

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Download the latest signed installer package for `container` from the [GitHub re
 
 To install the tool, double click the package file and follow the instructions. Enter your administrator password when prompted, to give the installer permission to place the installed files under `/usr/local`.
 
+Start the system service with:
+
+```
+container system start
+```
+
 ### Uninstall
 
 Use the `uninstall-container.sh` script to remove `container` from your system. To remove your user data along with the tool, run:

--- a/Sources/CLI/Application.swift
+++ b/Sources/CLI/Application.swift
@@ -21,6 +21,7 @@ import CVersion
 import ContainerClient
 import ContainerLog
 import ContainerPlugin
+import ContainerizationError
 import ContainerizationOS
 import Foundation
 import Logging
@@ -176,7 +177,13 @@ struct Application: AsyncParsableCommand {
                 Self.printModifiedHelpText()
                 return
             }
-            Application.exit(withError: error)
+            let errorAsString: String = String(describing: error)
+            if errorAsString.contains("XPC connection error") {
+                let modifiedError = ContainerizationError(.interrupted, message: "\(error)\nEnsure container system service has been started with `container system start`.")
+                Application.exit(withError: modifiedError)
+            } else {
+                Application.exit(withError: error)
+            }
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/apple/container/issues/80

Adds the following help message if you try to run `container` against a host that hasn't started the container system:

```
❯ /usr/local/bin/container list
Error: internalError: "failed to list containers" (cause: "interrupted: "Connection invalid: ensure container system has been started with `container system start`"")

❯ /usr/local/bin/container run -it --rm docker.io/alpine
Error: interrupted: "Connection invalid: ensure container system has been started with `container system start`"
```