### PR TITLE
Add container attach/detach support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -219,7 +219,11 @@ let package = Package(
             name: "ContainerClientTests",
             dependencies: [
                 .product(name: "Containerization", package: "containerization"),
+                .product(name: "ContainerizationOS", package: "containerization"),
+                .product(name: "Logging", package: "swift-log"),
                 "ContainerClient",
+                "ContainerSandboxService",
+                "ContainerXPC",
             ]
         ),
         .target(
@@ -290,9 +294,12 @@ let package = Package(
                 .product(name: "Containerization", package: "containerization"),
                 .product(name: "ContainerizationExtras", package: "containerization"),
                 .product(name: "ContainerizationOS", package: "containerization"),
+                .product(name: "ContainerizationOCI", package: "containerization"),
+                "ContainerSandboxService",
                 "ContainerBuild",
                 "ContainerClient",
                 "ContainerNetworkService",
+                "ContainerXPC",
             ],
             path: "Tests/CLITests"
         ),

--- a/Sources/CLI/Container/ContainerAttach.swift
+++ b/Sources/CLI/Container/ContainerAttach.swift
@@ -1,0 +1,82 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ContainerClient
+import ContainerizationError
+import ContainerizationOS
+import Foundation
+
+extension Application {
+    struct ContainerAttach: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "attach",
+            abstract: "Attach to a running container with PTY session support")
+
+        @OptionGroup
+        var global: Flags.Global
+        
+        @Flag(name: .long, help: "Do not send buffered history when attaching")
+        var noHistory = false
+        
+        @Option(name: .customLong("detach-keys"), help: "Override the key sequence for detaching a container")
+        var detachKeys: String?
+
+        @Argument(help: "Container ID or name to attach to")
+        var container: String
+
+        func run() async throws {
+            // Get container info
+            let container = try await ClientContainer.get(id: container)
+            try ensureRunning(container: container)
+            
+            // Check if container has terminal enabled
+            guard container.configuration.initProcess.terminal else {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "Cannot attach to container without terminal enabled"
+                )
+            }
+            
+            log.info("Attaching to container", metadata: ["container": "\(container.id)"])
+            
+            // Create attach client process
+            let process = try await container.attachToSession(sendHistory: !noHistory)
+            
+            // Run the attached session
+            let exitCode = try await runAttachedSession(process: process)
+            
+            if exitCode != 0 {
+                throw ArgumentParser.ExitCode(exitCode)
+            }
+        }
+        
+        private func runAttachedSession(process: ClientProcess) async throws -> Int32 {
+            // Get handles from the attach response
+            let handles = try await process.getAttachHandles()
+            
+            // Create ProcessIO for the attached session with detach key support
+            let io = try ProcessIO.createServerOwned(tty: true, handles: handles, detachKeys: detachKeys)
+            
+            // Run with standard process handling
+            return try await Application.handleProcess(
+                io: io,
+                process: process,
+                serverOwnedStdio: true
+            )
+        }
+    }
+}

--- a/Sources/ContainerClient/Core/ClientContainer.swift
+++ b/Sources/ContainerClient/Core/ClientContainer.swift
@@ -248,4 +248,26 @@ extension ClientContainer {
             )
         }
     }
+    
+    /// Attach to a PTY session for this container
+    /// - Parameter sendHistory: Whether to send buffered history when attaching
+    /// - Returns: A ClientProcess that represents the attached session
+    public func attachToSession(sendHistory: Bool = true) async throws -> ClientProcess {
+        do {
+            let client = self.sandboxClient
+            let handles = try await client.attach(containerID: self.id, sendHistory: sendHistory)
+            return ClientProcessImpl(
+                containerId: self.id,
+                processId: nil,
+                client: client,
+                attachHandles: handles
+            )
+        } catch {
+            throw ContainerizationError(
+                .internalError,
+                message: "failed to attach to container \(self.id)",
+                cause: error
+            )
+        }
+    }
 }

--- a/Sources/ContainerClient/DetachKeys.swift
+++ b/Sources/ContainerClient/DetachKeys.swift
@@ -1,0 +1,199 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Handles detection and parsing of detach key sequences for interactive containers
+/// Matches Docker's behavior with ctrl-p,ctrl-q as the default sequence
+public struct DetachKeys: Sendable {
+    /// The default detach key sequence matching Docker's behavior
+    public static let defaultSequence = "ctrl-p,ctrl-q"
+    
+    /// Parsed key sequence for detection
+    private let sequence: [UInt8]
+    
+    /// Current position in the sequence detection
+    private var position: Int = 0
+    
+    /// Initialize with a key sequence string
+    /// - Parameter sequenceString: Comma-separated key sequence (e.g., "ctrl-p,ctrl-q")
+    public init(_ sequenceString: String = defaultSequence) {
+        self.sequence = Self.parseSequence(sequenceString)
+    }
+    
+    /// Check if the given byte matches the next expected key in the sequence
+    /// - Parameter byte: Input byte to check
+    /// - Returns: DetachResult indicating if sequence is in progress, completed, or reset
+    public mutating func checkByte(_ byte: UInt8) -> DetachResult {
+        if position < sequence.count && byte == sequence[position] {
+            position += 1
+            if position == sequence.count {
+                // Complete sequence detected
+                position = 0
+                return .detach
+            }
+            return .inProgress
+        } else {
+            // Reset sequence detection
+            position = 0
+            // Check if this byte starts the sequence
+            if !sequence.isEmpty && byte == sequence[0] {
+                position = 1
+                return .inProgress
+            }
+            return .reset
+        }
+    }
+    
+    /// Reset the sequence detection state
+    public mutating func reset() {
+        position = 0
+    }
+    
+    /// Parse a sequence string into control character bytes
+    /// - Parameter sequenceString: Input sequence (e.g., "ctrl-p,ctrl-q")
+    /// - Returns: Array of control character bytes
+    private static func parseSequence(_ sequenceString: String) -> [UInt8] {
+        let parts = sequenceString.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+        return parts.compactMap { parseKey(String($0)) }
+    }
+    
+    /// Parse a single key string into its control character byte value
+    /// - Parameter keyString: Key specification (e.g., "ctrl-p", "ctrl-q")
+    /// - Returns: Control character byte value, or nil if invalid
+    private static func parseKey(_ keyString: String) -> UInt8? {
+        let lowercased = keyString.lowercased()
+        
+        // Handle ctrl-X format
+        if lowercased.hasPrefix("ctrl-") && lowercased.count == 6 {
+            let char = lowercased.last!
+            switch char {
+            case "a": return 0x01  // Ctrl-A
+            case "b": return 0x02  // Ctrl-B
+            case "c": return 0x03  // Ctrl-C
+            case "d": return 0x04  // Ctrl-D
+            case "e": return 0x05  // Ctrl-E
+            case "f": return 0x06  // Ctrl-F
+            case "g": return 0x07  // Ctrl-G
+            case "h": return 0x08  // Ctrl-H
+            case "i": return 0x09  // Ctrl-I (Tab)
+            case "j": return 0x0A  // Ctrl-J (LF)
+            case "k": return 0x0B  // Ctrl-K
+            case "l": return 0x0C  // Ctrl-L
+            case "m": return 0x0D  // Ctrl-M (CR)
+            case "n": return 0x0E  // Ctrl-N
+            case "o": return 0x0F  // Ctrl-O
+            case "p": return 0x10  // Ctrl-P
+            case "q": return 0x11  // Ctrl-Q
+            case "r": return 0x12  // Ctrl-R
+            case "s": return 0x13  // Ctrl-S
+            case "t": return 0x14  // Ctrl-T
+            case "u": return 0x15  // Ctrl-U
+            case "v": return 0x16  // Ctrl-V
+            case "w": return 0x17  // Ctrl-W
+            case "x": return 0x18  // Ctrl-X
+            case "y": return 0x19  // Ctrl-Y
+            case "z": return 0x1A  // Ctrl-Z
+            default: return nil
+            }
+        }
+        
+        // Handle special keys
+        switch lowercased {
+        case "enter", "return": return 0x0D
+        case "tab": return 0x09
+        case "escape", "esc": return 0x1B
+        case "space": return 0x20
+        case "backspace": return 0x08
+        case "delete", "del": return 0x7F
+        default: break
+        }
+        
+        // Handle single character
+        if keyString.count == 1 {
+            return keyString.utf8.first
+        }
+        
+        return nil
+    }
+}
+
+/// Result of detach key sequence detection
+public enum DetachResult: Sendable {
+    /// Still detecting sequence, don't forward the byte
+    case inProgress
+    /// Complete detach sequence detected
+    case detach
+    /// Sequence reset, forward all buffered bytes
+    case reset
+}
+
+/// Detach key detector for processing input streams
+public actor DetachKeyDetector {
+    private var detachKeys: DetachKeys
+    private var buffer: [UInt8] = []
+    
+    public init(sequence: String = DetachKeys.defaultSequence) {
+        self.detachKeys = DetachKeys(sequence)
+    }
+    
+    /// Process input data and detect detach sequences
+    /// - Parameter data: Input data to process
+    /// - Returns: Tuple of (shouldDetach, dataToForward)
+    public func processInput(_ data: Data) -> (shouldDetach: Bool, dataToForward: Data) {
+        var shouldDetach = false
+        var outputBytes: [UInt8] = []
+        
+        for byte in data {
+            let result = detachKeys.checkByte(byte)
+            
+            switch result {
+            case .inProgress:
+                // Buffer this byte, don't forward yet
+                buffer.append(byte)
+                
+            case .detach:
+                // Detach sequence complete, don't forward any buffered bytes
+                buffer.removeAll()
+                shouldDetach = true
+                // Break out of the for loop, not just the switch
+                return (shouldDetach: true, dataToForward: Data(outputBytes))
+                
+            case .reset:
+                // Forward any buffered bytes plus this byte
+                outputBytes.append(contentsOf: buffer)
+                outputBytes.append(byte)
+                buffer.removeAll()
+            }
+        }
+        
+        return (shouldDetach: shouldDetach, dataToForward: Data(outputBytes))
+    }
+    
+    /// Flush any buffered bytes (e.g., on connection close)
+    public func flush() -> Data {
+        let data = Data(buffer)
+        buffer.removeAll()
+        detachKeys.reset()
+        return data
+    }
+    
+    /// Reset the detector state
+    public func reset() {
+        buffer.removeAll()
+        detachKeys.reset()
+    }
+}

