### PR TITLE
Plugins: Remove unused devnull var

### DIFF
--- a/Sources/ContainerPlugin/ServiceManager.swift
+++ b/Sources/ContainerPlugin/ServiceManager.swift
@@ -60,7 +60,6 @@ public struct ServiceManager {
         launchctl.executableURL = URL(fileURLWithPath: "/bin/launchctl")
         launchctl.arguments = ["list"]
 
-        let null = FileHandle.nullDevice
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
         launchctl.standardOutput = stdoutPipe


### PR DESCRIPTION
We actually use the output (both stderr and stdout) of the command.