### PR TITLE
Add StartedAt field to container list output

### DIFF
--- a/Sources/CLI/Container/ContainerList.swift
+++ b/Sources/CLI/Container/ContainerList.swift
@@ -92,6 +92,7 @@ extension ClientContainer {
             self.configuration.platform.os,
             self.configuration.platform.architecture,
             self.status.rawValue,
+            self.configuration.startedAt.map { ISO8601DateFormatter().string(from: $0) } ?? "",
             self.networks.compactMap { try? CIDRAddress($0.address).address.description }.joined(separator: ","),
         ]
     }
@@ -101,10 +102,12 @@ struct PrintableContainer: Codable {
     let status: RuntimeStatus
     let configuration: ContainerConfiguration
     let networks: [Attachment]
+    let startedAt: Date?
 
     init(_ container: ClientContainer) {
         self.status = container.status
         self.configuration = container.configuration
         self.networks = container.networks
+        self.startedAt = container.startedAt
     }
 }

--- a/Sources/ContainerClient/Core/ClientContainer.swift
+++ b/Sources/ContainerClient/Core/ClientContainer.swift
@@ -47,6 +47,9 @@ public struct ClientContainer: Sendable, Codable {
     /// Network allocated to the container.
     public let networks: [Attachment]
 
+    /// When the container was started.
+    public let startedAt: Date?
+
     package init(configuration: ContainerConfiguration) {
         self.configuration = configuration
         self.status = .stopped
@@ -57,6 +60,7 @@ public struct ClientContainer: Sendable, Codable {
         self.configuration = snapshot.configuration
         self.status = snapshot.status
         self.networks = snapshot.networks
+        self.startedAt = snapshot.startedAt
     }
 
     public var initProcess: ClientProcess {
@@ -248,4 +252,6 @@ extension ClientContainer {
             )
         }
     }
+
+    
 }

--- a/Sources/ContainerClient/Core/ContainerSnapshot.swift
+++ b/Sources/ContainerClient/Core/ContainerSnapshot.swift
@@ -25,14 +25,18 @@ public struct ContainerSnapshot: Codable, Sendable {
     public let status: RuntimeStatus
     /// Network interfaces attached to the sandbox that are provided to the container.
     public let networks: [Attachment]
+    /// When the container was started.
+    public let startedAt: Date?
 
     public init(
         configuration: ContainerConfiguration,
         status: RuntimeStatus,
-        networks: [Attachment]
+        networks: [Attachment],
+        startedAt: Date? = nil
     ) {
         self.configuration = configuration
         self.status = status
         self.networks = networks
+        self.startedAt = startedAt
     }
 }


### PR DESCRIPTION
## Summary

This pull request adds support for tracking and exposing the container `startedAt` timestamp throughout the container lifecycle.

Fixes [apple/container#302](https://github.com/apple/container/issues/302).

## Changes

- Added `startedAt: Date?` to:
  - `ContainerSnapshot`
  - `ClientContainer`
  - `PrintableContainer`
- Timestamp is assigned in `ContainersService.containerStartHandler` using `Date()`
- Propagated the value through `Item.asSnapshot()`
- Included `startedAt` in:
  - `container list --format json` output
  - Optionally included in `asRow` for table display (ISO 8601 format)