--- a/Sources/ContainerClient/Flags.swift
+++ b/Sources/ContainerClient/Flags.swift
@@ -54,6 +54,9 @@ public struct Flags {
 
         @Option(name: [.customLong("user"), .customShort("u")], help: "Set the user for the process")
         public var user: String?
+        
+        @Option(name: .customLong("detach-keys"), help: "Override the key sequence for detaching a container")
+        public var detachKeys: String?
     }
 
     public struct Resource: ParsableArguments {

--- a/Sources/ContainerClient/SandboxRoutes.swift
+++ b/Sources/ContainerClient/SandboxRoutes.swift
@@ -35,4 +35,6 @@ public enum SandboxRoutes: String {
     case exec = "com.apple.container.sandbox/exec"
     /// Dial a vsock port in the sandbox.
     case dial = "com.apple.container.sandbox/dial"
+    /// Attach to a PTY session for a container.
+    case attach = "com.apple.container.sandbox/attach"
 }

--- a/Sources/ContainerClient/XPC+.swift
+++ b/Sources/ContainerClient/XPC+.swift
@@ -64,6 +64,13 @@ public enum XPCKeys: String {
     case width
     case height
     case processConfig
+    case serverOwnedStdio
+    /// Send history flag for attach
+    case sendHistory
+    /// History bytes sent on attach
+    case historyBytes
+    /// Whether history was truncated
+    case truncated
 
     /// Update progress
     case progressUpdateEndpoint

--- a/Sources/ContainerXPC/XPCMessage.swift
+++ b/Sources/ContainerXPC/XPCMessage.swift
@@ -203,7 +203,7 @@ extension XPCMessage {
         }
         if let fd {
             let fd2 = xpc_fd_dup(fd)
-            return FileHandle(fileDescriptor: fd2, closeOnDealloc: false)
+            return FileHandle(fileDescriptor: fd2, closeOnDealloc: true)
         }
         return nil
     }
@@ -227,8 +227,8 @@ extension XPCMessage {
                 return nil
             }
             return [
-                FileHandle(fileDescriptor: fd1, closeOnDealloc: false),
-                FileHandle(fileDescriptor: fd2, closeOnDealloc: false),
+                FileHandle(fileDescriptor: fd1, closeOnDealloc: true),
+                FileHandle(fileDescriptor: fd2, closeOnDealloc: true),
             ]
         }
         return nil

--- a/Sources/Helpers/RuntimeLinux/RuntimeLinuxHelper.swift
+++ b/Sources/Helpers/RuntimeLinux/RuntimeLinuxHelper.swift
@@ -81,6 +81,7 @@ struct RuntimeLinuxHelper: AsyncParsableCommand {
                     SandboxRoutes.wait.rawValue: server.wait,
                     SandboxRoutes.start.rawValue: server.startProcess,
                     SandboxRoutes.dial.rawValue: server.dial,
+                    SandboxRoutes.attach.rawValue: server.attach,
                 ],
                 log: log
             )

