### PR TITLE
Redirect to the documentation from the homepage

### DIFF
--- a/scripts/make-docs.sh
+++ b/scripts/make-docs.sh
@@ -40,3 +40,15 @@ fi
 /usr/bin/swift package ${opts[@]}
 
 echo '{}' > "$1/theme-settings.json"
+
+cat > "$1/index.html" <<'EOF'
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=./documentation/">
+  </head>
+  <body>
+    <p>If you are not redirected automatically, <a href="./documentation/">click here</a>.</p>
+  </body>
+</html>
+EOF


### PR DESCRIPTION
This PR fixes the homepage at https://apple.github.io/container/