### PR TITLE
Make image details public

### DIFF
--- a/Sources/ContainerClient/Core/ImageDetail.swift
+++ b/Sources/ContainerClient/Core/ImageDetail.swift
@@ -18,14 +18,14 @@ import Containerization
 import ContainerizationOCI
 
 public struct ImageDetail: Codable {
-    let name: String
-    let index: Descriptor
-    let variants: [Variants]
+    public let name: String
+    public let index: Descriptor
+    public let variants: [Variants]
 
-    struct Variants: Codable {
-        let platform: Platform
-        let config: ContainerizationOCI.Image
-        let size: Int64
+    public struct Variants: Codable {
+        public let platform: Platform
+        public let config: ContainerizationOCI.Image
+        public let size: Int64
 
         init(platform: Platform, size: Int64, config: ContainerizationOCI.Image) {
             self.platform = platform


### PR DESCRIPTION
I want to access the different variants of an image in my app, which information is only available in the ImageDetail. Although the function ClientImage.details() -> ImageDetail and its return type are already public, its properties aren’t, which prevents access to this information.