### PR TITLE
Fix user arg passthrough for container create

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ integration: init-block
 	@$(SWIFT) test -c $(BUILD_CONFIGURATION) --filter TestCLINetwork
 	@$(SWIFT) test -c $(BUILD_CONFIGURATION) --filter TestCLIRunLifecycle
 	@$(SWIFT) test -c $(BUILD_CONFIGURATION) --filter TestCLIExecCommand
+	@$(SWIFT) test -c $(BUILD_CONFIGURATION) --filter TestCLICreateCommand
 	@$(SWIFT) test -c $(BUILD_CONFIGURATION) --filter TestCLIRunCommand
 	@$(SWIFT) test -c $(BUILD_CONFIGURATION) --filter TestCLIImagesCommand
 	@$(SWIFT) test -c $(BUILD_CONFIGURATION) --filter TestCLIRunBase

--- a/Sources/CLI/Container/ContainerCreate.swift
+++ b/Sources/CLI/Container/ContainerCreate.swift
@@ -29,7 +29,7 @@ extension Application {
         @Argument(help: "Image name")
         var image: String
 
-        @Argument(help: "Container init process arguments")
+        @Argument(parsing: .captureForPassthrough, help: "Container init process arguments")
         var arguments: [String] = []
 
         @OptionGroup

--- a/Tests/CLITests/Subcommands/Containers/TestCLICreate.swift
+++ b/Tests/CLITests/Subcommands/Containers/TestCLICreate.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+class TestCLICreateCommand: CLITest {
+    @Test func testCreateArgsPassthrough() throws {
+        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
+        #expect(throws: Never.self, "expected container create to succeed") {
+            try doCreate(name: name, args: ["echo", "-n", "hello", "world"])
+            try doRemove(name: name)
+        }
+    }
+}


### PR DESCRIPTION
This matches other container commands that rely on user arguments at the end, such as `container run`. Closes #395.