### PR TITLE
CLI: Add --platform flag

### DIFF
--- a/Sources/CLI/BuildCommand.swift
+++ b/Sources/CLI/BuildCommand.swift
@@ -87,6 +87,9 @@ extension Application {
             ["linux"]
         }()
 
+        @Option(name: .long, help: "set the builds platform. This takes precedence over --os and --arch")
+        var platform: [String] = []
+
         @Option(name: .long, help: ArgumentHelp("Progress type - one of [auto|plain|tty]", valueName: "type"))
         var progress: String = "auto"
 
@@ -219,6 +222,16 @@ extension Application {
                     }
                     let platforms: [Platform] = try {
                         var results: [Platform] = []
+                        if !self.platform.isEmpty {
+                            for platform in self.platform {
+                                guard let p = try? Platform(from: platform) else {
+                                    throw ValidationError("invalid platform specified \(platform)")
+                                }
+                                results.append(p)
+                            }
+                            return results
+                        }
+
                         for o in self.os {
                             for a in self.arch {
                                 guard let platform = try? Platform(from: "\(o)/\(a)") else {

--- a/Sources/CLI/Image/ImagePull.swift
+++ b/Sources/CLI/Image/ImagePull.swift
@@ -37,7 +37,15 @@ extension Application {
         @OptionGroup
         var progressFlags: Flags.Progress
 
-        @Option(help: "Platform string in the form 'os/arch/variant'. Example 'linux/arm64/v8', 'linux/amd64'") var platform: String?
+        @Option(help: "Platform string in the form 'os/arch/variant'. Example 'linux/arm64/v8', 'linux/amd64'. This takes precedence over --os and --arch")
+        var platform: String?
+
+        @Option(name: .customLong("os"), help: "Set OS if image can target multiple operating systems")
+        public var os: String?
+
+        @Option(
+            name: [.customLong("arch"), .customShort("a")], help: "Set arch if image can target multiple architectures")
+        public var arch: String?
 
         @Argument var reference: String
 
@@ -55,6 +63,10 @@ extension Application {
             var p: Platform?
             if let platform {
                 p = try Platform(from: platform)
+            } else if os != nil || arch != nil {
+                let o = os ?? ""
+                let a = arch ?? ""
+                p = try Platform(from: "\(o)/\(a)")
             }
 
             let scheme = try RequestScheme(registry.scheme)

--- a/Sources/ContainerClient/Flags.swift
+++ b/Sources/ContainerClient/Flags.swift
@@ -112,6 +112,9 @@ public struct Flags {
             name: [.customLong("arch"), .customShort("a")], help: "Set arch if image can target multiple architectures")
         public var arch: String = Arch.hostArchitecture().rawValue
 
+        @Option(name: .customLong("platform"), help: "Platform for the image if it's multi-platform. This takes precedence over --os and --arch")
+        public var platform: String?
+
         @Option(name: [.customLong("volume"), .customShort("v")], help: "Bind mount a volume into the container")
         public var volumes: [String] = []
 

--- a/Sources/ContainerClient/Parser.swift
+++ b/Sources/ContainerClient/Parser.swift
@@ -31,7 +31,6 @@ public struct Parser {
         user: String?, uid: UInt32?, gid: UInt32?,
         defaultUser: ProcessConfiguration.User = .id(uid: 0, gid: 0)
     ) -> (user: ProcessConfiguration.User, groups: [UInt32]) {
-
         var supplementalGroups: [UInt32] = []
         let user: ProcessConfiguration.User = {
             if let user = user, !user.isEmpty {
@@ -58,6 +57,10 @@ public struct Parser {
 
     public static func platform(os: String, arch: String) -> ContainerizationOCI.Platform {
         .init(arch: arch, os: os)
+    }
+
+    public static func platform(from platform: String) throws -> ContainerizationOCI.Platform {
+        try .init(from: platform)
     }
 
     public static func resources(cpus: Int64?, memory: String?) throws -> ContainerConfiguration.Resources {

--- a/Sources/ContainerClient/Utility.swift
+++ b/Sources/ContainerClient/Utility.swift
@@ -71,7 +71,11 @@ public struct Utility {
         registry: Flags.Registry,
         progressUpdate: @escaping ProgressUpdateHandler
     ) async throws -> (ContainerConfiguration, Kernel) {
-        let requestedPlatform = Parser.platform(os: management.os, arch: management.arch)
+        var requestedPlatform = Parser.platform(os: management.os, arch: management.arch)
+        // Prefer --platform
+        if let platform = management.platform {
+            requestedPlatform = try Parser.platform(from: platform)
+        }
         let scheme = try RequestScheme(registry.scheme)
 
         await progressUpdate([
@@ -155,7 +159,10 @@ public struct Utility {
         } else {
             // networks may only be specified for macOS 26+
             guard #available(macOS 26, *) else {
-                throw ContainerizationError(.invalidArgument, message: "non-default network configuration requires macOS 26 or newer")
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "non-default network configuration requires macOS 26 or newer"
+                )
             }
             config.networks = management.networks
         }

--- a/Tests/CLITests/Subcommands/Images/TestCLIImages.swift
+++ b/Tests/CLITests/Subcommands/Images/TestCLIImages.swift
@@ -14,8 +14,6 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-//
-
 import Foundation
 import Testing
 
@@ -159,6 +157,35 @@ extension TestCLIImagesCommand {
             try doPull(imageName: alpine, args: pullArgs)
 
             let output = try doInspectImages(image: alpine)
+            #expect(output.count == 1, "expected a single image inspect output, got \(output)")
+
+            var found = false
+            for v in output[0].variants {
+                if v.platform.os == os && v.platform.architecture == arch {
+                    found = true
+                }
+            }
+            #expect(found, "expected to find image with os \(os) and architecture \(arch), instead got \(output[0])")
+        } catch {
+            Issue.record("failed to pull and inspect image \(error)")
+            return
+        }
+    }
+
+    @Test func testPullOsArch() throws {
+        do {
+            let os = "linux"
+            let arch = "amd64"
+            let pullArgs = [
+                "--os",
+                os,
+                "--arch",
+                arch,
+            ]
+
+            try doPull(imageName: alpine318, args: pullArgs)
+
+            let output = try doInspectImages(image: alpine318)
             #expect(output.count == 1, "expected a single image inspect output, got \(output)")
 
             var found = false

--- a/Tests/CLITests/Subcommands/Run/TestCLIRunOptions.swift
+++ b/Tests/CLITests/Subcommands/Run/TestCLIRunOptions.swift
@@ -280,6 +280,26 @@ class TestCLIRunCommand: CLITest {
         }
     }
 
+    @Test func testRunCommandPlatform() throws {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
+            let os = "linux"
+            let platform = "linux/amd64"
+            let expectedArch = "x86_64"
+            try doLongRun(name: name, args: ["--platform", platform])
+            defer {
+                try? doStop(name: name)
+            }
+            var output = try doExec(name: name, cmd: ["uname", "-sm"])
+            output = output.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            #expect(output == "\(os) \(expectedArch)", "expected container to use '\(os) \(expectedArch)', instead got '\(output)'")
+            try doStop(name: name)
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
+        }
+    }
+
     @Test func testRunCommandVolume() throws {
         do {
             let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])

--- a/Tests/CLITests/Utilities/CLITest.swift
+++ b/Tests/CLITests/Utilities/CLITest.swift
@@ -37,6 +37,7 @@ class CLITest {
     }
 
     let alpine = "ghcr.io/linuxcontainers/alpine:3.20"
+    let alpine318 = "ghcr.io/linuxcontainers/alpine:3.18"
     let busybox = "ghcr.io/containerd/busybox:1.36"
 
     let defaultContainerArgs = ["sleep", "infinity"]


### PR DESCRIPTION
Fixes #231

--platform is useful as it's what most folks are used to from other container tools. We support two separate flags today that when combined (--os and --arch) do essentially the same thing, but this is a combined single string form.