--- a/Sources/Services/ContainerSandboxService/PTYSession.swift
+++ b/Sources/Services/ContainerSandboxService/PTYSession.swift
@@ -1,0 +1,482 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Logging
+import ContainerizationOS
+import ContainerizationExtras
+import ContainerizationError
+import Darwin
+
+/// Manages I/O sessions for containers with support for history replay
+///
+/// This class provides unified I/O handling for server-owned PTY session
+/// - Always buffers output in ring buffers for history
+/// - Forwards output to client pipes using non-blocking I/O
+/// - Supports accurate history replay with clear boundary between historical and live data
+/// - Server owns all pipes - client connects to server-owned pipes
+///
+/// Design principles:
+/// - Non-blocking writes prevent slow clients from blocking container output
+/// - History buffer preserves output for later replay
+/// - Simple synchronization ensures accurate history/live boundary
+public final class PTYSession: @unchecked Sendable {
+    public let containerID: String
+    private let logger: Logger
+    
+    /// I/O mode for this session
+    public enum IOMode {
+        case pty(master: Terminal, slave: FileHandle)
+        case pipes(stdin: Pipe, stdout: Pipe, stderr: Pipe)
+    }
+    private let ioMode: IOMode
+    
+    /// Client-facing pipes (server-owned, created once)
+    private let clientStdinPipe: Pipe
+    private let clientStdoutPipe: Pipe
+    private let clientStderrPipe: Pipe?
+    
+    /// History buffer
+    private let historyBuffer: RingBuffer
+    
+    /// History replay synchronization
+    private let historyLock = NSLock()
+    private var isReplayingHistory = false
+    
+    /// Dispatch for I/O handling
+    private let readQueue = DispatchQueue(label: "com.apple.container.io.read")
+    private var readSources: [DispatchSourceRead] = []
+
+    /// Default buffer size for history (1MB)
+    public static let defaultBufferSize = 1024 * 1024
+    
+    public init(containerID: String, terminal: Bool, bufferSize: Int, logger: Logger) throws {
+        self.containerID = containerID
+        self.logger = logger
+        self.historyBuffer = RingBuffer(capacity: bufferSize)
+        
+        // Create client-facing pipes
+        self.clientStdinPipe = Pipe()
+        self.clientStdoutPipe = Pipe()
+        
+        // Make stdout pipe non-blocking
+        let outFD = clientStdoutPipe.fileHandleForWriting.fileDescriptor
+        var flags = fcntl(outFD, F_GETFL, 0)
+        guard flags != -1 else {
+            throw ContainerizationError(.internalError, message: "Failed to get pipe flags", cause: POSIXError(POSIXErrorCode(rawValue: errno) ?? .EPERM))
+        }
+        guard fcntl(outFD, F_SETFL, flags | O_NONBLOCK) != -1 else {
+            throw ContainerizationError(.internalError, message: "Failed to set non-blocking mode", cause: POSIXError(POSIXErrorCode(rawValue: errno) ?? .EPERM))
+        }
+        
+        if terminal {
+            // PTY mode
+            let (master, slave) = try Terminal.create()
+            self.ioMode = .pty(master: master, slave: FileHandle(fileDescriptor: slave.handle.fileDescriptor, closeOnDealloc: false))
+            self.clientStderrPipe = nil // PTY combines stdout/stderr
+            
+            // Setup forwarding: client stdin -> PTY master
+            setupStdinForwarding(from: clientStdinPipe.fileHandleForReading, to: master.handle)
+            
+            // Start reading from PTY master
+            startReading(from: master.handle.fileDescriptor)
+            
+            logger.debug("PTY session created", metadata: [
+                "containerID": "\(containerID)",
+                "masterFD": "\(master.handle.fileDescriptor)",
+                "slaveFD": "\(slave.handle.fileDescriptor)"
+            ])
+        } else {
+            // Pipe mode
+            let stdinPipe = Pipe()
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+            self.ioMode = .pipes(stdin: stdinPipe, stdout: stdoutPipe, stderr: stderrPipe)
+            self.clientStderrPipe = Pipe()
+            
+            // Make stderr pipe non-blocking too
+            let errFD = clientStderrPipe!.fileHandleForWriting.fileDescriptor
+            flags = fcntl(errFD, F_GETFL, 0)
+            guard flags != -1 else {
+                throw ContainerizationError(.internalError, message: "Failed to get stderr pipe flags", cause: POSIXError(POSIXErrorCode(rawValue: errno) ?? .EPERM))
+            }
+            guard fcntl(errFD, F_SETFL, flags | O_NONBLOCK) != -1 else {
+                throw ContainerizationError(.internalError, message: "Failed to set stderr non-blocking mode", cause: POSIXError(POSIXErrorCode(rawValue: errno) ?? .EPERM))
+            }
+            
+            // Setup forwarding: client -> container pipes
+            setupStdinForwarding(from: clientStdinPipe.fileHandleForReading, to: stdinPipe.fileHandleForWriting)
+            
+            // Start reading from container stdout/stderr
+            startReading(from: stdoutPipe.fileHandleForReading.fileDescriptor)
+            startReading(from: stderrPipe.fileHandleForReading.fileDescriptor, isStderr: true)
+            
+            logger.debug("Pipe session created", metadata: [
+                "containerID": "\(containerID)"
+            ])
+        }
+    }
+    
+    /// Container-side handles to pass to the container process
+    public var containerHandles: [FileHandle?] {
+        switch ioMode {
+        case .pty(_, let slave):
+            return [slave, slave, slave]
+        case .pipes(let stdin, let stdout, let stderr):
+            return [
+                stdin.fileHandleForReading,
+                stdout.fileHandleForWriting,
+                stderr.fileHandleForWriting
+            ]
+        }
+    }
+    
+    /// Client-side handles (always the same for a session)
+    public var clientHandles: [FileHandle?] {
+        return [
+            clientStdinPipe.fileHandleForWriting,
+            clientStdoutPipe.fileHandleForReading,
+            clientStderrPipe?.fileHandleForReading
+        ]
+    }
+    
+    /// Send buffered history to client
+    /// - Returns: Tuple of (historyBytes, truncated) indicating how much history was sent
+    public func sendHistory() -> (bytes: Int, truncated: Bool) {
+        logger.info("Sending history for session", metadata: ["containerID": "\(containerID)"])
+        
+        historyLock.lock()
+        isReplayingHistory = true
+        
+        // Get snapshot of history at this exact moment
+        let historyData = historyBuffer.readAll()
+        let truncated = historyBuffer.hasWrapped
+        
+        // Clear the flag - new data after this point is "live"
+        isReplayingHistory = false
+        historyLock.unlock()
+        
+        var totalBytes = 0
+        if let data = historyData {
+            totalBytes = data.count
+            
+            // Send truncation notice if buffer wrapped
+            if truncated {
+                let notice = "\n[*** Buffer wrapped - some output was truncated ***]\n"
+                if let noticeData = notice.data(using: .utf8) {
+                    writeHistoryData(noticeData, to: clientStdoutPipe.fileHandleForWriting)
+                }
+            }
+            
+            // Write history (temporarily make blocking for reliable delivery)
+            writeHistoryData(data, to: clientStdoutPipe.fileHandleForWriting)
+            
+            // For pipe mode with stderr, check if we have stderr history
+            if case .pipes = ioMode, clientStderrPipe != nil {
+                // In current implementation, stderr is mixed with stdout in history
+                // This could be enhanced to maintain separate buffers if needed
+            }
+        }
+        
+        logger.debug("History sent", metadata: [
+            "containerID": "\(containerID)",
+            "bytes": "\(totalBytes)",
+            "truncated": "\(truncated)"
+        ])
+        
+        return (totalBytes, truncated)
+    }
+    
+    /// Get buffer statistics
+    public func getBufferStats() -> (historySize: Int, truncated: Bool) {
+        return (
+            historySize: historyBuffer.count,
+            truncated: historyBuffer.hasWrapped
+        )
+    }
+    
+    // MARK: - Private Methods
+    
+    private func startReading(from fd: Int32, isStderr: Bool = false) {
+        logger.debug("Starting to read from descriptor", metadata: [
+            "containerID": "\(containerID)",
+            "fd": "\(fd)",
+            "isStderr": "\(isStderr)"
+        ])
+        
+        let source = DispatchSource.makeReadSource(
+            fileDescriptor: fd,
+            queue: readQueue
+        )
+        
+        source.setEventHandler { [weak self] in
+            self?.handleData(from: fd, isStderr: isStderr)
+        }
+        
+        source.setCancelHandler { [weak self] in
+            self?.logger.debug("Read source cancelled", metadata: [
+                "containerID": "\(self?.containerID ?? "unknown")",
+                "fd": "\(fd)"
+            ])
+        }
+        
+        source.resume()
+        readSources.append(source)
+        logger.debug("Read source started", metadata: ["containerID": "\(containerID)", "fd": "\(fd)"])
+    }
+    
+    private func handleData(from fd: Int32, isStderr: Bool) {
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 4096)
+        defer { buffer.deallocate() }
+        
+        let bytesRead = read(fd, buffer, 4096)
+        
+        guard bytesRead > 0 else {
+            if bytesRead < 0 && errno != EAGAIN && errno != EWOULDBLOCK {
+                logger.error("Read error", metadata: [
+                    "containerID": "\(containerID)",
+                    "fd": "\(fd)",
+                    "error": "\(String(cString: strerror(errno)))"
+                ])
+            }
+            return
+        }
+        
+        let data = Data(bytes: buffer, count: bytesRead)
+        
+        logger.debug("Read data", metadata: [
+            "containerID": "\(containerID)",
+            "bytesRead": "\(bytesRead)",
+            "isStderr": "\(isStderr)"
+        ])
+        
+        historyLock.lock()
+        
+        // Always buffer for history
+        // For PTY mode or pipe stdout, buffer everything
+        // For pipe stderr, only buffer if we have a stderr pipe
+        if !isStderr || clientStderrPipe != nil {
+            historyBuffer.write(data)
+            
+            if historyBuffer.hasWrapped {
+                logger.debug("Buffer wrapped", metadata: [
+                    "containerID": "\(containerID)"
+                ])
+            }
+        }
+        
+        // Forward to client pipe if not replaying history
+        if !isReplayingHistory {
+            let pipe = isStderr ? clientStderrPipe! : clientStdoutPipe
+            do {
+                try pipe.fileHandleForWriting.write(contentsOf: data)
+                logger.debug("Forwarded data to client", metadata: [
+                    "containerID": "\(containerID)",
+                    "bytes": "\(data.count)",
+                    "isStderr": "\(isStderr)"
+                ])
+            } catch {
+                // EAGAIN/EWOULDBLOCK - pipe full, client not keeping up
+                // This is expected with non-blocking I/O
+                if (error as NSError).code != EAGAIN {
+                    logger.debug("Failed to write to client pipe", metadata: [
+                        "containerID": "\(containerID)",
+                        "error": "\(error)",
+                        "isStderr": "\(isStderr)"
+                    ])
+                }
+            }
+        }
+        
+        historyLock.unlock()
+    }
+    
+    private func setupStdinForwarding(from source: FileHandle, to dest: FileHandle) {
+        source.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty else {
+                handle.readabilityHandler = nil
+                return
+            }
+            
+            do {
+                try dest.write(contentsOf: data)
+                self?.logger.debug("Forwarded stdin data", metadata: [
+                    "containerID": "\(self?.containerID ?? "unknown")",
+                    "bytes": "\(data.count)"
+                ])
+            } catch {
+                self?.logger.error("Failed to forward stdin", metadata: [
+                    "containerID": "\(self?.containerID ?? "unknown")",
+                    "error": "\(error)"
+                ])
+            }
+        }
+    }
+    
+    private func writeHistoryData(_ data: Data, to handle: FileHandle) {
+        // Temporarily make blocking for history replay
+        let fd = handle.fileDescriptor
+        let flags = fcntl(fd, F_GETFL, 0)
+        
+        if flags != -1 {
+            // Clear non-blocking flag
+            _ = fcntl(fd, F_SETFL, flags & ~O_NONBLOCK)
+            
+            do {
+                try handle.write(contentsOf: data)
+            } catch {
+                logger.error("Failed to send history", metadata: [
+                    "containerID": "\(containerID)",
+                    "error": "\(error)"
+                ])
+            }
+            
+            // Restore non-blocking
+            _ = fcntl(fd, F_SETFL, flags)
+        }
+    }
+    
+    public func cleanup() {
+        logger.debug("Cleaning up session", metadata: ["containerID": "\(containerID)"])
+        
+        for source in readSources {
+            source.cancel()
+        }
+        readSources.removeAll()
+        
+        // Clear stdin handlers
+        clientStdinPipe.fileHandleForReading.readabilityHandler = nil
+        
+        // Close handles based on mode
+        switch ioMode {
+        case .pty(let master, let slave):
+            try? master.reset()
+            try? slave.close()
+        case .pipes(let stdin, let stdout, let stderr):
+            try? stdin.fileHandleForReading.close()
+            try? stdout.fileHandleForWriting.close()
+            try? stderr.fileHandleForWriting.close()
+        }
+    }
+    
+    deinit {
+        cleanup()
+    }
+}
+
+/// A thread-safe ring buffer for storing output data
+private final class RingBuffer: @unchecked Sendable {
+    private let buffer: UnsafeMutableRawPointer
+    private let capacity: Int
+    private var head: Int = 0
+    private var tail: Int = 0
+    private var _count: Int = 0
+    private var _hasWrapped: Bool = false
+    private let lock = NSLock()
+    
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _count
+    }
+    
+    var hasWrapped: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _hasWrapped
+    }
+    
+    init(capacity: Int) {
+        self.capacity = capacity
+        self.buffer = UnsafeMutableRawPointer.allocate(byteCount: capacity, alignment: 1)
+    }
+    
+    deinit {
+        buffer.deallocate()
+    }
+    
+    func write(_ data: Data) {
+            lock.lock()
+            defer { lock.unlock() }
+            let bytesToWrite = data.count
+            
+            // If data is larger than buffer, only keep the last part
+            let dataOffset = max(0, bytesToWrite - capacity)
+            let actualBytesToWrite = min(bytesToWrite, capacity)
+            
+            data.withUnsafeBytes { bytes in
+                let src = bytes.baseAddress!.advanced(by: dataOffset)
+                
+                if actualBytesToWrite >= capacity {
+                    // Complete overwrite
+                    buffer.copyMemory(from: src, byteCount: capacity)
+                    head = 0
+                    tail = 0
+                    _count = capacity
+                    _hasWrapped = true
+                } else {
+                    // Normal write
+                    var written = 0
+                    while written < actualBytesToWrite {
+                        let spaceToEnd = capacity - head
+                        let toWrite = min(actualBytesToWrite - written, spaceToEnd)
+                        
+                        buffer.advanced(by: head).copyMemory(
+                            from: src.advanced(by: written),
+                            byteCount: toWrite
+                        )
+                        
+                        written += toWrite
+                        head = (head + toWrite) % capacity
+                        
+                        if _count < capacity {
+                            _count = min(_count + toWrite, capacity)
+                        } else {
+                            // Buffer is full, advance tail
+                            tail = head
+                            _hasWrapped = true
+                        }
+                    }
+                }
+            }
+        }
+    
+    func readAll() -> Data? {
+        lock.lock()
+        defer { lock.unlock() }
+        
+        guard _count > 0 else { return nil }
+        
+        var data = Data(count: _count)
+        data.withUnsafeMutableBytes { bytes in
+            let dst = bytes.baseAddress!
+            
+            if tail < head {
+                // Continuous read
+                dst.copyMemory(from: buffer.advanced(by: tail), byteCount: _count)
+            } else {
+                // Wrapped read
+                let firstPart = capacity - tail
+                dst.copyMemory(from: buffer.advanced(by: tail), byteCount: firstPart)
+                dst.advanced(by: firstPart).copyMemory(from: buffer, byteCount: head)
+            }
+        }
+        
+        // Don't clear the buffer after reading (keep history)
+        return data
+    }
+}

