### PR TITLE
Add unpack strategy to SnapshotStore

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cc0718ffe17715cc940f40d92b33532b6dd1767065ccc6039f7174402ba5930f",
+  "originHash" : "912a08d7a8cc6a403ab02a8d236337b39276fa0d4f675ceb6d69d5d624af8a49",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "1a59de82b052a86edd9e2bd6f023d212a061b0b4",
-        "version" : "0.2.0"
+        "revision" : "bdba5b5740be22a668f7a6d78e2cdd1efc339418",
+        "version" : "0.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ if let path = ProcessInfo.processInfo.environment["CONTAINERIZATION_PATH"] {
     scDependency = .package(path: path)
     scVersion = "latest"
 } else {
-    scVersion = "0.2.0"
+    scVersion = "0.3.0"
     scDependency = .package(url: "https://github.com/apple/containerization.git", exact: Version(stringLiteral: scVersion))
 }
 

--- a/Sources/Helpers/Images/ImagesHelper.swift
+++ b/Sources/Helpers/Images/ImagesHelper.swift
@@ -60,6 +60,8 @@ extension ImagesHelper {
             .appendingPathComponent("com.apple.container")
         }()
 
+        private static let unpackStrategy = SnapshotStore.defaultUnpackStrategy
+
         func run() async throws {
             let commandName = ImagesHelper._commandName
             let log = setupLogger()
@@ -89,7 +91,7 @@ extension ImagesHelper {
         private func initializeImagesService(root: URL, log: Logger, routes: inout [String: XPCServer.RouteHandler]) throws {
             let contentStore = RemoteContentStoreClient()
             let imageStore = try ImageStore(path: root, contentStore: contentStore)
-            let snapshotStore = try SnapshotStore(path: root)
+            let snapshotStore = try SnapshotStore(path: root, unpackStrategy: Self.unpackStrategy, log: log)
             let service = try ImagesService(contentStore: contentStore, imageStore: imageStore, snapshotStore: snapshotStore, log: log)
             let harness = ImagesServiceHarness(service: service, log: log)
 


### PR DESCRIPTION
Define a `UnpackStrategy` function type in the `SnapshotStore` to give more control over how an image is unpacked.

Previously, we were creating a 512 GB sparse block file for the initial file system of a container, which is overkill.

With this change, the vminit image is unpacked to a smaller block file, while container images are unpacked to the 512 GB block

Follows the same pattern as https://github.com/apple/container/blob/main/Sources/Helpers/RuntimeLinux/RuntimeLinuxHelper.swift#L71