### PR TITLE
Fix release workflow: tag regex, artifact validation, and token usage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: container project - release build
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+\\.[0-9]+\\.[0-9]+"
 
 jobs:
   build:
@@ -16,7 +16,9 @@ jobs:
       contents: read
       packages: read
       pages: write
+
   release:
+    if: startsWith(github.ref, 'refs/tags/')
     name: Publish release
     timeout-minutes: 30
     needs: build
@@ -30,10 +32,18 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: outputs
+
+      - name: Verify artifacts exist
+        run: |
+          echo "Checking for expected artifacts..."
+          ls -la outputs/container-package/
+          test -e outputs/container-package/*.zip || (echo "Missing .zip file!" && exit 1)
+          test -e outputs/container-package/*.pkg || (echo "Missing .pkg file!" && exit 1)
+
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           name: ${{ github.ref_name }}-prerelease
           draft: true
           make_latest: false


### PR DESCRIPTION
## 🔧 Summary
This PR improves the release.yml GitHub Actions workflow by addressing several critical issues to ensure consistent and reliable behavior during tag-based releases.

## ✅ Changes Included
### 1. Fixed tag trigger regex
- Escaped dots in the tag regex ([0-9]+\\.[0-9]+\\.[0-9]+) to ensure only semantic version tags like 1.2.3 trigger the workflow.
#####  Explanation
 - Old **Regex** is incorrect because . matches **any character**, so it matched:

`1-2-3`, `1_2_3`, even `1a2b3`, which is invalid for versioning.

 - Fixed **Regex** is strict — matches only 1.2.3.
 #### Find attached tested SCREEN SHOT BELOW .
**Bad Match with Old Regex:**
![proofwithBadMatch](https://github.com/user-attachments/assets/6dbec50d-6ffb-4338-a258-7b3629b08e24)


**Proper Match with Fixed Regex:**
![withfixedbadstring](https://github.com/user-attachments/assets/1c9b6315-074b-4db4-a911-6493a76b4b64)
---
### 💬 Note: If you're planning to adopt alternate version tag formats in the future — such as:

 - v1.0.2 (semantic with prefix)

- release-1.0.2 or rel-1.0.2

- 1.0.2-beta, 1.0.2-rc.1 (prereleases with suffixes)

 - x1.0.2x (custom wrapping formats)

**…feel free to reach out. I'm happy to help extend the workflow to support those formats reliably and safely.**
---
### 2. Added strict release job guard
- Prevented **accidental release runs** on non-tag events using if: startsWith(github.ref, 'refs/tags/').

### 3. Explicit artifact validation
- **Introduced a shell check** using ls and test to ensure .zip and .pkg files exist before attempting release. This gives early, clear failure instead of a **vague error** from `action-gh-release`.

### 4. Clarified GitHub token usage
- Switched from ${{ secrets.GITHUB_TOKEN }} to ${{ github.token }} for better readability and consistency with GitHub Actions best practices.

