### PR TITLE
Use enum for ClientHealthCheck namespace

### DIFF
--- a/Sources/ContainerClient/Core/ClientHealthCheck.swift
+++ b/Sources/ContainerClient/Core/ClientHealthCheck.swift
@@ -17,9 +17,8 @@
 import ContainerXPC
 import Foundation
 
-public struct ClientHealthCheck {
+public enum ClientHealthCheck {
     static let serviceIdentifier = "com.apple.container.apiserver"
-
 }
 
 extension ClientHealthCheck {


### PR DESCRIPTION
Switch `ClientHealthCheck` from a `struct` to an `enum` to prevent
instantiation.