--- a/Tests/CLITests/Subcommands/Attach/TestCLIAttach.swift
+++ b/Tests/CLITests/Subcommands/Attach/TestCLIAttach.swift
@@ -1,0 +1,210 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Testing
+import Foundation
+import ContainerizationOS
+@testable import container
+
+/// Integration tests for server-owned stdio using the actual container CLI binary
+/// These tests follow the existing integration test patterns in the codebase
+class TestCLIAttach: CLITest, @unchecked Sendable {
+    
+    @Test("Attach command works with server-owned stdio container")
+    func testAttachToServerOwnedStdioContainer() async throws {
+        let containerName = "test-attach-\(UUID().uuidString)"
+        
+        // Start a long-running container with server-owned stdio
+        let startProcess = Process()
+        startProcess.executableURL = try executablePath
+        startProcess.arguments = [
+            "run",
+            "--rm",
+            "--name", containerName,
+            "-itd", // -d for detached, -it for server-owned stdio
+            "ghcr.io/linuxcontainers/alpine:3.20",
+            "/bin/sh"
+        ]
+        
+        try startProcess.run()
+        startProcess.waitUntilExit()
+        
+        #expect(startProcess.terminationStatus == 0, "Container should start successfully")
+        
+        // Wait for container to be running
+        try waitForContainerRunning(containerName)
+        
+        // Attach to the container
+        let attachMessage = "Attached to container \(UUID().uuidString)"
+        let attachProcess = Process()
+        attachProcess.executableURL = try executablePath
+        attachProcess.arguments = [
+            "attach",
+            containerName
+        ]
+        
+        let attachPipe = Pipe()
+        attachProcess.standardOutput = attachPipe
+        attachProcess.standardError = attachPipe
+        attachProcess.standardInput = Pipe() // Provide stdin for attach
+        
+        try attachProcess.run()
+        
+        // Send a command through attach
+        let stdinHandle = attachProcess.standardInput as? Pipe
+        try stdinHandle?.fileHandleForWriting.write(contentsOf: "echo '\(attachMessage)'\n".data(using: .utf8)!)
+        try stdinHandle?.fileHandleForWriting.write(contentsOf: "exit\n".data(using: .utf8)!)
+        
+        let attachOutput = attachPipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: attachOutput, encoding: .utf8) ?? ""
+        
+        attachProcess.waitUntilExit()
+        
+        #expect(output.contains(attachMessage), "Should see message from attach session")
+        
+        // Clean up
+        _ = try? run(arguments: ["stop", containerName])
+    }
+    
+    @Test("Multiple attach sessions can send stdin and receive stdout")
+    func testMultipleAttachShareTerminal() async throws {
+        let containerName = "test-concurrent-attach-\(UUID().uuidString)"
+        
+        // Start container
+        let (_, _, startStatus) = try run(arguments: [
+            "run",
+            "--rm", 
+            "--name", containerName,
+            "-itd",
+            "ghcr.io/linuxcontainers/alpine:3.20",
+            "/bin/sh"
+        ])
+        #expect(startStatus == 0, "Container should start")
+        
+        try waitForContainerRunning(containerName)
+        
+        // Start three attach processes concurrently
+        let session1Marker = "SESSION1-\(UUID().uuidString)"
+        let session2Marker = "SESSION2-\(UUID().uuidString)"
+        let session3Marker = "SESSION3-\(UUID().uuidString)"
+        
+        let attach1 = Process()
+        attach1.executableURL = try executablePath
+        attach1.arguments = ["attach", containerName]
+        let pipe1 = Pipe()
+        attach1.standardOutput = pipe1
+        attach1.standardError = pipe1
+        attach1.standardInput = Pipe()
+        
+        let attach2 = Process()
+        attach2.executableURL = try executablePath
+        attach2.arguments = ["attach", containerName]
+        let pipe2 = Pipe()
+        attach2.standardOutput = pipe2
+        attach2.standardError = pipe2
+        attach2.standardInput = Pipe()
+        
+        let attach3 = Process()
+        attach3.executableURL = try executablePath
+        attach3.arguments = ["attach", containerName]
+        let pipe3 = Pipe()
+        attach3.standardOutput = pipe3
+        attach3.standardError = pipe3
+        attach3.standardInput = Pipe()
+        
+        // Start all processes
+        try attach1.run()
+        try attach2.run()
+        try attach3.run()
+        
+        // Give them time to connect
+        try await Task.sleep(nanoseconds: 500_000_000) // 0.5 seconds
+        
+        // Each session sends a unique echo command
+        let stdin1 = attach1.standardInput as? Pipe
+        let stdin2 = attach2.standardInput as? Pipe
+        let stdin3 = attach3.standardInput as? Pipe
+        
+        // Session 1 sends its marker
+        try stdin1?.fileHandleForWriting.write(contentsOf: "echo '\(session1Marker)'\n".data(using: .utf8)!)
+        try await Task.sleep(nanoseconds: 200_000_000) // 0.2 seconds
+        
+        // Session 2 sends its marker
+        try stdin2?.fileHandleForWriting.write(contentsOf: "echo '\(session2Marker)'\n".data(using: .utf8)!)
+        try await Task.sleep(nanoseconds: 200_000_000) // 0.2 seconds
+        
+        // Session 3 sends its marker
+        try stdin3?.fileHandleForWriting.write(contentsOf: "echo '\(session3Marker)'\n".data(using: .utf8)!)
+        try await Task.sleep(nanoseconds: 200_000_000) // 0.2 seconds
+        
+        // Session 1 sends exit to terminate all sessions
+        try stdin1?.fileHandleForWriting.write(contentsOf: "exit\n".data(using: .utf8)!)
+        
+        // Close stdin pipes
+        try stdin1?.fileHandleForWriting.close()
+        try stdin2?.fileHandleForWriting.close()
+        try stdin3?.fileHandleForWriting.close()
+        
+        // Wait for processes to exit with timeout
+        let timeout = Date().addingTimeInterval(5) // 5 second timeout
+        while (attach1.isRunning || attach2.isRunning || attach3.isRunning) && Date() < timeout {
+            try await Task.sleep(nanoseconds: 100_000_000) // 100ms
+        }
+        
+        // Force terminate if still running
+        if attach1.isRunning {
+            attach1.terminate()
+            attach1.waitUntilExit()
+        }
+        if attach2.isRunning {
+            attach2.terminate()
+            attach2.waitUntilExit()
+        }
+        if attach3.isRunning {
+            attach3.terminate()
+            attach3.waitUntilExit()
+        }
+        
+        // Read output after processes exit
+        let output1 = String(data: pipe1.fileHandleForReading.availableData, encoding: .utf8) ?? ""
+        let output2 = String(data: pipe2.fileHandleForReading.availableData, encoding: .utf8) ?? ""
+        let output3 = String(data: pipe3.fileHandleForReading.availableData, encoding: .utf8) ?? ""
+        
+        // Verify each session could send stdin (its own marker appears somewhere)
+        let allOutputs = output1 + output2 + output3
+        #expect(allOutputs.contains(session1Marker), "Session 1 marker should appear in output")
+        #expect(allOutputs.contains(session2Marker), "Session 2 marker should appear in output")
+        #expect(allOutputs.contains(session3Marker), "Session 3 marker should appear in output")
+        
+        // Verify each session receives stdout (should see at least one other session's marker)
+        // Since outputs are shared, each session should see markers from other sessions
+        let session1SeesOthers = output1.contains(session2Marker) || output1.contains(session3Marker)
+        let session2SeesOthers = output2.contains(session1Marker) || output2.contains(session3Marker)
+        let session3SeesOthers = output3.contains(session1Marker) || output3.contains(session2Marker)
+        
+        #expect(session1SeesOthers || output1.contains(session1Marker), 
+                "Session 1 should see output from the shared terminal")
+        #expect(session2SeesOthers || output2.contains(session2Marker), 
+                "Session 2 should see output from the shared terminal")
+        #expect(session3SeesOthers || output3.contains(session3Marker), 
+                "Session 3 should see output from the shared terminal")
+        
+        // Clean up
+        let (_, _, stopStatus) = try run(arguments: ["stop", containerName])
+        #expect(stopStatus == 0, "Container should stop")
+    }    
+    
+}

