### PR TITLE
Docs: Add macOS 15 container-to-container communication limitation note to the tutorial

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -224,6 +224,11 @@ You will often see these two options abbreviated and specified together as `-ti`
 
 Your web server is accessible from other containers as well as from your host. Launch a second container using your `web-test` image, and this time, specify a `curl` command to retrieve the `index.html` content from the first container.
 
+> [!NOTE]
+> Container relies on the new features and enhancements present in the macOS 26 beta.
+> As a result, the functionality of accessing the web server from another container will not work on macOS 15.
+> See https://github.com/apple/container/blob/main/docs/technical-overview.md#macos-15-limitations for more details.
+
 ```bash
 container run -it --rm web-test curl http://192.168.64.3
 ```


### PR DESCRIPTION
Add note about macOS 15 network isolation preventing container-to-container communication

Ref: https://github.com/apple/container/issues/326