### PR TITLE
Add default year for hawkeye formatting

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -310,7 +310,7 @@ let package = Package(
                 .define("CZ_VERSION", to: "\"\(scVersion)\""),
                 .define("GIT_COMMIT", to: "\"\(gitCommit)\""),
                 .define("RELEASE_VERSION", to: "\"\(releaseVersion)\""),
-                .define("BUILDER_SHIM_VERSION", to: "\"\(builderShimVersion)\"")
+                .define("BUILDER_SHIM_VERSION", to: "\"\(builderShimVersion)\""),
             ]
         ),
     ]

--- a/scripts/install-hawkeye.sh
+++ b/scripts/install-hawkeye.sh
@@ -17,6 +17,6 @@ if command -v .local/bin/hawkeye >/dev/null 2>&1; then
     echo "hawkeye already installed"
 else
     echo "Installing hawkeye"
-    export VERSION=v6.0.4
+    export VERSION=v6.1.0
     curl --proto '=https' --tlsv1.2 -LsSf https://github.com/korandoru/hawkeye/releases/download/${VERSION}/hawkeye-installer.sh | CARGO_HOME=.local sh -s -- --no-modify-path
 fi

--- a/scripts/license-header.txt
+++ b/scripts/license-header.txt
@@ -1,4 +1,4 @@
-Copyright ©{{ " " }}{%- if attrs.git_file_modified_year != attrs.git_file_created_year -%}{{ attrs.git_file_created_year }}-{{ attrs.git_file_modified_year }}{%- else -%}{{ attrs.git_file_created_year }}{%- endif -%}{{ " " }}{{ props["copyrightOwner"] }}. All rights reserved.
+Copyright ©{{ " " }}{%- set created = attrs.git_file_created_year or attrs.disk_file_created_year -%}{%- set modified = attrs.git_file_modified_year or created -%}{%- if created != modified -%} {{created}}-{{modified}}{%- else -%}{{created}}{%- endif -%}{{ " " }}{{ props["copyrightOwner"] }}. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This adds a default year to use when a file does not yet have git attributes (aka for a newly created file). 