### PR TITLE
limit build and test for runners to Apple repository

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   buildAndTest:
     name: Build and test the project
+    if: github.repository == 'apple/container'
     timeout-minutes: 60
     runs-on: [self-hosted, macos, sequoia, ARM64]
     permissions:


### PR DESCRIPTION
constrains build to run on apple/container

fixes #209 