### PR TITLE
Regenerate documentation on `make docs`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,12 +182,10 @@ serve-docs:
 	@python3 -m http.server --bind 127.0.0.1 --directory ./_serve
 
 .PHONY: docs
-docs: _site
-
-_site:
+docs:
 	@echo Updating API documentation...
-	rm -rf $@
-	@scripts/make-docs.sh $@ container
+	@rm -rf _site
+	@scripts/make-docs.sh _site container
 
 .PHONY: cleancontent
 cleancontent:


### PR DESCRIPTION
This PR allows using `make docs` without manually removing the existing `_site` folder.