### PR TITLE
Bump Containerization to 0.5.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b75d239759865c54143e43f6c12839f0cb6a7ab70488af986fdf966ede58f78d",
+  "originHash" : "5cec5c196f44a46c11a3df7bd10731692009c1abaedf2fead9926e6e98b3f6a8",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "41d41e4ffe5c625e1fe01da454879423f5333eea",
-        "version" : "0.4.1"
+        "revision" : "0a4ff1b737c37563196754f62a3218873a49c6a7",
+        "version" : "0.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ import PackageDescription
 
 let releaseVersion = ProcessInfo.processInfo.environment["RELEASE_VERSION"] ?? "0.0.0"
 let gitCommit = ProcessInfo.processInfo.environment["GIT_COMMIT"] ?? "unspecified"
-let scVersion = "0.4.1"
+let scVersion = "0.5.0"
 let builderShimVersion = "0.6.0"
 
 let package = Package(

--- a/Sources/CLI/Application.swift
+++ b/Sources/CLI/Application.swift
@@ -182,7 +182,7 @@ struct Application: AsyncParsableCommand {
                 return -1
             }
 
-            try await process.start(io.stdio)
+            try await process.start()
             defer {
                 try? io.close()
             }

--- a/Sources/CLI/Builder/BuilderStart.swift
+++ b/Sources/CLI/Builder/BuilderStart.swift
@@ -245,10 +245,12 @@ extension ClientContainer {
                 detach: true
             )
             defer { try? io.close() }
-            let process = try await bootstrap()
-            _ = try await process.start(io.stdio)
+
+            let process = try await bootstrap(stdio: io.stdio)
+            _ = try await process.start()
             await taskManager?.finish()
             try io.closeAfterStart()
+
             log.debug("starting BuildKit and BuildKit-shim")
         } catch {
             try? await stop()

--- a/Sources/CLI/Container/ContainerExec.swift
+++ b/Sources/CLI/Container/ContainerExec.swift
@@ -81,7 +81,9 @@ extension Application {
 
                 let process = try await container.createProcess(
                     id: UUID().uuidString.lowercased(),
-                    configuration: config)
+                    configuration: config,
+                    stdio: io.stdio
+                )
 
                 exitCode = try await Application.handleProcess(io: io, process: process)
             } catch {

--- a/Sources/CLI/Container/ContainerStart.swift
+++ b/Sources/CLI/Container/ContainerStart.swift
@@ -51,19 +51,19 @@ extension Application {
             progress.start()
 
             let container = try await ClientContainer.get(id: containerID)
-            let process = try await container.bootstrap()
-
-            progress.set(description: "Starting init process")
-            let detach = !self.attach && !self.interactive
             do {
+                let detach = !self.attach && !self.interactive
                 let io = try ProcessIO.create(
                     tty: container.configuration.initProcess.terminal,
                     interactive: self.interactive,
                     detach: detach
                 )
+
+                let process = try await container.bootstrap(stdio: io.stdio)
                 progress.finish()
+
                 if detach {
-                    try await process.start(io.stdio)
+                    try await process.start()
                     defer {
                         try? io.close()
                     }

--- a/Sources/CLI/RunCommand.swift
+++ b/Sources/CLI/RunCommand.swift
@@ -110,15 +110,15 @@ extension Application {
 
             let detach = self.managementFlags.detach
 
-            let process = try await container.bootstrap()
-            progress.finish()
-
             do {
                 let io = try ProcessIO.create(
                     tty: self.processFlags.tty,
                     interactive: self.processFlags.interactive,
                     detach: detach
                 )
+
+                let process = try await container.bootstrap(stdio: io.stdio)
+                progress.finish()
 
                 if !self.managementFlags.cidfile.isEmpty {
                     let path = self.managementFlags.cidfile
@@ -137,7 +137,7 @@ extension Application {
                 }
 
                 if detach {
-                    try await process.start(io.stdio)
+                    try await process.start()
                     defer {
                         try? io.close()
                     }

--- a/Sources/ContainerClient/Core/ClientContainer.swift
+++ b/Sources/ContainerClient/Core/ClientContainer.swift
@@ -144,9 +144,9 @@ extension ClientContainer {
 }
 
 extension ClientContainer {
-    public func bootstrap() async throws -> ClientProcess {
+    public func bootstrap(stdio: [FileHandle?]) async throws -> ClientProcess {
         let client = self.sandboxClient
-        try await client.bootstrap()
+        try await client.bootstrap(stdio: stdio)
         return ClientProcessImpl(containerId: self.id, client: self.sandboxClient)
     }
 
@@ -183,10 +183,14 @@ extension ClientContainer {
 
 extension ClientContainer {
     /// Execute a new process inside a running container.
-    public func createProcess(id: String, configuration: ProcessConfiguration) async throws -> ClientProcess {
+    public func createProcess(
+        id: String,
+        configuration: ProcessConfiguration,
+        stdio: [FileHandle?]
+    ) async throws -> ClientProcess {
         do {
             let client = self.sandboxClient
-            try await client.createProcess(id, config: configuration)
+            try await client.createProcess(id, config: configuration, stdio: stdio)
             return ClientProcessImpl(containerId: self.id, processId: id, client: client)
         } catch {
             throw ContainerizationError(

--- a/Sources/ContainerClient/Core/ClientProcess.swift
+++ b/Sources/ContainerClient/Core/ClientProcess.swift
@@ -32,7 +32,7 @@ public protocol ClientProcess: Sendable {
     var id: String { get }
 
     /// Start the underlying process inside of the container.
-    func start(_ stdio: [FileHandle?]) async throws
+    func start() async throws
     /// Send a terminal resize request to the process `id`.
     func resize(_ size: Terminal.Size) async throws
     /// Send or "kill" a signal to the process `id`.
@@ -66,10 +66,10 @@ struct ClientProcessImpl: ClientProcess, Sendable {
     }
 
     /// Start the container and return the initial process.
-    public func start(_ stdio: [FileHandle?]) async throws {
+    public func start() async throws {
         do {
             let client = self.client
-            try await client.startProcess(self.id, stdio: stdio)
+            try await client.startProcess(self.id)
         } catch {
             throw ContainerizationError(
                 .internalError,


### PR DESCRIPTION
0.5.0 introduces a new way to configure the containers and execs. This is now done all upfront at constructor time in a callback style. I'm very happy with the config improvements, but because IO can only be setup at constructor time this makes it so that we need to supply IO at creation time of the VM or exec, which isn't the end of the world. All that really changes is `boostrap()` and `createProcess()` now take in IO instead of slightly later in `process.start()`