--- a/Tests/CLITests/Subcommands/Run/TestCLIRunLegacyIO.swift
+++ b/Tests/CLITests/Subcommands/Run/TestCLIRunLegacyIO.swift
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Testing
+import Foundation
+import ContainerizationOS
+@testable import container
+
+/// Integration tests for server-owned stdio using the actual container CLI binary
+/// These tests follow the existing integration test patterns in the codebase
+class TestCLIRunLegacyIO: CLITest, @unchecked Sendable {
+    
+    @Test("Legacy stdio flag forces client-owned stdio")
+    func testLegacyStdioFlag() async throws {
+        let containerName = "test-legacy-stdio-\(UUID().uuidString)"
+        let testMessage = "Legacy stdio test \(UUID().uuidString)"
+        
+        // Use runInteractive with explicit --legacy-stdio flag
+        let terminal = try runInteractive(arguments: [
+            "run",
+            "--legacy-stdio",
+            "--rm",
+            "--name", containerName,
+            "-it",
+            "ghcr.io/linuxcontainers/alpine:3.20",
+            "/bin/sh"
+        ])
+        
+        // With legacy stdio, we can interact via the terminal
+        let stdoutTask = Task {
+            for try await line in terminal.readLines() {
+                if line.contains(testMessage) {
+                    return true
+                }
+            }
+            return false
+        }
+        
+        // Send commands
+        try terminal.write("echo '\(testMessage)'\n")
+        try terminal.write("exit\n")
+        
+        let found = try await stdoutTask.value
+        #expect(found, "Should see test message with legacy stdio")
+    }
+    
+    @Test("Environment variable forces legacy stdio")
+    func testEnvironmentVariableLegacyStdio() async throws {
+        let containerName = "test-env-legacy-\(UUID().uuidString)"
+        let testMessage = "Env legacy stdio \(UUID().uuidString)"
+        
+        // Set environment variable
+        let process = Process()
+        process.executableURL = try executablePath
+        process.environment = ProcessInfo.processInfo.environment
+        process.environment?["CONTAINER_LEGACY_STDIO"] = "1"
+        
+        process.arguments = [
+            "run",
+            "--rm",
+            "--name", containerName,
+            "-it", // Would normally trigger server stdio
+            "ghcr.io/linuxcontainers/alpine:3.20",
+            "/bin/sh", "-c", "echo '\(testMessage)'"
+        ]
+        
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = outputPipe
+        
+        // With legacy stdio forced by env var, we need to provide stdin
+        let stdinPipe = Pipe()
+        process.standardInput = stdinPipe
+        
+        try process.run()
+        
+        let output = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        let outputStr = String(data: output, encoding: .utf8) ?? ""
+        
+        process.waitUntilExit()
+        
+        #expect(outputStr.contains(testMessage), "Should see output with env-forced legacy stdio")
+        #expect(process.terminationStatus == 0, "Should exit successfully")
+    }
+}

--- a/Tests/ContainerClientTests/TestDetachKeys.swift
+++ b/Tests/ContainerClientTests/TestDetachKeys.swift
@@ -1,0 +1,329 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Testing
+import Foundation
+@testable import ContainerClient
+
+/// Test suite for detach key sequence detection and parsing
+struct TestDetachKeys {
+    
+    @Test("Default sequence is ctrl-p,ctrl-q")
+    func testDefaultSequence() {
+        #expect(DetachKeys.defaultSequence == "ctrl-p,ctrl-q")
+    }
+    
+    @Test("Parse ctrl-p control character")
+    func testParseCtrlP() {
+        var detachKeys = DetachKeys("ctrl-p")
+        
+        // Send ctrl-p (0x10)
+        let result = detachKeys.checkByte(0x10)
+        #expect(result == .detach)
+    }
+    
+    @Test("Parse ctrl-q control character")
+    func testParseCtrlQ() {
+        var detachKeys = DetachKeys("ctrl-q")
+        
+        // Send ctrl-q (0x11)
+        let result = detachKeys.checkByte(0x11)
+        #expect(result == .detach)
+    }
+    
+    @Test("Default ctrl-p,ctrl-q sequence detection")
+    func testDefaultSequenceDetection() {
+        var detachKeys = DetachKeys()
+        
+        // Send ctrl-p (0x10)
+        var result = detachKeys.checkByte(0x10)
+        #expect(result == .inProgress)
+        
+        // Send ctrl-q (0x11)
+        result = detachKeys.checkByte(0x11)
+        #expect(result == .detach)
+    }
+    
+    @Test("Partial sequence followed by wrong key resets")
+    func testPartialSequenceReset() {
+        var detachKeys = DetachKeys()
+        
+        // Send ctrl-p (0x10)
+        var result = detachKeys.checkByte(0x10)
+        #expect(result == .inProgress)
+        
+        // Send wrong key (e.g., 'a')
+        result = detachKeys.checkByte(0x61) // 'a'
+        #expect(result == .reset)
+        
+        // State should be reset, sending ctrl-p should start sequence again
+        result = detachKeys.checkByte(0x10)
+        #expect(result == .inProgress)
+    }
+    
+    @Test("Custom sequence parsing")
+    func testCustomSequence() {
+        var detachKeys = DetachKeys("ctrl-a,ctrl-b")
+        
+        // Send ctrl-a (0x01)
+        var result = detachKeys.checkByte(0x01)
+        #expect(result == .inProgress)
+        
+        // Send ctrl-b (0x02)
+        result = detachKeys.checkByte(0x02)
+        #expect(result == .detach)
+    }
+    
+    @Test("Single key sequence")
+    func testSingleKeySequence() {
+        var detachKeys = DetachKeys("ctrl-x")
+        
+        // Send ctrl-x (0x18)
+        let result = detachKeys.checkByte(0x18)
+        #expect(result == .detach)
+    }
+    
+    @Test("Three key sequence")
+    func testThreeKeySequence() {
+        var detachKeys = DetachKeys("ctrl-a,ctrl-b,ctrl-c")
+        
+        // Send ctrl-a (0x01)
+        var result = detachKeys.checkByte(0x01)
+        #expect(result == .inProgress)
+        
+        // Send ctrl-b (0x02)
+        result = detachKeys.checkByte(0x02)
+        #expect(result == .inProgress)
+        
+        // Send ctrl-c (0x03)
+        result = detachKeys.checkByte(0x03)
+        #expect(result == .detach)
+    }
+    
+    @Test("Invalid sequence string")
+    func testInvalidSequence() {
+        let detachKeys = DetachKeys("invalid-key")
+        // Should create empty sequence, so any byte should reset
+        var mutableKeys = detachKeys
+        let result = mutableKeys.checkByte(0x10)
+        #expect(result == .reset)
+    }
+    
+    @Test("Reset functionality")
+    func testReset() {
+        var detachKeys = DetachKeys()
+        
+        // Start sequence
+        var result = detachKeys.checkByte(0x10) // ctrl-p
+        #expect(result == .inProgress)
+        
+        // Reset
+        detachKeys.reset()
+        
+        // Next byte should start fresh
+        result = detachKeys.checkByte(0x10) // ctrl-p again
+        #expect(result == .inProgress)
+    }
+    
+    @Test("Special key parsing")
+    func testSpecialKeys() {
+        var enterKeys = DetachKeys("enter")
+        var result = enterKeys.checkByte(0x0D) // CR
+        #expect(result == .detach)
+        
+        var tabKeys = DetachKeys("tab")
+        result = tabKeys.checkByte(0x09) // Tab
+        #expect(result == .detach)
+        
+        var escapeKeys = DetachKeys("escape")
+        result = escapeKeys.checkByte(0x1B) // Escape
+        #expect(result == .detach)
+    }
+    
+    @Test("Case insensitive parsing")
+    func testCaseInsensitive() {
+        var upperKeys = DetachKeys("CTRL-P")
+        var lowerKeys = DetachKeys("ctrl-p")
+        
+        // Both should produce same result
+        let upperResult = upperKeys.checkByte(0x10)
+        let lowerResult = lowerKeys.checkByte(0x10)
+        
+        #expect(upperResult == .detach)
+        #expect(lowerResult == .detach)
+    }
+}
+
+/// Test suite for DetachKeyDetector actor functionality
+@Suite("DetachKeyDetector actor")
+struct DetachKeyDetectorTests {
+    
+    @Test("Basic input processing")
+    func testBasicInputProcessing() async {
+        let detector = DetachKeyDetector()
+        
+        // Send normal data - should be forwarded
+        let normalData = Data("hello".utf8)
+        let (shouldDetach, dataToForward) = await detector.processInput(normalData)
+        
+        #expect(!shouldDetach)
+        #expect(dataToForward == normalData)
+    }
+    
+    @Test("Detach sequence detection")
+    func testDetachSequenceDetection() async {
+        let detector = DetachKeyDetector()
+        
+        // Send ctrl-p, ctrl-q sequence
+        let ctrlP = Data([0x10])
+        let ctrlQ = Data([0x11])
+        
+        // First part of sequence
+        let (shouldDetach1, dataToForward1) = await detector.processInput(ctrlP)
+        #expect(!shouldDetach1)
+        #expect(dataToForward1.isEmpty) // Buffered, not forwarded
+        
+        // Complete sequence
+        let (shouldDetach2, dataToForward2) = await detector.processInput(ctrlQ)
+        #expect(shouldDetach2)
+        #expect(dataToForward2.isEmpty) // Sequence consumed
+    }
+    
+    @Test("Partial sequence then normal data")
+    func testPartialSequenceThenNormalData() async {
+        let detector = DetachKeyDetector()
+        
+        // Send ctrl-p (start of sequence)
+        let ctrlP = Data([0x10])
+        let (shouldDetach1, dataToForward1) = await detector.processInput(ctrlP)
+        #expect(!shouldDetach1)
+        #expect(dataToForward1.isEmpty)
+        
+        // Send normal character (should reset and forward buffered + new data)
+        let normalData = Data("a".utf8)
+        let (shouldDetach2, dataToForward2) = await detector.processInput(normalData)
+        #expect(!shouldDetach2)
+        
+        // Should forward both the buffered ctrl-p and the 'a'
+        let expectedData = Data([0x10]) + normalData
+        #expect(dataToForward2 == expectedData)
+    }
+    
+    @Test("Multiple data chunks with sequence")
+    func testMultipleChunksWithSequence() async {
+        let detector = DetachKeyDetector()
+        
+        // Send data chunk with ctrl-p at the end
+        let chunk1 = Data("hello\u{10}".utf8) // hello + ctrl-p
+        let (shouldDetach1, dataToForward1) = await detector.processInput(chunk1)
+        #expect(!shouldDetach1)
+        // Should forward "hello" but buffer ctrl-p
+        #expect(dataToForward1 == Data("hello".utf8))
+        
+        // Send ctrl-q to complete sequence
+        let chunk2 = Data([0x11])
+        let (shouldDetach2, dataToForward2) = await detector.processInput(chunk2)
+        #expect(shouldDetach2)
+        #expect(dataToForward2.isEmpty)
+    }
+    
+    @Test("Custom detach sequence")
+    func testCustomDetachSequence() async {
+        let detector = DetachKeyDetector(sequence: "ctrl-a,ctrl-x")
+        
+        // Send ctrl-a
+        let ctrlA = Data([0x01])
+        let (shouldDetach1, dataToForward1) = await detector.processInput(ctrlA)
+        #expect(!shouldDetach1)
+        #expect(dataToForward1.isEmpty)
+        
+        // Send ctrl-x to complete custom sequence
+        let ctrlX = Data([0x18])
+        let (shouldDetach2, dataToForward2) = await detector.processInput(ctrlX)
+        #expect(shouldDetach2)
+        #expect(dataToForward2.isEmpty)
+    }
+    
+    @Test("Flush buffered data")
+    func testFlushBufferedData() async {
+        let detector = DetachKeyDetector()
+        
+        // Send partial sequence
+        let ctrlP = Data([0x10])
+        let (shouldDetach, dataToForward) = await detector.processInput(ctrlP)
+        #expect(!shouldDetach)
+        #expect(dataToForward.isEmpty)
+        
+        // Flush should return buffered data
+        let flushedData = await detector.flush()
+        #expect(flushedData == ctrlP)
+        
+        // After flush, detector should be reset
+        let (shouldDetach2, dataToForward2) = await detector.processInput(ctrlP)
+        #expect(!shouldDetach2)
+        #expect(dataToForward2.isEmpty) // Should buffer again
+    }
+    
+    @Test("Reset detector state")
+    func testResetDetectorState() async {
+        let detector = DetachKeyDetector()
+        
+        // Send partial sequence
+        let ctrlP = Data([0x10])
+        let (shouldDetach, dataToForward) = await detector.processInput(ctrlP)
+        #expect(!shouldDetach)
+        #expect(dataToForward.isEmpty)
+        
+        // Reset
+        await detector.reset()
+        
+        // After reset, should start fresh
+        let (shouldDetach2, dataToForward2) = await detector.processInput(ctrlP)
+        #expect(!shouldDetach2)
+        #expect(dataToForward2.isEmpty) // Should buffer again, not forward
+    }
+    
+    @Test("Empty input data")
+    func testEmptyInputData() async {
+        let detector = DetachKeyDetector()
+        
+        let emptyData = Data()
+        let (shouldDetach, dataToForward) = await detector.processInput(emptyData)
+        
+        #expect(!shouldDetach)
+        #expect(dataToForward.isEmpty)
+    }
+    
+    @Test("Large input data with sequence at various positions")
+    func testLargeInputWithSequence() async {
+        let detector = DetachKeyDetector()
+        
+        // Create large data with ctrl-p, ctrl-q in the middle
+        var largeData = Data("start".utf8)
+        largeData.append(contentsOf: Array(repeating: UInt8(65), count: 1000)) // 1000 'A's
+        largeData.append(0x10) // ctrl-p
+        largeData.append(0x11) // ctrl-q
+        largeData.append(contentsOf: "end".utf8)
+        
+        let (shouldDetach, dataToForward) = await detector.processInput(largeData)
+        
+        #expect(shouldDetach)
+        // Should forward everything before the detach sequence
+        // The "end" part after the detach sequence should be ignored (not forwarded)
+        let expectedForwarded = Data("start".utf8) + Data(Array(repeating: UInt8(65), count: 1000))
+        #expect(dataToForward == expectedForwarded, "Should only forward data before detach sequence")
+    }
+}

