### PR TITLE
Remove async from AttachmentAllocator lookup

### DIFF
--- a/Sources/Services/ContainerNetworkService/AttachmentAllocator.swift
+++ b/Sources/Services/ContainerNetworkService/AttachmentAllocator.swift
@@ -52,7 +52,7 @@ actor AttachmentAllocator {
     }
 
     /// Retrieve the allocator index for a hostname.
-    func lookup(hostname: String) async throws -> UInt32? {
+    func lookup(hostname: String) throws -> UInt32? {
         hostnames[hostname]
     }
 }

--- a/Sources/Services/ContainerNetworkService/NetworkService.swift
+++ b/Sources/Services/ContainerNetworkService/NetworkService.swift
@@ -101,7 +101,7 @@ public actor NetworkService: Sendable {
         }
 
         let hostname = try message.hostname()
-        let index = try await allocator.lookup(hostname: hostname)
+        let index = try allocator.lookup(hostname: hostname)
         let reply = message.reply()
         guard let index else {
             return reply


### PR DESCRIPTION
The `lookup(hostname:)` method in `AttachmentAllocator` no longer requires
async, as it only performs a synchronous dictionary lookup.
