### PR TITLE
Make test suites run sequentially with respect to other test suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,12 @@ integration: init-block
 	@echo "Removing any existing containers"
 	@bin/container rm --all
 	@echo "Starting CLI integration tests"
-	@RUN_CLI_INTEGRATION_TESTS=1 $(SWIFT) test -c $(BUILD_CONFIGURATION) $(CURRENT_SDK_ARGS) --filter TestCLI
+	@$(SWIFT) test -c $(BUILD_CONFIGURATION) $(CURRENT_SDK_ARGS) --filter TestCLIRunLifecycle
+	@$(SWIFT) test -c $(BUILD_CONFIGURATION) $(CURRENT_SDK_ARGS) --filter TestCLIExecCommand
+	@$(SWIFT) test -c $(BUILD_CONFIGURATION) $(CURRENT_SDK_ARGS) --filter TestCLIRunCommand
+	@$(SWIFT) test -c $(BUILD_CONFIGURATION) $(CURRENT_SDK_ARGS) --filter TestCLIImagesCommand
+	@$(SWIFT) test -c $(BUILD_CONFIGURATION) $(CURRENT_SDK_ARGS) --filter TestCLIRunBase
+	@$(SWIFT) test -c $(BUILD_CONFIGURATION) $(CURRENT_SDK_ARGS) --filter TestCLIBuildBase
 	@echo Ensuring apiserver stopped after the CLI integration tests...
 	@scripts/ensure-container-stopped.sh
 


### PR DESCRIPTION
Right now swift testing does not have finer grain test parallelization controls. As a result our easy options are either to have ALL tests in ALL test suites run sequentially or have tests within a given test suite run sequentially while other test suites are run at the same time. 

This has been problematic for our CI since we opted for the second option above, where, for examples, the tests in the builder test suite run sequentially, but the builder test suite runs at the same time as the container run test suite. When this happens, a lot of different tests try to pull the necessary images for testing at the same time, causing some tests to timeout.