### PR TITLE
Add cause string to error message sent with xpc

### DIFF
--- a/Sources/ContainerXPC/XPCMessage.swift
+++ b/Sources/ContainerXPC/XPCMessage.swift
@@ -86,7 +86,11 @@ extension XPCMessage {
     }
 
     public func set(error: ContainerizationError) {
-        let serializableError = ContainerXPCError(code: error.code.description, message: error.message)
+        var message = error.message
+        if let cause = error.cause {
+            message += " (cause: \"\(cause)\")"
+        }
+        let serializableError = ContainerXPCError(code: error.code.description, message: message)
         let data = try? JSONEncoder().encode(serializableError)
         precondition(data != nil)
 


### PR DESCRIPTION
Looks like we've been ignoring the "cause" field for ContainerizationError when sent over xpc. Add the cause to the `ContainerXPCError` message field instead of a new `cause` field since `Error` is not encodable. The goal here is just to preserve information. 