--- a/Tests/ContainerClientTests/TestPTYSession.swift
+++ b/Tests/ContainerClientTests/TestPTYSession.swift
@@ -1,0 +1,612 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Testing
+import Foundation
+import ContainerSandboxService
+import ContainerClient
+import ContainerXPC
+import Logging
+import ContainerizationOS
+
+/// Parameterized tests for stdio modes - tests both new (server-owned) and legacy (client-owned) modes
+struct TestPTYSession {
+    
+    enum StdioMode: String, CaseIterable {
+        case serverOwned = "server-owned"
+        case legacy = "legacy"
+        
+        var usesServerStdio: Bool {
+            self == .serverOwned
+        }
+    }
+    
+    // MARK: - Helper for PTY Session Management
+    
+    /// Execute a test with a PTY session, ensuring cleanup happens even on failure.
+    /// This helper eliminates the repetitive cleanup code in do-catch blocks.
+    ///
+    /// - Parameters:
+    ///   - containerID: Unique identifier for the PTY session
+    ///   - bufferSize: Size of the ring buffer for session history (default: 4096)
+    ///   - logger: Logger instance to use (creates default if not provided)
+    ///   - body: The test closure that receives the session and manager
+    /// - Returns: The result of the test closure
+    /// - Throws: Any error from session creation or the test body
+    func withPTYSession<T>(
+        containerID: String,
+        bufferSize: Int? = 4096,
+        logger: Logger? = nil,
+        body: (PTYSession) async throws -> T
+    ) async throws -> T {
+        let actualLogger = logger ?? Logger(label: "test.pty.session")
+        let session = try PTYSession(
+            containerID: containerID,
+            terminal: true,
+            bufferSize: bufferSize ?? PTYSession.defaultBufferSize,
+            logger: actualLogger
+        )
+        
+        defer {
+            session.cleanup()
+        }
+        
+        return try await body(session)
+    }
+    
+    // MARK: - Basic I/O Tests (work in both modes)
+    
+    @Test("Basic pipe I/O works", arguments: StdioMode.allCases)
+    func testBasicPipeIO(mode: StdioMode) throws {
+        // Both modes should support basic pipe I/O
+        let stdin = Pipe()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        
+        // Simulate server/client handle split based on mode
+        let (serverHandles, clientHandles) = splitHandles(
+            stdin: stdin,
+            stdout: stdout,
+            stderr: stderr,
+            mode: mode
+        )
+        
+        // Test stdout
+        let testData = "Hello stdio \(mode.rawValue)\n".data(using: .utf8)!
+        try serverHandles.stdout.write(contentsOf: testData)
+        
+        let received = readAvailableData(from: clientHandles.stdout)
+        #expect(received == testData)
+        
+        // Test stderr
+        let errorData = "Error in \(mode.rawValue)\n".data(using: .utf8)!
+        try serverHandles.stderr.write(contentsOf: errorData)
+        
+        let errorReceived = readAvailableData(from: clientHandles.stderr)
+        #expect(errorReceived == errorData)
+        
+        // Test stdin
+        let inputData = "Input for \(mode.rawValue)\n".data(using: .utf8)!
+        try clientHandles.stdin.write(contentsOf: inputData)
+        
+        let serverInput = readAvailableData(from: serverHandles.stdin)
+        #expect(serverInput == inputData)
+    }
+    
+    @Test("Character-by-character I/O", arguments: StdioMode.allCases)
+    func testCharacterIO(mode: StdioMode) throws {
+        let stdin = Pipe()
+        let stdout = Pipe()
+        
+        let (serverHandles, clientHandles) = splitHandles(
+            stdin: stdin,
+            stdout: stdout,
+            stderr: Pipe(),
+            mode: mode
+        )
+        
+        // Test writing and reading a single character at a time
+        let testString = "Hello!"
+        
+        // Write all characters first
+        for char in testString {
+            let charData = String(char).data(using: .utf8)!
+            try clientHandles.stdin.write(contentsOf: charData)
+        }
+        
+        // Read all data at once
+        let allData = readAvailableData(from: serverHandles.stdin)
+        let receivedString = String(data: allData, encoding: .utf8) ?? ""
+        #expect(receivedString == testString, "Should receive all characters")
+        
+        // Echo back all at once
+        try serverHandles.stdout.write(contentsOf: allData)
+        
+        // Client should see the echo
+        let echoData = readAvailableData(from: clientHandles.stdout)
+        let echoString = String(data: echoData, encoding: .utf8) ?? ""
+        #expect(echoString == testString, "Should see echoed characters")
+    }
+    
+    // MARK: - PTY Tests (server-owned mode only)
+    
+    @Test("PTY terminal mode with echo", arguments: [StdioMode.serverOwned])
+    func testPTYTerminalEcho(mode: StdioMode) async throws {
+        try await withPTYSession(
+            containerID: "pty-echo-test",
+            logger: Logger(label: "test.pty.echo")
+        ) { session in
+            // Get both client and container handles to demonstrate PTY echo
+            let clientHandles = session.clientHandles
+            let containerHandles = session.containerHandles
+            
+            guard let clientStdin = clientHandles[0],
+                  let clientStdout = clientHandles[1],
+                  let containerStdout = containerHandles[1] else {
+                Issue.record("Failed to get handles")
+                return
+            }
+            
+            // Write a test string from client
+            let testString = "Hello PTY!"
+            let testData = testString.data(using: .utf8)!
+            try clientStdin.write(contentsOf: testData)
+            
+            // Send newline to flush
+            try clientStdin.write(contentsOf: "\n".data(using: .utf8)!)
+            
+            // Simulate container echoing the input back
+            // In a real PTY with a shell, this would happen automatically
+            let echoData = (testString + "\n").data(using: .utf8)!
+            try containerStdout.write(contentsOf: echoData)
+            
+            // Small delay for data to propagate
+            try await Task.sleep(nanoseconds: 50_000_000) // 50ms
+            
+            // Client should see the echo
+            let receivedData = readAvailableData(from: clientStdout, timeout: 0.5)
+            let receivedStr = String(data: receivedData, encoding: .utf8) ?? ""
+            
+            // Verify the echo was received
+            #expect(receivedStr.contains(testString), "Client should see echoed input: '\(receivedStr)'")
+        }
+    }
+    
+    @Test("PTY attach/detach cycle", arguments: [StdioMode.serverOwned])
+    func testPTYAttachDetachCycle(mode: StdioMode) async throws {
+        try await withPTYSession(
+            containerID: "attach-cycle-test",
+            logger: Logger(label: "test.attach.cycle")
+        ) { session in
+            // First attachment - get history
+            let (historyBytes1, truncated1) = session.sendHistory()
+            #expect(historyBytes1 == 0, "No history on first attach")
+            #expect(!truncated1, "History should not be truncated")
+            
+            // Get client handles
+            let clientHandles = session.clientHandles
+            guard let stdin = clientHandles[0],
+                  let stdout = clientHandles[1] else {
+                Issue.record("Failed to get client handles")
+                return
+            }
+            
+            // Write some data
+            let message1 = "First attach message\n"
+            try stdin.write(contentsOf: message1.data(using: .utf8)!)
+            try await Task.sleep(nanoseconds: 50_000_000) // 50ms
+            
+            // Read to confirm it went through
+            let output1 = readAvailableData(from: stdout)
+            #expect(output1.count > 0, "Should receive data in first session")
+            
+            // Simulate detach by just waiting (in real scenario, client would disconnect)
+            try await Task.sleep(nanoseconds: 100_000_000) // 100ms
+            
+            // Write more data while "detached" (data goes to history buffer)
+            let message2 = "Data while detached\n"
+            try stdin.write(contentsOf: message2.data(using: .utf8)!)
+            try await Task.sleep(nanoseconds: 50_000_000) // 50ms
+            
+            // Second attachment - should get history
+            let (historyBytes2, truncated2) = session.sendHistory()
+            #expect(historyBytes2 > 0, "Should have history on reattach: \(historyBytes2) bytes")
+            #expect(!truncated2, "History should not be truncated")
+            
+            // The history is already in the buffer, we just need to verify the size
+            #expect(historyBytes2 >= message1.count + message2.count, 
+                    "History should include both messages")
+        }
+    }
+    
+    @Test("Multiple concurrent attach sessions", arguments: [StdioMode.serverOwned])
+    func testMultipleConcurrentAttach(mode: StdioMode) async throws {
+        try await withPTYSession(
+            containerID: "concurrent-test",
+            logger: Logger(label: "test.concurrent")
+        ) { session in
+            // Note: In reality, PTY sessions share a single terminal
+            // All clients see the same output
+            let clientHandles = session.clientHandles
+            guard let stdin = clientHandles[0],
+                  let stdout = clientHandles[1] else {
+                Issue.record("Failed to get client handles")
+                return
+            }
+            
+            // Write a broadcast message
+            let broadcast = "Broadcast to all sessions\n"
+            try stdin.write(contentsOf: broadcast.data(using: .utf8)!)
+            try await Task.sleep(nanoseconds: 50_000_000) // 50ms
+            
+            // Read the broadcast
+            let output = readAvailableData(from: stdout)
+            let outputStr = String(data: output, encoding: .utf8) ?? ""
+            #expect(outputStr.contains("Broadcast"), "Should see broadcast message")
+            
+            // Multiple clients would all see the same output from the shared PTY
+            // This is the expected behavior for terminal sharing
+        }
+    }
+    
+    // MARK: - Buffer Management Tests
+    
+    @Test("PTY buffer overflow handling", arguments: [StdioMode.serverOwned])
+    func testPTYBufferOverflow(mode: StdioMode) async throws {
+        let bufferSize = 1024 // Small buffer to test overflow
+        
+        try await withPTYSession(
+            containerID: "buffer-overflow-test",
+            bufferSize: bufferSize,
+            logger: Logger(label: "test.buffer.overflow")
+        ) { session in
+            let clientHandles = session.clientHandles
+            guard let stdin = clientHandles[0] else {
+                Issue.record("Failed to get stdin handle")
+                return
+            }
+            
+            // Write more data than buffer can hold
+            let chunk = String(repeating: "A", count: 100)
+            var totalWritten = 0
+            for i in 0..<20 {
+                let data = "\(i): \(chunk)\n".data(using: .utf8)!
+                try stdin.write(contentsOf: data)
+                totalWritten += data.count
+            }
+            
+            // Let buffer process
+            try await Task.sleep(nanoseconds: 100_000_000) // 100ms
+            
+            // Check buffer stats
+            let stats = session.getBufferStats()
+            #expect(stats.historySize > 0, "Buffer should contain data")
+            #expect(stats.truncated || totalWritten <= bufferSize, 
+                    "Buffer should be truncated or data fits")
+            
+            // Get history and verify truncation if needed
+            let (historyBytes, truncated) = session.sendHistory()
+            #expect(historyBytes > 0, "Should have history bytes")
+            #expect(historyBytes <= bufferSize, "History should not exceed buffer size")
+            
+            if totalWritten > bufferSize {
+                #expect(truncated, "History should be truncated when overflow occurs")
+            }
+        }
+    }
+    
+    // MARK: - Error Cases
+    
+    @Test("Closed pipe handling", arguments: StdioMode.allCases)
+    func testClosedPipeHandling(mode: StdioMode) throws {
+        // Save the original SIGPIPE handler
+        let oldHandler = signal(SIGPIPE, SIG_IGN)
+        defer {
+            // Restore the original handler
+            signal(SIGPIPE, oldHandler)
+        }
+        
+        let stdin = Pipe()
+        let stdout = Pipe()
+        
+        let (serverHandles, clientHandles) = splitHandles(
+            stdin: stdin,
+            stdout: stdout,
+            stderr: Pipe(),
+            mode: mode
+        )
+        
+        // Close client stdout
+        clientHandles.stdout.closeFile()
+        
+        // Server write should fail gracefully
+        let testData = "Test data\n".data(using: .utf8)!
+        do {
+            try serverHandles.stdout.write(contentsOf: testData)
+            // Might succeed if buffered
+        } catch {
+            // Expected - pipe is closed
+        }
+        
+        // Close server stdin
+        serverHandles.stdin.closeFile()
+        
+        // Client write should fail
+        do {
+            try clientHandles.stdin.write(contentsOf: testData)
+            Issue.record("Write to closed pipe should fail")
+        } catch {
+            // Expected
+        }
+    }
+    
+    // MARK: - Line Discipline Tests
+    
+    @Test("Line buffering behavior", arguments: StdioMode.allCases)
+    func testLineBuffering(mode: StdioMode) throws {
+        let stdin = Pipe()
+        let stdout = Pipe()
+        
+        let (serverHandles, clientHandles) = splitHandles(
+            stdin: stdin,
+            stdout: stdout,
+            stderr: Pipe(),
+            mode: mode
+        )
+        
+        // Write a complete line with newline
+        let fullLine = "Complete line with newline\n"
+        try serverHandles.stdout.write(contentsOf: fullLine.data(using: .utf8)!)
+        
+        // Read the complete line
+        let lineData = readAvailableData(from: clientHandles.stdout)
+        let lineStr = String(data: lineData, encoding: .utf8) ?? ""
+        #expect(lineStr == fullLine, "Should receive complete line")
+        
+        // Write another line to test multiple lines
+        let secondLine = "Second line\n"
+        try serverHandles.stdout.write(contentsOf: secondLine.data(using: .utf8)!)
+        
+        let secondData = readAvailableData(from: clientHandles.stdout)
+        let secondStr = String(data: secondData, encoding: .utf8) ?? ""
+        #expect(secondStr == secondLine, "Should receive second line")
+    }
+    
+    // MARK: - Helper Methods
+    
+    /// Read available data with a timeout to prevent blocking
+    private func readAvailableData(from handle: FileHandle, timeout: TimeInterval = 0.1) -> Data {
+        var data = Data()
+        let endTime = Date().addingTimeInterval(timeout)
+        
+        while Date() < endTime {
+            // Check if data is available without blocking
+            let availableData = handle.availableData
+            if availableData.count > 0 {
+                data.append(availableData)
+                break
+            }
+            // Small sleep to prevent busy waiting
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        
+        return data
+    }
+    
+    private func splitHandles(
+        stdin: Pipe,
+        stdout: Pipe,
+        stderr: Pipe,
+        mode: StdioMode
+    ) -> (server: (stdin: FileHandle, stdout: FileHandle, stderr: FileHandle),
+         client: (stdin: FileHandle, stdout: FileHandle, stderr: FileHandle)) {
+        
+        // In both modes, the handle split is the same for pipes
+        // Server gets read end of stdin, write end of stdout/stderr
+        // Client gets write end of stdin, read end of stdout/stderr
+        
+        return (
+            server: (
+                stdin: stdin.fileHandleForReading,
+                stdout: stdout.fileHandleForWriting,
+                stderr: stderr.fileHandleForWriting
+            ),
+            client: (
+                stdin: stdin.fileHandleForWriting,
+                stdout: stdout.fileHandleForReading,
+                stderr: stderr.fileHandleForReading
+            )
+        )
+    }
+
+@Test("Server-owned stdio creates real PTY sessions")
+    func testServerOwnedPTY() async throws {
+        try await withPTYSession(
+            containerID: "summary-pty",
+            logger: Logger(label: "test.summary.pty")
+        ) { session in
+            // Verify PTY was created with valid handles
+            let containerHandles = session.containerHandles
+            #expect(containerHandles.count == 3, "Should have stdin, stdout, stderr handles")
+            
+            // In PTY mode, all three handles point to the same PTY slave
+            if let stdin = containerHandles[0],
+               let stdout = containerHandles[1],
+               let stderr = containerHandles[2] {
+                #expect(stdin.fileDescriptor > 0, "PTY slave FD is valid")
+                #expect(stdout.fileDescriptor == stdin.fileDescriptor, 
+                        "stdout uses same PTY slave")
+                #expect(stderr.fileDescriptor == stdin.fileDescriptor, 
+                        "stderr uses same PTY slave")
+            } else {
+                Issue.record("Failed to get container handles")
+            }
+            
+            // Verify client handles are pipes
+            let clientHandles = session.clientHandles
+            #expect(clientHandles[0] != nil, "Client stdin exists")
+            #expect(clientHandles[1] != nil, "Client stdout exists")
+            #expect(clientHandles[2] == nil, "Client stderr is nil for PTY mode")
+        }
+    }
+    
+    @Test("Legacy mode uses standard pipes")
+    func testLegacyPipes() throws {
+        // Legacy mode just uses regular pipes
+        let stdin = Pipe()
+        let stdout = Pipe()
+        let _ = Pipe() // stderr not used in this test
+        
+        // Client writes to stdin
+        let input = "Legacy input\n".data(using: .utf8)!
+        try stdin.fileHandleForWriting.write(contentsOf: input)
+        
+        // Server reads from stdin
+        let received = readAvailableData(from: stdin.fileHandleForReading)
+        #expect(received == input, "Legacy stdin works")
+        
+        // Server writes to stdout
+        let output = "Legacy output\n".data(using: .utf8)!
+        try stdout.fileHandleForWriting.write(contentsOf: output)
+        
+        // Client reads from stdout
+        let clientOutput = readAvailableData(from: stdout.fileHandleForReading)
+        #expect(clientOutput == output, "Legacy stdout works")
+    }
+    
+    @Test("Attach/detach works in server-owned mode")
+    func testAttachDetachServerOwned() async throws {
+        try await withPTYSession(
+            containerID: "summary-attach",
+            logger: Logger(label: "test.summary.attach")
+        ) { session in
+            // First attach - no history
+            let (historyBytes1, _) = session.sendHistory()
+            #expect(historyBytes1 == 0, "No history on first attach")
+            
+            // In a real scenario, the container process would be connected to the PTY
+            // and would generate output. For this test, we'll simulate by checking
+            // that the PTY session is properly set up and history tracking works.
+            
+            // Get container handles to simulate container writing
+            let containerHandles = session.containerHandles
+            guard let containerStdout = containerHandles[1] else {
+                Issue.record("Failed to get container stdout handle")
+                return
+            }
+            
+            // Simulate container output
+            let message = "Container output data\n"
+            try containerStdout.write(contentsOf: message.data(using: .utf8)!)
+            try await Task.sleep(nanoseconds: 50_000_000) // 50ms
+            
+            // Second attach - should have history
+            let (historyBytes2, _) = session.sendHistory()
+            #expect(historyBytes2 > 0, "Has history on reattach: \(historyBytes2) bytes")
+            #expect(historyBytes2 >= message.count, "History contains the output")
+        }
+    }
+    
+    @Test("Character I/O works in both modes")
+    func testCharacterIOBothModes() throws {
+        // Test both legacy (pipes) and server (would use PTY)
+        for mode in ["legacy", "server"] {
+            let stdin = Pipe()
+            let stdout = Pipe()
+            
+            // Send character
+            let char = "X"
+            let charData = char.data(using: .utf8)!
+            try stdin.fileHandleForWriting.write(contentsOf: charData)
+            
+            // Read character
+            let received = readAvailableData(from: stdin.fileHandleForReading)
+            #expect(received == charData, "\(mode): Character passes through")
+            
+            // Echo character
+            try stdout.fileHandleForWriting.write(contentsOf: charData)
+            let echo = readAvailableData(from: stdout.fileHandleForReading)
+            #expect(echo == charData, "\(mode): Character echo works")
+        }
+    }
+    
+    @Test("Binary data works correctly")
+    func testBinaryDataIntegrity() throws {
+        let pipe = Pipe()
+        
+        // Test binary data including nulls
+        let binaryData = Data([0x00, 0x01, 0xFF, 0x42, 0x00, 0xDE, 0xAD, 0xBE, 0xEF])
+        try pipe.fileHandleForWriting.write(contentsOf: binaryData)
+        
+        let received = readAvailableData(from: pipe.fileHandleForReading)
+        #expect(received == binaryData, "Binary data preserved")
+    }
+    
+    @Test("Multiple sessions can attach to same PTY")
+    func testMultipleAttach() async throws {
+        try await withPTYSession(
+            containerID: "summary-multi",
+            logger: Logger(label: "test.summary.multi")
+        ) { session in
+            // PTY sessions share the same terminal
+            // All output is broadcast to all attached clients
+            let clientHandles = session.clientHandles
+            guard let stdin = clientHandles[0],
+                  let stdout = clientHandles[1] else {
+                Issue.record("Failed to get client handles")
+                return
+            }
+            
+            // Write from "session 1"
+            let msg1 = "Message from session 1\n"
+            try stdin.write(contentsOf: msg1.data(using: .utf8)!)
+            try await Task.sleep(nanoseconds: 50_000_000) // 50ms
+            
+            // Both "sessions" see the same output
+            let output = readAvailableData(from: stdout)
+            let outputStr = String(data: output, encoding: .utf8) ?? ""
+            #expect(outputStr.contains("session 1"), "Output visible to all sessions")
+            
+            // In a real multi-attach scenario, multiple clients would connect
+            // to the same PTY session and all see the same terminal output
+        }
+    }
+    
+    @Test("Stdio handle transfer via XPC works")
+    func testXPCHandleTransfer() throws {
+        let stdin = Pipe()
+        let stdout = Pipe()
+        
+        // Simulate server creating handles
+        let message = XPCMessage(route: "test")
+        message.set(key: .stdin, value: stdin.fileHandleForWriting)
+        message.set(key: .stdout, value: stdout.fileHandleForReading)
+        
+        // Client extracts handles
+        let clientStdin = message.fileHandle(key: .stdin)
+        let clientStdout = message.fileHandle(key: .stdout)
+        
+        #expect(clientStdin != nil, "Stdin transferred")
+        #expect(clientStdout != nil, "Stdout transferred")
+        
+        // Verify handles work
+        let testData = "XPC test\n".data(using: .utf8)!
+        try clientStdin!.write(contentsOf: testData)
+        
+        let received = readAvailableData(from: stdin.fileHandleForReading)
+        #expect(received == testData, "XPC-transferred handle works")
+    }
+}    


### PR DESCRIPTION
Closes #378.

Add container attach/detach support

This change introduces a new `container attach` command that allows users to attach
to running containers with terminal support.

## Key changes:
- Move stdio management for interactive run from client to server so that sessions can exist beyond CLI lifetime.
- Update stdio to use a ring buffer so attach can get recent history.
- Enable legacy (client driven stdio) and server stdio coexistence.

## CLI Changes
- Added `container attach <id>` subcommand for attaching to an existing session.
- Added `--legacy-stdio` run flag to let newer clients talk to older servers.
- Added `--detach-keys` option to run and attach to set detachment keys (defaulted to ctrl-p,ctrl-q)

## Testing
- Added integration tests for attach functionality
- Added session management tests
- Added fallback/legacy mode tests

## Build changes
- Added a couple of additional makefile flags to make it easier to target tests: `INTEGRATION_TEST_FILTER`, `INTEGRATION_TEST_SKIP`, `TEST_FILTER`
- Removed the hand written TestCLI filter list and used a single filter with `--no-parallel`

