### PR TITLE
Explain how to install a release build in BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -26,6 +26,7 @@ make install
 Or to install a release build, with better performance than the debug build:
 
 ```bash
+BUILD_CONFIGURATION=release make all test integration
 BUILD_CONFIGURATION=release make install
 ```
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -23,6 +23,12 @@ Copy the binaries to `/usr/local/bin` and `/usr/local/libexec` (requires enterin
 make install
 ```
 
+Or to install a release build, with better performance than the debug build:
+
+```bash
+BUILD_CONFIGURATION=release make install
+```
+
 ## Compile protobufs
 
 `container` uses gRPC to communicate to the builder virtual machine that creates images from `Dockerfile`s, and depends on specific versions of `grpc-swift` and `swift-protobuf`. If you make changes to the gRPC APIs in the [container-builder-shim](https://github.com/apple/container-builder-shim) project, install the tools and re-generate the gRPC code in this project using:


### PR DESCRIPTION
When users run commands with a debug build, they see a warning that debug builds may have worse performance. Add instructions to BUILDING.md so that users who wish to install from source know how to get a release build.

I tested the command locally and ran `container --version` to verify that I got a release build.