### PR TITLE
ProcessIO: Don't error if stdin isn't a pty and !-i

### DIFF
--- a/Sources/CLI/RunCommand.swift
+++ b/Sources/CLI/RunCommand.swift
@@ -194,7 +194,7 @@ struct ProcessIO {
 
     static func create(tty: Bool, interactive: Bool, detach: Bool) throws -> ProcessIO {
         let current: Terminal? = try {
-            if !tty {
+            if !tty || !interactive {
                 return nil
             }
             let current = try Terminal.current


### PR DESCRIPTION
We don't need to error unless we're supplying io.