### PR TITLE
Transition to `Mutex`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -262,7 +262,6 @@ let package = Package(
             name: "TerminalProgress",
             dependencies: [
                 .product(name: "ContainerizationOS", package: "containerization"),
-                .product(name: "SendableProperty", package: "containerization"),
             ]
         ),
         .testTarget(

--- a/Sources/TerminalProgress/ProgressBar+Terminal.swift
+++ b/Sources/TerminalProgress/ProgressBar+Terminal.swift
@@ -66,8 +66,10 @@ extension ProgressBar {
         var text = text
 
         // Clears previously printed characters if the new string is shorter.
-        text += String(repeating: " ", count: max(printedWidth - text.count, 0))
-        printedWidth = text.count
+        printedWidth.withLock {
+            text += String(repeating: " ", count: max($0 - text.count, 0))
+            $0 = text.count
+        }
         state.withLock {
             $0.output = text
         }

--- a/Sources/TerminalProgress/ProgressBar.swift
+++ b/Sources/TerminalProgress/ProgressBar.swift
@@ -15,15 +15,13 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import SendableProperty
 import Synchronization
 
 /// A progress bar that updates itself as tasks are completed.
 public final class ProgressBar: Sendable {
     let config: ProgressConfig
     let state: Mutex<State>
-    @SendableProperty
-    var printedWidth = 0
+    let printedWidth = Mutex(0)
     let term: FileHandle?
     let termQueue = DispatchQueue(label: "com.apple.container.ProgressBar")
     private let standardError = StandardError()


### PR DESCRIPTION
Due to the reduced use of the macro, we can now fully transition to `Mutex`.