### PR TITLE
Assigns default nameserver in sandbox service.

### DIFF
--- a/Sources/ContainerClient/Utility.swift
+++ b/Sources/ContainerClient/Utility.swift
@@ -169,21 +169,12 @@ public struct Utility {
             networkStatuses.append(networkStatus)
         }
 
-        let nameservers: [String]
-        if management.dnsNameservers.isEmpty {
-            let subnet = try CIDRAddress(networkStatuses[0].address)
-            let nameserver = IPv4Address(fromValue: subnet.lower.value + 1).description
-            nameservers = [nameserver]
-        } else {
-            nameservers = management.dnsNameservers
-        }
-
         if management.dnsDisabled {
             config.dns = nil
         } else {
             let domain = management.dnsDomain ?? ClientDefaults.getOptional(key: .defaultDNSDomain)
             config.dns = .init(
-                nameservers: nameservers,
+                nameservers: management.dnsNameservers,
                 domain: domain,
                 searchDomains: management.dnsSearchDomains,
                 options: management.dnsOptions


### PR DESCRIPTION
* Closes #148.
* Storing the default nameserver in the bundle config means that DNS won't work if the container stops and then restarts later when the subnet address has changed.