### PR TITLE
Docs: clarify Xcode 26 beta must be the active developer directory

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -4,7 +4,7 @@ To build the `container` project, you need:
 
 - Mac with Apple silicon
 - macOS 15 minimum, macOS 26 beta recommended
-- Xcode 26 beta
+- Xcode 26 beta, set as the [active developer directory](https://developer.apple.com/library/archive/technotes/tn2339/_index.html#//apple_ref/doc/uid/DTS40014588-CH1-HOW_DO_I_SELECT_THE_DEFAULT_VERSION_OF_XCODE_TO_USE_FOR_MY_COMMAND_LINE_TOOLS_)
 
 > [!IMPORTANT]
 > There is a bug in the `vmnet` framework on macOS 26 beta that causes network creation to fail if the `container` helper applications are located under your `Documents` or `Desktop` directories. If you use `make install`, you can simply run the `container` binary in `/usr/local`. If you prefer to use the binaries that `make all` creates in your project `bin` and `libexec` directories, locate your project elsewhere, such as `~/projects/container`, until this issue is resolved.


### PR DESCRIPTION
And add instructions for setting it so

Related: https://github.com/apple/containerization/issues/66
