### PR TITLE
Move github issues to use feature and bug Types instead of Labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -1,7 +1,8 @@
 name: Bug report
 description: File a bug report.
 title: "[Bug]: "
-labels: ["bug", "triage"]
+labels: ["triage"]
+type: "Bug"
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/02-feature.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature.yml
@@ -1,7 +1,8 @@
 name: Feature or enhancement request
 description: File a request for a feature or enhancement
 title: "[Request]: "
-labels: ["feature", "triage"]
+labels: ["triage"]
+type: "Feature"
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Github now has a "Type" feature for issues. Types are set at the organization level and can be used for consistent classification of issues across an organization. We'd like to switch to using these to classify if an issue is a bug or feature instead of labels. Labels will be used for more granular classification within a repo. 

See [github docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/configuring-issues/managing-issue-types-in-an-organization) for more information about GitHub Issue Types. 