### PR TITLE
Apple Container's implementation of compose functionality using familiar docker-compose YAML syntax.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b75d239759865c54143e43f6c12839f0cb6a7ab70488af986fdf966ede58f78d",
+  "originHash" : "1faa303f286345fb56a3b7b693d4852b971d51dfccbd63ffbb8eb840edffadbc",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -251,6 +251,15 @@
       "state" : {
         "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
         "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "3d6871d5b4a5cd519adf233fbb576e0a2af71c17",
+        "version" : "5.4.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -39,6 +39,7 @@ let package = Package(
         .library(name: "ContainerPlugin", targets: ["ContainerPlugin"]),
         .library(name: "ContainerXPC", targets: ["ContainerXPC"]),
         .library(name: "SocketForwarder", targets: ["SocketForwarder"]),
+        .library(name: "ContainerCompose", targets: ["ContainerCompose"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
@@ -52,6 +53,7 @@ let package = Package(
         .package(url: "https://github.com/orlandos-nl/DNSClient.git", from: "2.4.1"),
         .package(url: "https://github.com/Bouke/DNS.git", from: "1.2.0"),
         .package(url: "https://github.com/apple/containerization.git", exact: Version(stringLiteral: scVersion)),
+        .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
     ],
     targets: [
         .executableTarget(
@@ -69,6 +71,7 @@ let package = Package(
                 "ContainerClient",
                 "ContainerPlugin",
                 "ContainerLog",
+                "ContainerCompose",
             ],
             path: "Sources/CLI"
         ),
@@ -321,6 +324,26 @@ let package = Package(
                 .define("GIT_COMMIT", to: "\"\(gitCommit)\""),
                 .define("RELEASE_VERSION", to: "\"\(releaseVersion)\""),
                 .define("BUILDER_SHIM_VERSION", to: "\"\(builderShimVersion)\""),
+            ]
+        ),
+        .target(
+            name: "ContainerCompose",
+            dependencies: [
+                .product(name: "Yams", package: "Yams"),
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "Containerization", package: "containerization"),
+                .product(name: "ContainerizationOS", package: "containerization"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                "ContainerClient",
+                "TerminalProgress",
+            ]
+        ),
+        .testTarget(
+            name: "ContainerComposeTests",
+            dependencies: [
+                "ContainerCompose",
+                .product(name: "Containerization", package: "containerization"),
+                .product(name: "Logging", package: "swift-log"),
             ]
         ),
     ]

--- a/Sources/CLI/Application.swift
+++ b/Sources/CLI/Application.swift
@@ -265,12 +265,14 @@ struct Application: AsyncParsableCommand {
         guard #available(macOS 26, *) else {
             return [
                 BuilderCommand.self,
+                ComposeCommand.self,
                 SystemCommand.self,
             ]
         }
 
         return [
             BuilderCommand.self,
+            ComposeCommand.self,
             NetworkCommand.self,
             SystemCommand.self,
         ]

--- a/Sources/CLI/Compose/ComposeCommand.swift
+++ b/Sources/CLI/Compose/ComposeCommand.swift
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ContainerClient
+import Foundation
+
+extension Application {
+    struct ComposeCommand: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "compose",
+            abstract: "Manage multi-container applications",
+            subcommands: [
+                ComposeUp.self,
+                ComposeDown.self,
+                ComposePS.self,
+                ComposeStart.self,
+                ComposeStop.self,
+                ComposeRestart.self,
+                ComposeLogs.self,
+                ComposeExec.self,
+                ComposeHealth.self,
+                ComposeValidate.self,
+            ]
+        )
+    }
+}
+
+// MARK: - Shared Options
+
+struct ComposeOptions: ParsableArguments {
+    @Option(name: [.customLong("file"), .customShort("f")], help: "Specify an alternate compose file")
+    var file: String = "docker-compose.yaml"
+    
+    @Option(name: [.customLong("project"), .customShort("p")], help: "Specify an alternate project name")
+    var project: String?
+    
+    @Option(name: .long, help: "Specify a profile to enable")
+    var profile: [String] = []
+    
+    @Option(name: .long, help: "Set an environment variable (can be used multiple times)")
+    var env: [String] = []
+    
+    func getProjectName() -> String {
+        if let project = project {
+            return project
+        }
+        // Use current directory name as default project name
+        let currentPath = FileManager.default.currentDirectoryPath
+        let url = URL(fileURLWithPath: currentPath)
+        return url.lastPathComponent.lowercased().replacingOccurrences(of: " ", with: "")
+    }
+    
+    func getComposeFileURL() -> URL {
+        if file.hasPrefix("/") {
+            return URL(fileURLWithPath: file)
+        } else {
+            let currentPath = FileManager.default.currentDirectoryPath
+            return URL(fileURLWithPath: currentPath).appendingPathComponent(file)
+        }
+    }
+    
+    func setEnvironmentVariables() {
+        for envVar in env {
+            let parts = envVar.split(separator: "=", maxSplits: 1)
+            if parts.count == 2 {
+                setenv(String(parts[0]), String(parts[1]), 1)
+            }
+        }
+    }
+}

--- a/Sources/CLI/Compose/ComposeDown.swift
+++ b/Sources/CLI/Compose/ComposeDown.swift
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ContainerClient
+import ContainerCompose
+import Foundation
+import Logging
+import TerminalProgress
+
+extension Application {
+    struct ComposeDown: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "down",
+            abstract: "Stop and remove containers, networks"
+        )
+        
+        @OptionGroup
+        var composeOptions: ComposeOptions
+        
+        @OptionGroup
+        var global: Flags.Global
+        
+        @Flag(name: .long, help: "Remove named volumes declared in the volumes section")
+        var volumes: Bool = false
+        
+        @Flag(name: .long, help: "Remove containers for services not in the compose file")
+        var removeOrphans: Bool = false
+        
+        func run() async throws {
+            // Set environment variables
+            composeOptions.setEnvironmentVariables()
+            
+            // Parse compose file
+            let parser = ComposeParser(log: log)
+            let composeFile = try parser.parse(from: composeOptions.getComposeFileURL())
+            
+            // Convert to project
+            let converter = ProjectConverter(log: log)
+            let project = try converter.convert(
+                composeFile: composeFile,
+                projectName: composeOptions.getProjectName(),
+                profiles: composeOptions.profile,
+                selectedServices: []
+            )
+            
+            // Create progress handler
+            let progressConfig = try ProgressConfig(
+                description: "Stopping services",
+                showTasks: true,
+                showItems: false
+            )
+            let progress = ProgressBar(config: progressConfig)
+            defer { progress.finish() }
+            progress.start()
+            
+            // Create orchestrator
+            let orchestrator = Orchestrator(log: log)
+            
+            // Stop services
+            try await orchestrator.down(
+                project: project,
+                removeVolumes: volumes,
+                progressHandler: progress.handler
+            )
+            
+            progress.finish()
+            print("Stopped and removed project '\(project.name)'")
+        }
+    }
+}

--- a/Sources/CLI/Compose/ComposeExec.swift
+++ b/Sources/CLI/Compose/ComposeExec.swift
@@ -1,0 +1,99 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ContainerClient
+import ContainerCompose
+import Foundation
+import Logging
+
+extension Application {
+    struct ComposeExec: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "exec",
+            abstract: "Execute a command in a running container"
+        )
+        
+        @OptionGroup
+        var composeOptions: ComposeOptions
+        
+        @OptionGroup
+        var global: Flags.Global
+        
+        @Flag(name: [.customLong("detach"), .customShort("d")], help: "Run command in the background")
+        var detach: Bool = false
+        
+        @Flag(name: [.customLong("interactive"), .customShort("i")], help: "Keep STDIN open even if not attached")
+        var interactive: Bool = false
+        
+        @Flag(name: [.customLong("tty"), .customShort("t")], help: "Allocate a pseudo-TTY")
+        var tty: Bool = false
+        
+        @Option(name: [.customLong("user"), .customShort("u")], help: "Username or UID")
+        var user: String?
+        
+        @Option(name: [.customLong("workdir"), .customShort("w")], help: "Working directory inside the container")
+        var workdir: String?
+        
+        @Option(name: [.customLong("env"), .customShort("e")], help: "Set environment variables")
+        var envVars: [String] = []
+        
+        @Argument(help: "Service to run command in")
+        var service: String
+        
+        @Argument(parsing: .captureForPassthrough, help: "Command to execute")
+        var command: [String] = []
+        
+        func run() async throws {
+            // Set environment variables
+            composeOptions.setEnvironmentVariables()
+            
+            // Parse compose file
+            let parser = ComposeParser(log: log)
+            let composeFile = try parser.parse(from: composeOptions.getComposeFileURL())
+            
+            // Convert to project
+            let converter = ProjectConverter(log: log)
+            let project = try converter.convert(
+                composeFile: composeFile,
+                projectName: composeOptions.getProjectName(),
+                profiles: composeOptions.profile,
+                selectedServices: []
+            )
+            
+            // Create orchestrator
+            let orchestrator = Orchestrator(log: log)
+            
+            // Execute command
+            let exitCode = try await orchestrator.exec(
+                project: project,
+                serviceName: service,
+                command: command,
+                detach: detach,
+                interactive: interactive,
+                tty: tty,
+                user: user,
+                workdir: workdir,
+                environment: envVars
+            )
+            
+            // Exit with the same code as the executed command
+            if exitCode != 0 {
+                throw ExitCode(exitCode)
+            }
+        }
+    }
+}

--- a/Sources/CLI/Compose/ComposeHealth.swift
+++ b/Sources/CLI/Compose/ComposeHealth.swift
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ContainerClient
+import ContainerCompose
+import Foundation
+import Logging
+
+extension Application {
+    /// Check health status of services in a compose project.
+    ///
+    /// This command executes the health checks defined in the compose file
+    /// and reports the current health status of each service.
+    struct ComposeHealth: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "health",
+        abstract: "Check health status of services"
+    )
+    
+    @OptionGroup var composeOptions: ComposeOptions
+    
+    @OptionGroup var global: Flags.Global
+    
+    @Argument(help: "Services to check (omit to check all)")
+    var services: [String] = []
+    
+    @Flag(name: .shortAndLong, help: "Exit with non-zero status if any service is unhealthy")
+    var quiet: Bool = false
+    
+    func run() async throws {
+        let log = Logger(label: "compose.health")
+        
+        // Set environment variables
+        composeOptions.setEnvironmentVariables()
+        
+        // Parse compose file
+        let parser = ComposeParser(log: log)
+        let composeFile = try parser.parse(from: composeOptions.getComposeFileURL())
+        
+        // Convert to project
+        let converter = ProjectConverter(log: log)
+        let project = try converter.convert(
+            composeFile: composeFile,
+            projectName: composeOptions.getProjectName(),
+            profiles: composeOptions.profile
+        )
+        
+        // Create orchestrator
+        let orchestrator = Orchestrator(log: log)
+        
+        // Check health
+        let healthStatus = try await orchestrator.checkHealth(
+            project: project,
+            services: services
+        )
+        
+        if quiet {
+            // In quiet mode, just exit with appropriate code
+            let allHealthy = healthStatus.values.allSatisfy { $0 }
+            throw ExitCode(allHealthy ? 0 : 1)
+        } else {
+            // Display health status
+            if healthStatus.isEmpty {
+                print("No services with health checks found")
+            } else {
+                for (service, isHealthy) in healthStatus.sorted(by: { $0.key < $1.key }) {
+                    let status = isHealthy ? "healthy" : "unhealthy"
+                    let symbol = isHealthy ? "✓" : "✗"
+                    print("\(symbol) \(service): \(status)")
+                }
+                
+                // Exit with error if any unhealthy
+                let allHealthy = healthStatus.values.allSatisfy { $0 }
+                if !allHealthy {
+                    throw ExitCode.failure
+                }
+            }
+        }
+    }
+    }
+}

--- a/Sources/CLI/Compose/ComposeLogs.swift
+++ b/Sources/CLI/Compose/ComposeLogs.swift
@@ -33,7 +33,7 @@ extension Application {
         @OptionGroup
         var global: Flags.Global
         
-        @Flag(name: [.customLong("follow"), .customShort("f")], help: "Follow log output")
+        @Flag(name: .long, help: "Follow log output")
         var follow: Bool = false
         
         @Option(name: .long, help: "Number of lines to show from the end of the logs")

--- a/Sources/CLI/Compose/ComposeLogs.swift
+++ b/Sources/CLI/Compose/ComposeLogs.swift
@@ -1,0 +1,99 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ContainerClient
+import ContainerCompose
+import Foundation
+import Logging
+
+extension Application {
+    struct ComposeLogs: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "logs",
+            abstract: "View output from containers"
+        )
+        
+        @OptionGroup
+        var composeOptions: ComposeOptions
+        
+        @OptionGroup
+        var global: Flags.Global
+        
+        @Flag(name: [.customLong("follow"), .customShort("f")], help: "Follow log output")
+        var follow: Bool = false
+        
+        @Option(name: .long, help: "Number of lines to show from the end of the logs")
+        var tail: Int?
+        
+        @Flag(name: [.customLong("timestamps"), .customShort("t")], help: "Show timestamps")
+        var timestamps: Bool = false
+        
+        @Argument(help: "Services to display logs for")
+        var services: [String] = []
+        
+        func run() async throws {
+            // Set environment variables
+            composeOptions.setEnvironmentVariables()
+            
+            // Parse compose file
+            let parser = ComposeParser(log: log)
+            let composeFile = try parser.parse(from: composeOptions.getComposeFileURL())
+            
+            // Convert to project
+            let converter = ProjectConverter(log: log)
+            let project = try converter.convert(
+                composeFile: composeFile,
+                projectName: composeOptions.getProjectName(),
+                profiles: composeOptions.profile,
+                selectedServices: services
+            )
+            
+            // Create orchestrator
+            let orchestrator = Orchestrator(log: log)
+            
+            // Get logs stream
+            let logStream = try await orchestrator.logs(
+                project: project,
+                services: services,
+                follow: follow,
+                tail: tail,
+                timestamps: timestamps
+            )
+            
+            // Print logs with service names and optional timestamps
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+            
+            for try await entry in logStream {
+                var output = "[\(entry.serviceName)]"
+                
+                if timestamps {
+                    output += " \(dateFormatter.string(from: entry.timestamp))"
+                }
+                
+                output += " \(entry.message)"
+                
+                switch entry.stream {
+                case .stdout:
+                    print(output)
+                case .stderr:
+                    FileHandle.standardError.write(Data((output + "\n").utf8))
+                }
+            }
+        }
+    }
+}

--- a/Sources/CLI/Compose/ComposePS.swift
+++ b/Sources/CLI/Compose/ComposePS.swift
@@ -1,0 +1,89 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ContainerClient
+import ContainerCompose
+import Foundation
+import Logging
+
+extension Application {
+    struct ComposePS: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "ps",
+            abstract: "List containers"
+        )
+        
+        @OptionGroup
+        var composeOptions: ComposeOptions
+        
+        @OptionGroup
+        var global: Flags.Global
+        
+        @Flag(name: [.customLong("all"), .customShort("a")], help: "Show all containers (default shows just running)")
+        var all: Bool = false
+        
+        @Flag(name: [.customLong("quiet"), .customShort("q")], help: "Only display container IDs")
+        var quiet: Bool = false
+        
+        func run() async throws {
+            // Set environment variables
+            composeOptions.setEnvironmentVariables()
+            
+            // Parse compose file
+            let parser = ComposeParser(log: log)
+            let composeFile = try parser.parse(from: composeOptions.getComposeFileURL())
+            
+            // Convert to project
+            let converter = ProjectConverter(log: log)
+            let project = try converter.convert(
+                composeFile: composeFile,
+                projectName: composeOptions.getProjectName(),
+                profiles: composeOptions.profile,
+                selectedServices: []
+            )
+            
+            // Create orchestrator
+            let orchestrator = Orchestrator(log: log)
+            
+            // Get service statuses
+            let statuses = try await orchestrator.ps(project: project)
+            
+            if quiet {
+                // Just print container IDs
+                for status in statuses where !status.containerID.isEmpty {
+                    print(status.containerID)
+                }
+            } else {
+                // Print table
+                var rows: [[String]] = [["NAME", "CONTAINER ID", "IMAGE", "STATUS", "PORTS"]]
+                
+                for status in statuses {
+                    rows.append([
+                        status.name,
+                        status.containerID.isEmpty ? "-" : String(status.containerID.prefix(12)),
+                        status.image,
+                        status.status,
+                        status.ports
+                    ])
+                }
+                
+                let table = TableOutput(rows: rows)
+                print(table.format())
+            }
+        }
+    }
+}

--- a/Sources/CLI/Compose/ComposeRestart.swift
+++ b/Sources/CLI/Compose/ComposeRestart.swift
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ContainerClient
+import ContainerCompose
+import Foundation
+import TerminalProgress
+
+extension Application {
+    struct ComposeRestart: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "restart",
+            abstract: "Restart services"
+        )
+        
+        @OptionGroup
+        var composeOptions: ComposeOptions
+        
+        @OptionGroup
+        var global: Flags.Global
+        
+        @Option(name: [.customLong("timeout"), .customShort("t")], help: "Specify a shutdown timeout in seconds (default: 10)")
+        var timeout: Int = 10
+        
+        @Argument(help: "Services to restart (omit to restart all)")
+        var services: [String] = []
+        
+        func run() async throws {
+            // Set environment variables
+            composeOptions.setEnvironmentVariables()
+            
+            // Parse compose file
+            let parser = ComposeParser(log: log)
+            let composeFile = try parser.parse(from: composeOptions.getComposeFileURL())
+            
+            // Convert to project
+            let converter = ProjectConverter(log: log)
+            let project = try converter.convert(
+                composeFile: composeFile,
+                projectName: composeOptions.getProjectName(),
+                profiles: composeOptions.profile
+            )
+            
+            // Create orchestrator
+            let orchestrator = Orchestrator(log: log)
+            
+            // Create progress bar
+            let progressConfig = try ProgressConfig(
+                description: "Restarting services",
+                showTasks: true
+            )
+            let progress = ProgressBar(config: progressConfig)
+            defer { progress.finish() }
+            progress.start()
+            
+            // Restart services
+            try await orchestrator.restart(
+                project: project,
+                services: services,
+                timeout: timeout,
+                progressHandler: progress.handler
+            )
+            
+            log.info("Services restarted")
+        }
+    }
+}

--- a/Sources/CLI/Compose/ComposeStart.swift
+++ b/Sources/CLI/Compose/ComposeStart.swift
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ContainerClient
+import ContainerCompose
+import Foundation
+import Logging
+import TerminalProgress
+
+extension Application {
+    struct ComposeStart: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "start",
+            abstract: "Start services"
+        )
+        
+        @OptionGroup
+        var composeOptions: ComposeOptions
+        
+        @OptionGroup
+        var global: Flags.Global
+        
+        @Argument(help: "Services to start")
+        var services: [String] = []
+        
+        func run() async throws {
+            // Set environment variables
+            composeOptions.setEnvironmentVariables()
+            
+            // Parse compose file
+            let parser = ComposeParser(log: log)
+            let composeFile = try parser.parse(from: composeOptions.getComposeFileURL())
+            
+            // Convert to project
+            let converter = ProjectConverter(log: log)
+            let project = try converter.convert(
+                composeFile: composeFile,
+                projectName: composeOptions.getProjectName(),
+                profiles: composeOptions.profile,
+                selectedServices: services
+            )
+            
+            // Create progress handler
+            let progressConfig = try ProgressConfig(
+                description: "Starting services",
+                showTasks: true,
+                showItems: false
+            )
+            let progress = ProgressBar(config: progressConfig)
+            defer { progress.finish() }
+            progress.start()
+            
+            // Create orchestrator
+            let orchestrator = Orchestrator(log: log)
+            
+            // Start services
+            try await orchestrator.start(
+                project: project,
+                services: services,
+                progressHandler: progress.handler
+            )
+            
+            progress.finish()
+            print("Started services for project '\(project.name)'")
+        }
+    }
+}

--- a/Sources/CLI/Compose/ComposeStop.swift
+++ b/Sources/CLI/Compose/ComposeStop.swift
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ContainerClient
+import ContainerCompose
+import Foundation
+import Logging
+import TerminalProgress
+
+extension Application {
+    struct ComposeStop: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "stop",
+            abstract: "Stop services"
+        )
+        
+        @OptionGroup
+        var composeOptions: ComposeOptions
+        
+        @OptionGroup
+        var global: Flags.Global
+        
+        @Option(name: [.customLong("time"), .customShort("t")], help: "Specify a shutdown timeout in seconds")
+        var timeout: Int = 10
+        
+        @Argument(help: "Services to stop")
+        var services: [String] = []
+        
+        func run() async throws {
+            // Set environment variables
+            composeOptions.setEnvironmentVariables()
+            
+            // Parse compose file
+            let parser = ComposeParser(log: log)
+            let composeFile = try parser.parse(from: composeOptions.getComposeFileURL())
+            
+            // Convert to project
+            let converter = ProjectConverter(log: log)
+            let project = try converter.convert(
+                composeFile: composeFile,
+                projectName: composeOptions.getProjectName(),
+                profiles: composeOptions.profile,
+                selectedServices: services
+            )
+            
+            // Create progress handler
+            let progressConfig = try ProgressConfig(
+                description: "Stopping services",
+                showTasks: true,
+                showItems: false
+            )
+            let progress = ProgressBar(config: progressConfig)
+            defer { progress.finish() }
+            progress.start()
+            
+            // Create orchestrator
+            let orchestrator = Orchestrator(log: log)
+            
+            // Stop services
+            try await orchestrator.stop(
+                project: project,
+                services: services,
+                timeout: timeout,
+                progressHandler: progress.handler
+            )
+            
+            progress.finish()
+            print("Stopped services for project '\(project.name)'")
+        }
+    }
+}

--- a/Sources/CLI/Compose/ComposeUp.swift
+++ b/Sources/CLI/Compose/ComposeUp.swift
@@ -1,0 +1,102 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ContainerClient
+import ContainerCompose
+import ContainerizationError
+import Foundation
+import TerminalProgress
+
+extension Application {
+    struct ComposeUp: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "up",
+            abstract: "Create and start containers"
+        )
+        
+        @OptionGroup
+        var composeOptions: ComposeOptions
+        
+        @OptionGroup
+        var global: Flags.Global
+        
+        @Flag(name: [.customLong("detach"), .customShort("d")], help: "Run containers in the background")
+        var detach: Bool = false
+        
+        @Flag(name: .long, help: "Remove containers for services not defined in the Compose file")
+        var removeOrphans: Bool = false
+        
+        @Flag(name: .long, help: "Recreate containers even if their configuration hasn't changed")
+        var forceRecreate: Bool = false
+        
+        @Flag(name: .long, help: "Don't recreate containers if they exist")
+        var noRecreate: Bool = false
+        
+        @Flag(name: .long, help: "Don't start services after creating them")
+        var noDeps: Bool = false
+        
+        @Argument(help: "Services to start")
+        var services: [String] = []
+        
+        func run() async throws {
+            // Set environment variables
+            composeOptions.setEnvironmentVariables()
+            
+            // Parse compose file
+            let parser = ComposeParser(log: log)
+            let composeFile = try parser.parse(from: composeOptions.getComposeFileURL())
+            
+            // Convert to project
+            let converter = ProjectConverter(log: log)
+            let project = try converter.convert(
+                composeFile: composeFile,
+                projectName: composeOptions.getProjectName(),
+                profiles: composeOptions.profile,
+                selectedServices: services
+            )
+            
+            // Create progress handler
+            let progressConfig = try ProgressConfig(
+                description: "Starting services",
+                showTasks: true,
+                showItems: false
+            )
+            let progress = ProgressBar(config: progressConfig)
+            defer { progress.finish() }
+            progress.start()
+            
+            // Create orchestrator
+            let orchestrator = Orchestrator(log: log)
+            
+            // Start services
+            try await orchestrator.up(
+                project: project,
+                services: services,
+                detach: detach,
+                forceRecreate: forceRecreate,
+                noRecreate: noRecreate,
+                progressHandler: progress.handler
+            )
+            
+            progress.finish()
+            
+            if detach {
+                print("Started project '\(project.name)' in detached mode")
+            }
+        }
+    }
+}

--- a/Sources/CLI/Compose/ComposeValidate.swift
+++ b/Sources/CLI/Compose/ComposeValidate.swift
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ContainerClient
+import ContainerCompose
+import Foundation
+
+extension Application {
+    struct ComposeValidate: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "validate",
+            abstract: "Validate a compose file"
+        )
+        
+        @OptionGroup
+        var composeOptions: ComposeOptions
+        
+        @OptionGroup
+        var global: Flags.Global
+        
+        @Flag(name: .long, help: "Don't print anything, just validate")
+        var quiet: Bool = false
+        
+        func run() async throws {
+            // Set environment variables
+            composeOptions.setEnvironmentVariables()
+            
+            // Parse compose file
+            let parser = ComposeParser(log: log)
+            let composeFile = try parser.parse(from: composeOptions.getComposeFileURL())
+            
+            if !quiet {
+                print("✓ Compose file is valid")
+                print("  File: \(composeOptions.getComposeFileURL().path)")
+                print("  Version: \(composeFile.version ?? "not specified")")
+                print("  Services: \(composeFile.services.count)")
+                
+                for (name, service) in composeFile.services {
+                    print("    - \(name)")
+                    if let image = service.image {
+                        print("      Image: \(image)")
+                    }
+                    if let profiles = service.profiles, !profiles.isEmpty {
+                        print("      Profiles: \(profiles)")
+                    }
+                }
+                
+                if let networks = composeFile.networks, !networks.isEmpty {
+                    print("  Networks: \(networks.count)")
+                    for (name, _) in networks {
+                        print("    - \(name)")
+                    }
+                }
+                
+                if let volumes = composeFile.volumes, !volumes.isEmpty {
+                    print("  Volumes: \(volumes.count)")
+                    for (name, _) in volumes {
+                        print("    - \(name)")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/ContainerCompose/Models/ComposeFile.swift
+++ b/Sources/ContainerCompose/Models/ComposeFile.swift
@@ -1,0 +1,374 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Yams
+
+// MARK: - Top Level Compose File
+
+public struct ComposeFile: Codable {
+    public let version: String?
+    public let services: [String: ComposeService]
+    public let networks: [String: ComposeNetwork]?
+    public let volumes: [String: ComposeVolume]?
+    
+    public init(version: String? = nil,
+                services: [String: ComposeService] = [:],
+                networks: [String: ComposeNetwork]? = nil,
+                volumes: [String: ComposeVolume]? = nil) {
+        self.version = version
+        self.services = services
+        self.networks = networks
+        self.volumes = volumes
+    }
+}
+
+// MARK: - Service Definition
+
+public struct ComposeService: Codable {
+    public let image: String?
+    public let build: BuildConfig?
+    public let command: StringOrList?
+    public let entrypoint: StringOrList?
+    public let workingDir: String?
+    public let environment: Environment?
+    public let envFile: StringOrList?
+    public let volumes: [String]?
+    public let ports: [String]?
+    public let networks: NetworkConfig?
+    public let dependsOn: DependsOn?
+    public let deploy: DeployConfig?
+    public let memLimit: String?
+    public let cpus: String?
+    public let containerName: String?
+    public let healthcheck: HealthCheckConfig?
+    public let profiles: [String]?
+    public let extends: ExtendsConfig?
+    public let restart: String?
+    public let labels: Labels?
+    
+    enum CodingKeys: String, CodingKey {
+        case image, build, command, entrypoint
+        case workingDir = "working_dir"
+        case environment
+        case envFile = "env_file"
+        case volumes, ports, networks
+        case dependsOn = "depends_on"
+        case deploy
+        case memLimit = "mem_limit"
+        case cpus
+        case containerName = "container_name"
+        case healthcheck, profiles, extends, restart, labels
+    }
+}
+
+// MARK: - Build Configuration
+
+public struct BuildConfig: Codable {
+    public let context: String?
+    public let dockerfile: String?
+    public let args: [String: String]?
+}
+
+// MARK: - Deploy Configuration
+
+public struct DeployConfig: Codable {
+    public let resources: Resources?
+}
+
+public struct Resources: Codable {
+    public let limits: ResourceLimits?
+    public let reservations: ResourceReservations?
+}
+
+public struct ResourceLimits: Codable {
+    public let cpus: String?
+    public let memory: String?
+}
+
+public struct ResourceReservations: Codable {
+    public let cpus: String?
+    public let memory: String?
+}
+
+// MARK: - Health Check Configuration
+
+public struct HealthCheckConfig: Codable {
+    public let test: StringOrList?
+    public let interval: String?
+    public let timeout: String?
+    public let retries: Int?
+    public let startPeriod: String?
+    public let disable: Bool?
+    
+    enum CodingKeys: String, CodingKey {
+        case test, interval, timeout, retries
+        case startPeriod = "start_period"
+        case disable
+    }
+}
+
+// MARK: - Extends Configuration
+
+public struct ExtendsConfig: Codable {
+    public let service: String
+    public let file: String?
+}
+
+// MARK: - Network Configuration
+
+public struct ComposeNetwork: Codable {
+    public let driver: String?
+    public let external: External?
+    public let name: String?
+    
+    public enum External: Codable {
+        case bool(Bool)
+        case config(ExternalConfig)
+        
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if let boolValue = try? container.decode(Bool.self) {
+                self = .bool(boolValue)
+            } else if let config = try? container.decode(ExternalConfig.self) {
+                self = .config(config)
+            } else {
+                throw DecodingError.typeMismatch(External.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected Bool or ExternalConfig"))
+            }
+        }
+        
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case .bool(let value):
+                try container.encode(value)
+            case .config(let config):
+                try container.encode(config)
+            }
+        }
+    }
+    
+    public struct ExternalConfig: Codable {
+        public let name: String?
+    }
+}
+
+// MARK: - Volume Configuration
+
+public struct ComposeVolume: Codable {
+    public let driver: String?
+    public let external: ComposeNetwork.External?
+    public let name: String?
+    
+    public init(driver: String? = nil, external: ComposeNetwork.External? = nil, name: String? = nil) {
+        self.driver = driver
+        self.external = external
+        self.name = name
+    }
+    
+    public init(from decoder: Decoder) throws {
+        // Try to decode as a dictionary first
+        do {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let driver = try container.decodeIfPresent(String.self, forKey: .driver)
+            let external = try container.decodeIfPresent(ComposeNetwork.External.self, forKey: .external)
+            let name = try container.decodeIfPresent(String.self, forKey: .name)
+            self.init(driver: driver, external: external, name: name)
+        } catch {
+            // If decoding as dictionary fails, it might be an empty value
+            // Initialize with all nil values
+            self.init()
+        }
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case driver, external, name
+    }
+}
+
+// MARK: - Helper Types
+
+public enum StringOrList: Codable {
+    case string(String)
+    case list([String])
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let str = try? container.decode(String.self) {
+            self = .string(str)
+        } else if let list = try? container.decode([String].self) {
+            self = .list(list)
+        } else {
+            throw DecodingError.typeMismatch(StringOrList.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected String or [String]"))
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let str):
+            try container.encode(str)
+        case .list(let list):
+            try container.encode(list)
+        }
+    }
+    
+    public var asArray: [String] {
+        switch self {
+        case .string(let str):
+            return [str]
+        case .list(let list):
+            return list
+        }
+    }
+}
+
+public enum Environment: Codable {
+    case list([String])
+    case dict([String: String])
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let list = try? container.decode([String].self) {
+            self = .list(list)
+        } else if let dict = try? container.decode([String: String].self) {
+            self = .dict(dict)
+        } else {
+            throw DecodingError.typeMismatch(Environment.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected [String] or [String: String]"))
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .list(let list):
+            try container.encode(list)
+        case .dict(let dict):
+            try container.encode(dict)
+        }
+    }
+    
+    public var asDictionary: [String: String] {
+        switch self {
+        case .list(let list):
+            var dict: [String: String] = [:]
+            for item in list {
+                let parts = item.split(separator: "=", maxSplits: 1)
+                if parts.count == 2 {
+                    dict[String(parts[0])] = String(parts[1])
+                }
+            }
+            return dict
+        case .dict(let dict):
+            return dict
+        }
+    }
+}
+
+public enum NetworkConfig: Codable {
+    case list([String])
+    case dict([String: NetworkServiceConfig])
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let list = try? container.decode([String].self) {
+            self = .list(list)
+        } else if let dict = try? container.decode([String: NetworkServiceConfig].self) {
+            self = .dict(dict)
+        } else {
+            throw DecodingError.typeMismatch(NetworkConfig.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected [String] or network configuration"))
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .list(let list):
+            try container.encode(list)
+        case .dict(let dict):
+            try container.encode(dict)
+        }
+    }
+}
+
+public struct NetworkServiceConfig: Codable {
+    public let aliases: [String]?
+}
+
+public enum DependsOn: Codable {
+    case list([String])
+    case dict([String: DependsOnConfig])
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let list = try? container.decode([String].self) {
+            self = .list(list)
+        } else if let dict = try? container.decode([String: DependsOnConfig].self) {
+            self = .dict(dict)
+        } else {
+            throw DecodingError.typeMismatch(DependsOn.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected [String] or depends_on configuration"))
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .list(let list):
+            try container.encode(list)
+        case .dict(let dict):
+            try container.encode(dict)
+        }
+    }
+    
+    public var asList: [String] {
+        switch self {
+        case .list(let list):
+            return list
+        case .dict(let dict):
+            return Array(dict.keys)
+        }
+    }
+}
+
+public struct DependsOnConfig: Codable {
+    public let condition: String?
+}
+
+public enum Labels: Codable {
+    case list([String])
+    case dict([String: String])
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let list = try? container.decode([String].self) {
+            self = .list(list)
+        } else if let dict = try? container.decode([String: String].self) {
+            self = .dict(dict)
+        } else {
+            throw DecodingError.typeMismatch(Labels.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected [String] or [String: String]"))
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .list(let list):
+            try container.encode(list)
+        case .dict(let dict):
+            try container.encode(dict)
+        }
+    }
+}

--- a/Sources/ContainerCompose/Models/Project.swift
+++ b/Sources/ContainerCompose/Models/Project.swift
@@ -1,0 +1,286 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Represents a parsed and normalized compose project
+public struct Project: Sendable {
+    public let name: String
+    public let services: [String: Service]
+    public let networks: [String: Network]
+    public let volumes: [String: Volume]
+    
+    public init(name: String,
+                services: [String: Service] = [:],
+                networks: [String: Network] = [:],
+                volumes: [String: Volume] = [:]) {
+        self.name = name
+        self.services = services
+        self.networks = networks
+        self.volumes = volumes
+    }
+}
+
+/// Represents a service in the project
+public struct Service: Sendable {
+    public let name: String
+    public let image: String?
+    public let command: [String]?
+    public let entrypoint: [String]?
+    public let workingDir: String?
+    public let environment: [String: String]
+    public let ports: [PortMapping]
+    public let volumes: [VolumeMount]
+    public let networks: [String]
+    public let dependsOn: [String]
+    public let healthCheck: HealthCheck?
+    public let deploy: Deploy?
+    public let restart: String?
+    public let containerName: String?
+    public let profiles: [String]
+    public let labels: [String: String]
+    
+    // Resource constraints
+    public let cpus: String?
+    public let memory: String?
+    
+    public init(name: String,
+                image: String? = nil,
+                command: [String]? = nil,
+                entrypoint: [String]? = nil,
+                workingDir: String? = nil,
+                environment: [String: String] = [:],
+                ports: [PortMapping] = [],
+                volumes: [VolumeMount] = [],
+                networks: [String] = [],
+                dependsOn: [String] = [],
+                healthCheck: HealthCheck? = nil,
+                deploy: Deploy? = nil,
+                restart: String? = nil,
+                containerName: String? = nil,
+                profiles: [String] = [],
+                labels: [String: String] = [:],
+                cpus: String? = nil,
+                memory: String? = nil) {
+        self.name = name
+        self.image = image
+        self.command = command
+        self.entrypoint = entrypoint
+        self.workingDir = workingDir
+        self.environment = environment
+        self.ports = ports
+        self.volumes = volumes
+        self.networks = networks
+        self.dependsOn = dependsOn
+        self.healthCheck = healthCheck
+        self.deploy = deploy
+        self.restart = restart
+        self.containerName = containerName
+        self.profiles = profiles
+        self.labels = labels
+        self.cpus = cpus
+        self.memory = memory
+    }
+}
+
+/// Port mapping configuration
+public struct PortMapping: Sendable {
+    public let hostIP: String?
+    public let hostPort: String
+    public let containerPort: String
+    public let portProtocol: String
+    
+    public init(hostIP: String? = nil, hostPort: String, containerPort: String, portProtocol: String = "tcp") {
+        self.hostIP = hostIP
+        self.hostPort = hostPort
+        self.containerPort = containerPort
+        self.portProtocol = portProtocol
+    }
+    
+    /// Parse from docker-compose port format
+    public init?(from portString: String) {
+        let components = portString.split(separator: ":")
+        guard components.count >= 2 else { return nil }
+        
+        // Check for protocol suffix
+        var lastComponent = String(components.last!)
+        var parsedProtocol = "tcp"
+        
+        if lastComponent.contains("/") {
+            let protocolParts = lastComponent.split(separator: "/")
+            if protocolParts.count == 2 {
+                lastComponent = String(protocolParts[0])
+                parsedProtocol = String(protocolParts[1])
+            }
+        }
+        
+        switch components.count {
+        case 2:
+            // "hostPort:containerPort"
+            self.hostIP = nil
+            self.hostPort = String(components[0])
+            self.containerPort = lastComponent
+            self.portProtocol = parsedProtocol
+            
+        case 3:
+            // "hostIP:hostPort:containerPort"
+            self.hostIP = String(components[0])
+            self.hostPort = String(components[1])
+            self.containerPort = lastComponent
+            self.portProtocol = parsedProtocol
+            
+        default:
+            return nil
+        }
+    }
+}
+
+/// Volume mount configuration
+public struct VolumeMount: Sendable {
+    public let source: String
+    public let target: String
+    public let readOnly: Bool
+    public let type: VolumeType
+    
+    public enum VolumeType: Sendable {
+        case bind
+        case volume
+        case tmpfs
+    }
+    
+    public init(source: String, target: String, readOnly: Bool = false, type: VolumeType = .bind) {
+        self.source = source
+        self.target = target
+        self.readOnly = readOnly
+        self.type = type
+    }
+    
+    /// Parse from docker-compose volume format
+    public init?(from volumeString: String) {
+        let components = volumeString.split(separator: ":", maxSplits: 2)
+        guard components.count >= 2 else { return nil }
+        
+        let source = String(components[0])
+        let target = String(components[1])
+        
+        // Check for read-only flag
+        var isReadOnly = false
+        if components.count == 3 {
+            let options = String(components[2])
+            isReadOnly = options.contains("ro")
+        }
+        
+        // Determine volume type
+        let volumeType: VolumeType
+        if source.hasPrefix(":tmpfs:") {
+            volumeType = .tmpfs
+            self.source = ""
+            self.target = target
+            self.readOnly = isReadOnly
+            self.type = volumeType
+        } else if source.hasPrefix("/") || source.hasPrefix("./") || source.hasPrefix("../") {
+            volumeType = .bind
+            self.source = source
+            self.target = target
+            self.readOnly = isReadOnly
+            self.type = volumeType
+        } else {
+            volumeType = .volume
+            self.source = source
+            self.target = target
+            self.readOnly = isReadOnly
+            self.type = volumeType
+        }
+    }
+}
+
+/// Health check configuration
+public struct HealthCheck: Sendable {
+    public let test: [String]
+    public let interval: TimeInterval?
+    public let timeout: TimeInterval?
+    public let retries: Int?
+    public let startPeriod: TimeInterval?
+    
+    public init(test: [String],
+                interval: TimeInterval? = nil,
+                timeout: TimeInterval? = nil,
+                retries: Int? = nil,
+                startPeriod: TimeInterval? = nil) {
+        self.test = test
+        self.interval = interval
+        self.timeout = timeout
+        self.retries = retries
+        self.startPeriod = startPeriod
+    }
+}
+
+/// Deployment configuration
+public struct Deploy: Sendable {
+    public let resources: ServiceResources?
+    
+    public init(resources: ServiceResources? = nil) {
+        self.resources = resources
+    }
+}
+
+/// Resource constraints
+public struct ServiceResources: Sendable {
+    public let limits: ServiceResourceConfig?
+    public let reservations: ServiceResourceConfig?
+    
+    public init(limits: ServiceResourceConfig? = nil, reservations: ServiceResourceConfig? = nil) {
+        self.limits = limits
+        self.reservations = reservations
+    }
+}
+
+/// CPU and memory configuration
+public struct ServiceResourceConfig: Sendable {
+    public let cpus: String?
+    public let memory: String?
+    
+    public init(cpus: String? = nil, memory: String? = nil) {
+        self.cpus = cpus
+        self.memory = memory
+    }
+}
+
+/// Network configuration
+public struct Network: Sendable {
+    public let name: String
+    public let driver: String
+    public let external: Bool
+    
+    public init(name: String, driver: String = "bridge", external: Bool = false) {
+        self.name = name
+        self.driver = driver
+        self.external = external
+    }
+}
+
+/// Volume configuration
+public struct Volume: Sendable {
+    public let name: String
+    public let driver: String
+    public let external: Bool
+    
+    public init(name: String, driver: String = "local", external: Bool = false) {
+        self.name = name
+        self.driver = driver
+        self.external = external
+    }
+}

--- a/Sources/ContainerCompose/Orchestrator/DependencyResolver.swift
+++ b/Sources/ContainerCompose/Orchestrator/DependencyResolver.swift
@@ -1,0 +1,202 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import ContainerizationError
+
+/// Resolves service dependencies using topological sorting.
+///
+/// The DependencyResolver analyzes service dependencies and determines:
+/// - The order in which services should be started
+/// - The order in which services should be stopped (reverse of start order)
+/// - Which services can be started in parallel
+/// - Detection of circular dependencies
+///
+/// This ensures that dependent services are always started after their
+/// dependencies and stopped before them.
+public struct DependencyResolver {
+    
+    /// Result of dependency resolution
+    public struct ResolutionResult {
+        /// Services in the order they should be started
+        public let startOrder: [String]
+        
+        /// Services in the order they should be stopped (reverse of start)
+        public var stopOrder: [String] {
+            return startOrder.reversed()
+        }
+        
+        /// Groups of services that can be started in parallel
+        public let parallelGroups: [[String]]
+    }
+    
+    /// Resolve dependencies for the given services.
+    ///
+    /// Uses Kahn's algorithm for topological sorting to determine the order
+    /// in which services should be started, ensuring all dependencies are
+    /// satisfied.
+    ///
+    /// - Parameter services: Dictionary of service name to service definition
+    /// - Returns: Resolution result containing start order and parallel groups
+    /// - Throws: `ContainerizationError` if circular dependencies are detected or unknown services are referenced
+    public static func resolve(services: [String: Service]) throws -> ResolutionResult {
+        // Build adjacency list and in-degree map
+        var graph: [String: Set<String>] = [:]
+        var inDegree: [String: Int] = [:]
+        
+        // Initialize
+        for name in services.keys {
+            graph[name] = Set()
+            inDegree[name] = 0
+        }
+        
+        // Build dependency graph
+        for (name, service) in services {
+            for dependency in service.dependsOn {
+                // Validate dependency exists
+                guard services[dependency] != nil else {
+                    throw ContainerizationError(
+                        .notFound,
+                        message: "Service '\(name)' depends on unknown service '\(dependency)'"
+                    )
+                }
+                
+                // Add edge from dependency to dependent
+                graph[dependency]!.insert(name)
+                inDegree[name]! += 1
+            }
+        }
+        
+        // Detect cycles using DFS
+        try detectCycles(services: services)
+        
+        // Perform topological sort with level grouping
+        var queue: [String] = []
+        var result: [String] = []
+        var parallelGroups: [[String]] = []
+        
+        // Find all nodes with no dependencies
+        for (name, degree) in inDegree where degree == 0 {
+            queue.append(name)
+        }
+        
+        // Process level by level
+        while !queue.isEmpty {
+            let currentLevel = queue
+            queue = []
+            
+            parallelGroups.append(currentLevel.sorted())
+            
+            for node in currentLevel {
+                result.append(node)
+                
+                // Reduce in-degree for all dependents
+                for dependent in graph[node]! {
+                    inDegree[dependent]! -= 1
+                    if inDegree[dependent]! == 0 {
+                        queue.append(dependent)
+                    }
+                }
+            }
+        }
+        
+        // Verify all nodes were processed
+        if result.count != services.count {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "Circular dependency detected in service dependencies"
+            )
+        }
+        
+        return ResolutionResult(
+            startOrder: result,
+            parallelGroups: parallelGroups
+        )
+    }
+    
+    /// Detect cycles in the dependency graph using DFS
+    private static func detectCycles(services: [String: Service]) throws {
+        var visited = Set<String>()
+        var recursionStack = Set<String>()
+        
+        func hasCycle(service: String, path: [String]) throws {
+            if recursionStack.contains(service) {
+                let cycleStart = path.firstIndex(of: service) ?? 0
+                let cycle = path[cycleStart...] + [service]
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "Circular dependency detected: \(cycle.joined(separator: " → "))"
+                )
+            }
+            
+            if visited.contains(service) {
+                return
+            }
+            
+            visited.insert(service)
+            recursionStack.insert(service)
+            
+            if let serviceConfig = services[service] {
+                for dependency in serviceConfig.dependsOn {
+                    try hasCycle(service: dependency, path: path + [service])
+                }
+            }
+            
+            recursionStack.remove(service)
+        }
+        
+        for serviceName in services.keys {
+            if !visited.contains(serviceName) {
+                try hasCycle(service: serviceName, path: [])
+            }
+        }
+    }
+    
+    /// Filter services based on selected services and their dependencies
+    public static func filterWithDependencies(
+        services: [String: Service],
+        selected: [String]
+    ) -> [String: Service] {
+        if selected.isEmpty {
+            return services
+        }
+        
+        var result: [String: Service] = [:]
+        var toProcess = Set(selected)
+        var processed = Set<String>()
+        
+        while !toProcess.isEmpty {
+            let current = toProcess.removeFirst()
+            if processed.contains(current) {
+                continue
+            }
+            processed.insert(current)
+            
+            guard let service = services[current] else {
+                continue
+            }
+            
+            result[current] = service
+            
+            // Add dependencies
+            for dep in service.dependsOn {
+                toProcess.insert(dep)
+            }
+        }
+        
+        return result
+    }
+}

--- a/Sources/ContainerCompose/Orchestrator/Orchestrator.swift
+++ b/Sources/ContainerCompose/Orchestrator/Orchestrator.swift
@@ -1,0 +1,1117 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import ContainerClient
+import Containerization
+import ContainerizationError
+import ContainerizationOS
+import Logging
+import TerminalProgress
+#if os(macOS)
+import Darwin
+#else
+import Glibc
+#endif
+import ContainerizationOCI
+
+/// Manages the lifecycle of services in a compose project.
+///
+/// The Orchestrator is responsible for:
+/// - Starting and stopping services in dependency order
+/// - Managing container lifecycle (create, start, stop, remove)
+/// - Tracking container state within a project
+/// - Handling service logs and command execution
+///
+/// All operations are thread-safe through the actor model.
+public actor Orchestrator {
+    private let log: Logger
+    private var projectState: [String: ProjectState] = [:]
+    
+    /// State of a project
+    private struct ProjectState {
+        var containers: [String: ContainerState] = [:]
+    }
+    
+    /// State of a container in a project
+    private struct ContainerState {
+        let serviceName: String
+        let containerID: String
+        let containerName: String
+        var status: ContainerStatus
+    }
+    
+    /// Container status
+    private enum ContainerStatus {
+        case created
+        case running
+        case stopped
+        case removed
+        case healthy
+        case unhealthy
+        case starting  // health: starting - not yet healthy
+    }
+    
+    public init(log: Logger) {
+        self.log = log
+    }
+    
+    /// Start services in a project.
+    ///
+    /// Services are started in dependency order, with independent services
+    /// starting in parallel. Existing containers may be reused or recreated
+    /// based on the provided options.
+    ///
+    /// - Parameters:
+    ///   - project: The project containing service definitions
+    ///   - services: Specific services to start (empty means all)
+    ///   - detach: Whether to run containers in the background
+    ///   - forceRecreate: Force recreation of existing containers
+    ///   - noRecreate: Never recreate existing containers
+    ///   - progressHandler: Optional handler for progress updates
+    /// - Throws: `ContainerizationError` if service configuration is invalid or container operations fail
+    public func up(
+        project: Project,
+        services: [String] = [],
+        detach: Bool = false,
+        forceRecreate: Bool = false,
+        noRecreate: Bool = false,
+        progressHandler: ProgressUpdateHandler? = nil
+    ) async throws {
+        log.info("Starting project '\(project.name)'")
+        
+        // Filter services if specific ones requested
+        let targetServices = services.isEmpty ? project.services : 
+            DependencyResolver.filterWithDependencies(services: project.services, selected: services)
+        
+        // Resolve dependencies
+        let resolution = try DependencyResolver.resolve(services: targetServices)
+        log.debug("Service start order: \(resolution.startOrder.joined(separator: ", "))")
+        
+        // Initialize project state
+        if projectState[project.name] == nil {
+            projectState[project.name] = ProjectState()
+        }
+        
+        // Start services in dependency order
+        let totalSteps = resolution.startOrder.count * 2 // Create + start for each
+        var currentStep = 0
+        
+        for group in resolution.parallelGroups {
+            // Start services in parallel within each group
+            try await withThrowingTaskGroup(of: Void.self) { taskGroup in
+                for serviceName in group {
+                    guard let service = targetServices[serviceName] else { continue }
+                    
+                    let capturedProject = project
+                    let capturedService = service
+                    let capturedForceRecreate = forceRecreate
+                    let capturedNoRecreate = noRecreate
+                    let capturedDetach = detach
+                    let capturedProgressHandler = progressHandler
+                    
+                    taskGroup.addTask { [weak self] in
+                        guard let self else { return }
+                        try await self.startService(
+                            project: capturedProject,
+                            service: capturedService,
+                            forceRecreate: capturedForceRecreate,
+                            noRecreate: capturedNoRecreate,
+                            detach: capturedDetach,
+                            progressHandler: capturedProgressHandler
+                        )
+                    }
+                }
+                
+                // Wait for all services in the group to start
+                try await taskGroup.waitForAll()
+                currentStep += group.count * 2
+                
+                await progressHandler?([
+                    .setTasks(currentStep),
+                    .setTotalTasks(totalSteps)
+                ])
+            }
+        }
+        
+        log.info("Project '\(project.name)' started successfully")
+    }
+    
+    /// Stop and remove services in a project.
+    ///
+    /// Services are stopped in reverse dependency order to ensure dependent
+    /// services are stopped before their dependencies. All containers are
+    /// removed after being stopped.
+    ///
+    /// - Parameters:
+    ///   - project: The project containing service definitions
+    ///   - removeVolumes: Whether to remove associated volumes (not implemented)
+    ///   - progressHandler: Optional handler for progress updates
+    /// - Throws: `ContainerizationError` if container operations fail
+    public func down(
+        project: Project,
+        removeVolumes: Bool = false,
+        progressHandler: ProgressUpdateHandler? = nil
+    ) async throws {
+        log.info("Stopping project '\(project.name)'")
+        
+        guard let state = projectState[project.name] else {
+            log.info("Project '\(project.name)' has no running containers")
+            return
+        }
+        
+        // Get services in reverse dependency order
+        let resolution = try DependencyResolver.resolve(services: project.services)
+        let stopOrder = resolution.stopOrder
+        
+        let totalSteps = state.containers.count
+        var currentStep = 0
+        
+        // Stop containers in reverse order
+        for serviceName in stopOrder {
+            if let containerState = state.containers[serviceName] {
+                try await stopAndRemoveContainer(
+                    containerID: containerState.containerID,
+                    containerName: containerState.containerName
+                )
+                
+                currentStep += 1
+                await progressHandler?([
+                    .setTasks(currentStep),
+                    .setTotalTasks(totalSteps)
+                ])
+            }
+        }
+        
+        // Clear project state
+        projectState[project.name] = nil
+        
+        log.info("Project '\(project.name)' stopped and removed")
+    }
+    
+    /// List containers in a project.
+    ///
+    /// Returns the current status of all services defined in the project,
+    /// including services that have no running containers.
+    ///
+    /// - Parameter project: The project to query
+    /// - Returns: Array of service status information
+    /// - Throws: `ContainerizationError` if unable to query containers
+    public func ps(project: Project) async throws -> [ServiceStatus] {
+        var statuses: [ServiceStatus] = []
+        
+        // Get all containers
+        let containers = try await ClientContainer.list()
+        
+        for (serviceName, service) in project.services {
+            let containerName = service.containerName ?? "\(project.name)_\(serviceName)"
+            
+            if let container = containers.first(where: { $0.id == containerName }) {
+                var statusText = container.status.rawValue
+                
+                // Check for health status if health check is defined
+                if service.healthCheck != nil {
+                    if let state = projectState[project.name],
+                       let containerState = state.containers[serviceName] {
+                        switch containerState.status {
+                        case .healthy:
+                            statusText = "\(statusText) (healthy)"
+                        case .unhealthy:
+                            statusText = "\(statusText) (unhealthy)"
+                        case .starting:
+                            statusText = "\(statusText) (health: starting)"
+                        default:
+                            break
+                        }
+                    } else if container.status == RuntimeStatus.running {
+                        // If running but no health state, execute a check
+                        let isHealthy = await executeHealthCheck(
+                            container: container,
+                            healthCheck: service.healthCheck!
+                        )
+                        statusText = "\(statusText) (\(isHealthy ? "healthy" : "unhealthy"))"
+                    }
+                }
+                
+                statuses.append(ServiceStatus(
+                    name: serviceName,
+                    containerID: container.id,
+                    containerName: containerName,
+                    status: statusText,
+                    ports: formatPorts(service.ports),
+                    image: service.image ?? "unknown"
+                ))
+            } else {
+                // Service defined but no container
+                statuses.append(ServiceStatus(
+                    name: serviceName,
+                    containerID: "",
+                    containerName: containerName,
+                    status: "not created",
+                    ports: "",
+                    image: service.image ?? "unknown"
+                ))
+            }
+        }
+        
+        return statuses
+    }
+    
+    /// Start stopped services in a project
+    public func start(
+        project: Project,
+        services: [String] = [],
+        progressHandler: ProgressUpdateHandler? = nil
+    ) async throws {
+        log.info("Starting services in project '\(project.name)'")
+        
+        // Filter services if specific ones requested
+        let targetServices = services.isEmpty ? project.services : 
+            DependencyResolver.filterWithDependencies(services: project.services, selected: services)
+        
+        // Resolve dependencies
+        let resolution = try DependencyResolver.resolve(services: targetServices)
+        log.debug("Service start order: \(resolution.startOrder.joined(separator: ", "))")
+        
+        // Get existing containers
+        let containers = try await ClientContainer.list()
+        
+        var totalSteps = 0
+        var toStart: [(String, Service, ClientContainer)] = []
+        
+        // Find containers that need starting
+        for serviceName in resolution.startOrder {
+            guard let service = targetServices[serviceName] else { continue }
+            let containerName = service.containerName ?? "\(project.name)_\(serviceName)"
+            
+            if let container = containers.first(where: { $0.id == containerName }) {
+                if container.status != RuntimeStatus.running {
+                    toStart.append((serviceName, service, container))
+                    totalSteps += 1
+                }
+            }
+        }
+        
+        if toStart.isEmpty {
+            log.info("All services are already running")
+            return
+        }
+        
+        var currentStep = 0
+        
+        // Start containers in dependency order
+        for (serviceName, _, container) in toStart {
+            await progressHandler?([
+                .setDescription("Starting service '\(serviceName)'")
+            ])
+            
+            let process = try await container.bootstrap()
+            
+            // Start in detached mode
+            try await process.start([nil, nil, nil])
+            
+            currentStep += 1
+            await progressHandler?([
+                .setTasks(currentStep),
+                .setTotalTasks(totalSteps)
+            ])
+        }
+        
+        log.info("Started \(toStart.count) service(s)")
+    }
+    
+    /// Stop running services in a project
+    public func stop(
+        project: Project,
+        services: [String] = [],
+        timeout: Int = 10,
+        progressHandler: ProgressUpdateHandler? = nil
+    ) async throws {
+        log.info("Stopping services in project '\(project.name)'")
+        
+        // Filter services if specific ones requested
+        let targetServices = services.isEmpty ? project.services :
+            DependencyResolver.filterWithDependencies(services: project.services, selected: services)
+        
+        // Resolve dependencies
+        let resolution = try DependencyResolver.resolve(services: targetServices)
+        let stopOrder = resolution.stopOrder
+        
+        // Get existing containers
+        let containers = try await ClientContainer.list()
+        
+        var totalSteps = 0
+        var toStop: [(String, Service, ClientContainer)] = []
+        
+        // Find containers that need stopping
+        for serviceName in stopOrder {
+            guard let service = targetServices[serviceName] else { continue }
+            let containerName = service.containerName ?? "\(project.name)_\(serviceName)"
+            
+            if let container = containers.first(where: { $0.id == containerName }) {
+                if container.status == RuntimeStatus.running {
+                    toStop.append((serviceName, service, container))
+                    totalSteps += 1
+                }
+            }
+        }
+        
+        if toStop.isEmpty {
+            log.info("No services are running")
+            return
+        }
+        
+        var currentStep = 0
+        
+        // Stop containers in reverse dependency order
+        for (serviceName, _, container) in toStop {
+            await progressHandler?([
+                .setDescription("Stopping service '\(serviceName)'")
+            ])
+            
+            let stopOptions = ContainerStopOptions(
+                timeoutInSeconds: Int32(timeout),
+                signal: SIGTERM
+            )
+            try await container.stop(opts: stopOptions)
+            
+            currentStep += 1
+            await progressHandler?([
+                .setTasks(currentStep),
+                .setTotalTasks(totalSteps)
+            ])
+        }
+        
+        log.info("Stopped \(toStop.count) service(s)")
+    }
+    
+    /// Restart services in a project
+    public func restart(
+        project: Project,
+        services: [String] = [],
+        timeout: Int = 10,
+        progressHandler: ProgressUpdateHandler? = nil
+    ) async throws {
+        log.info("Restarting services in project '\(project.name)'")
+        
+        // Stop services first
+        try await stop(
+            project: project,
+            services: services,
+            timeout: timeout,
+            progressHandler: progressHandler
+        )
+        
+        // Small delay between stop and start
+        try await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
+        
+        // Start services
+        try await start(
+            project: project,
+            services: services,
+            progressHandler: progressHandler
+        )
+        
+        log.info("Restarted services for project '\(project.name)'")
+    }
+    
+    /// Get logs from services
+    public func logs(
+        project: Project,
+        services: [String] = [],
+        follow: Bool = false,
+        tail: Int? = nil,
+        timestamps: Bool = false
+    ) async throws -> AsyncThrowingStream<LogEntry, Error> {
+        // Filter services if specific ones requested
+        let targetServices = services.isEmpty ? Array(project.services.keys) : services
+        
+        // Find containers for requested services
+        let containers = try await ClientContainer.list()
+        var serviceContainers: [(String, ClientContainer)] = []
+        
+        for serviceName in targetServices {
+            guard let service = project.services[serviceName] else {
+                log.warning("Service '\(serviceName)' not found in project")
+                continue
+            }
+            
+            let containerName = service.containerName ?? "\(project.name)_\(serviceName)"
+            
+            if let container = containers.first(where: { $0.id == containerName }) {
+                serviceContainers.append((serviceName, container))
+            } else {
+                log.warning("Container for service '\(serviceName)' not found")
+            }
+        }
+        
+        if serviceContainers.isEmpty {
+            throw ContainerizationError(
+                .notFound,
+                message: "No containers found for requested services"
+            )
+        }
+        
+        // Return multiplexed log stream
+        return AsyncThrowingStream { continuation in
+            Task {
+                await withTaskGroup(of: Void.self) { group in
+                    for (serviceName, container) in serviceContainers {
+                        group.addTask { [weak self] in
+                            do {
+                                // Get log file handles using existing container logs API
+                                let logHandles = try await container.logs()
+                                let stdoutHandle = logHandles[0]  // stdout
+                                
+                                if let numLines = tail {
+                                    // Read last N lines if tail is specified
+                                    var buffer = Data()
+                                    let size = try stdoutHandle.seekToEnd()
+                                    var offset = size
+                                    var lines: [String] = []
+                                    
+                                    while offset > 0, lines.count < numLines {
+                                        let readSize = min(1024, offset)
+                                        offset -= readSize
+                                        try stdoutHandle.seek(toOffset: offset)
+                                        
+                                        let data = stdoutHandle.readData(ofLength: Int(readSize))
+                                        buffer.insert(contentsOf: data, at: 0)
+                                        
+                                        if let chunk = String(data: buffer, encoding: .utf8) {
+                                            lines = chunk.components(separatedBy: .newlines)
+                                            lines = lines.filter { !$0.isEmpty }
+                                        }
+                                    }
+                                    
+                                    lines = Array(lines.suffix(numLines))
+                                    for line in lines {
+                                        let entry = LogEntry(
+                                            serviceName: serviceName,
+                                            timestamp: Date(),
+                                            message: line,
+                                            stream: .stdout
+                                        )
+                                        continuation.yield(entry)
+                                    }
+                                } else {
+                                    // Read all logs
+                                    if let data = try stdoutHandle.readToEnd(),
+                                       let str = String(data: data, encoding: .utf8) {
+                                        let lines = str.components(separatedBy: .newlines)
+                                        for line in lines where !line.isEmpty {
+                                            let entry = LogEntry(
+                                                serviceName: serviceName,
+                                                timestamp: Date(),
+                                                message: line,
+                                                stream: .stdout
+                                            )
+                                            continuation.yield(entry)
+                                        }
+                                    }
+                                }
+                                
+                                if follow {
+                                    // Set up following using readabilityHandler like ContainerLogs
+                                    _ = try stdoutHandle.seekToEnd()
+                                    stdoutHandle.readabilityHandler = { handle in
+                                        let data = handle.availableData
+                                        if data.isEmpty {
+                                            // Container might have restarted
+                                            do {
+                                                _ = try stdoutHandle.seekToEnd()
+                                            } catch {
+                                                stdoutHandle.readabilityHandler = nil
+                                                return
+                                            }
+                                        }
+                                        if let str = String(data: data, encoding: .utf8), !str.isEmpty {
+                                            let lines = str.components(separatedBy: .newlines)
+                                            for line in lines where !line.isEmpty {
+                                                let entry = LogEntry(
+                                                    serviceName: serviceName,
+                                                    timestamp: Date(),
+                                                    message: line,
+                                                    stream: .stdout
+                                                )
+                                                continuation.yield(entry)
+                                            }
+                                        }
+                                    }
+                                }
+                            } catch {
+                                self?.log.error("Failed to get logs for service '\(serviceName)': \(error)")
+                            }
+                        }
+                    }
+                    
+                    // Wait for all log tasks
+                    await group.waitForAll()
+                }
+                
+                if !follow {
+                    continuation.finish()
+                }
+            }
+        }
+    }
+    
+    /// Execute a command in a running service container
+    public func exec(
+        project: Project,
+        serviceName: String,
+        command: [String],
+        detach: Bool = false,
+        interactive: Bool = false,
+        tty: Bool = false,
+        user: String? = nil,
+        workdir: String? = nil,
+        environment: [String] = []
+    ) async throws -> Int32 {
+        guard let service = project.services[serviceName] else {
+            throw ContainerizationError(
+                .notFound,
+                message: "Service '\(serviceName)' not found in project"
+            )
+        }
+        
+        let containerName = service.containerName ?? "\(project.name)_\(serviceName)"
+        
+        // Find container
+        let containers = try await ClientContainer.list()
+        guard let container = containers.first(where: { $0.id == containerName }) else {
+            throw ContainerizationError(
+                .notFound,
+                message: "Container for service '\(serviceName)' not found"
+            )
+        }
+        
+        // Check if container is running
+        if container.status != RuntimeStatus.running {
+            throw ContainerizationError(
+                .invalidState,
+                message: "Container for service '\(serviceName)' is not running"
+            )
+        }
+        
+        // Get container instance
+        let containerInstance = try await ClientContainer.get(id: container.id)
+        
+        // Create process configuration for exec
+        let executable = command.first ?? "/bin/sh"
+        let arguments = command.count > 1 ? Array(command.dropFirst()) : []
+        
+        var procConfig = ProcessConfiguration(
+            executable: executable,
+            arguments: arguments,
+            environment: environment,
+            workingDirectory: workdir ?? "/",
+            terminal: tty
+        )
+        
+        // Set user if specified
+        if let user = user {
+            procConfig.user = .raw(userString: user)
+        }
+        
+        // Create and start process using the same pattern as ContainerExec
+        let process = try await containerInstance.createProcess(
+            id: UUID().uuidString.lowercased(),
+            configuration: procConfig
+        )
+        
+        // Handle process I/O based on flags
+        if detach {
+            try await process.start([nil, nil, nil])
+            return 0
+        } else {
+            // For interactive exec, connect stdio
+            let stdin = interactive ? FileHandle.standardInput : nil
+            let stdout = FileHandle.standardOutput
+            let stderr = FileHandle.standardError
+            
+            try await process.start([stdin, stdout, stderr])
+            
+            // Wait for process to complete
+            let exitCode = try await process.wait()
+            return exitCode
+        }
+    }
+    
+    // MARK: - Private Methods
+    
+    private func startService(
+        project: Project,
+        service: Service,
+        forceRecreate: Bool,
+        noRecreate: Bool,
+        detach: Bool,
+        progressHandler: ProgressUpdateHandler?
+    ) async throws {
+        let containerName = service.containerName ?? "\(project.name)_\(service.name)"
+        
+        await progressHandler?([
+            .setDescription("Starting service '\(service.name)'")
+        ])
+        
+        // Check if container already exists
+        let existingContainer = try? await ClientContainer.get(id: containerName)
+        
+        if let existing = existingContainer {
+            if forceRecreate {
+                // Remove existing container
+                try await stopAndRemoveContainer(
+                    containerID: existing.id,
+                    containerName: containerName
+                )
+            } else if noRecreate {
+                // Just start existing container
+                if existing.status != RuntimeStatus.running {
+                    let process = try await existing.bootstrap()
+                    
+                    // Start container in detached mode (compose always manages containers detached)
+                    try await process.start([nil, nil, nil])
+                }
+                return
+            } else {
+                // Check if recreation needed (config changed)
+                // For now, just start if stopped
+                if existing.status != RuntimeStatus.running {
+                    let process = try await existing.bootstrap()
+                    
+                    // Start container in detached mode (compose always manages containers detached)
+                    try await process.start([nil, nil, nil])
+                }
+                return
+            }
+        }
+        
+        // Create new container
+        let containerConfig = try await createContainerConfig(
+            project: project,
+            service: service,
+            containerName: containerName,
+            progressHandler: progressHandler
+        )
+        
+        // Get default kernel for the platform
+        let kernel = try await ClientKernel.getDefaultKernel(for: SystemPlatform.current)
+        
+        let container: ClientContainer
+        do {
+            container = try await ClientContainer.create(
+                configuration: containerConfig,
+                options: ContainerCreateOptions(autoRemove: false),
+                kernel: kernel
+            )
+        } catch {
+            log.error("Failed to create container for service '\(service.name)': \(error)")
+            throw error
+        }
+        
+        // Update project state
+        projectState[project.name]!.containers[service.name] = ContainerState(
+            serviceName: service.name,
+            containerID: container.id,
+            containerName: containerName,
+            status: .created
+        )
+        
+        // Start container using the same logic as ContainerStart
+        let process = try await container.bootstrap()
+        
+        // Start container in detached mode (compose always manages containers detached)
+        try await process.start([nil, nil, nil])
+        
+        // Update status
+        projectState[project.name]!.containers[service.name]!.status = .running
+        
+        // Check health if defined
+        if let healthCheck = service.healthCheck {
+            await progressHandler?([
+                .setDescription("Checking health for '\(service.name)'")
+            ])
+            
+            // Wait for start period
+            let startPeriod = healthCheck.startPeriod ?? 0
+            if startPeriod > 0 {
+                try await Task.sleep(nanoseconds: UInt64(startPeriod) * 1_000_000_000)
+            }
+            
+            // Execute initial health check
+            let isHealthy = await executeHealthCheck(
+                container: container,
+                healthCheck: healthCheck
+            )
+            
+            projectState[project.name]!.containers[service.name]!.status = isHealthy ? .healthy : .unhealthy
+            
+            if !isHealthy {
+                log.warning("Service '\(service.name)' failed initial health check")
+            }
+        }
+        
+        await progressHandler?([
+            .setDescription("Service '\(service.name)' started")
+        ])
+    }
+    
+    private func createContainerConfig(
+        project: Project,
+        service: Service,
+        containerName: String,
+        progressHandler: ProgressUpdateHandler?
+    ) async throws -> ContainerConfiguration {
+        guard let image = service.image else {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "Service '\(service.name)' has no image specified"
+            )
+        }
+        
+        // Create process configuration
+        // Determine executable and arguments
+        let executable: String
+        let arguments: [String]
+        if let entrypoint = service.entrypoint, !entrypoint.isEmpty {
+            executable = entrypoint[0]
+            arguments = Array(entrypoint.dropFirst()) + (service.command ?? [])
+        } else if let command = service.command, !command.isEmpty {
+            executable = command[0]
+            arguments = Array(command.dropFirst())
+        } else {
+            // Use shell as default
+            executable = "/bin/sh"
+            arguments = []
+        }
+        
+        // Convert environment to array format
+        let environment = service.environment.map { key, value in
+            "\(key)=\(value)"
+        }
+        
+        let procConfig = ProcessConfiguration(
+            executable: executable,
+            arguments: arguments,
+            environment: environment,
+            workingDirectory: service.workingDir ?? "/"
+        )
+        
+        // Fetch the image using the same approach as Utility.containerConfigFromFlags
+        await progressHandler?([
+            .setDescription("Fetching image '\(image)'"),
+            .setItemsName("blobs")
+        ])
+        
+        let fetchedImage = try await ClientImage.fetch(
+            reference: image,
+            platform: .current,
+            scheme: .https
+        )
+        
+        // Unpack the fetched image
+        await progressHandler?([
+            .setDescription("Unpacking image '\(image)'"),
+            .setItemsName("entries")
+        ])
+        
+        _ = try await fetchedImage.getCreateSnapshot(
+            platform: .current,
+            progressUpdate: nil
+        )
+        
+        let imageDescription = fetchedImage.description
+        
+        // Create container configuration
+        var config = ContainerConfiguration(
+            id: containerName,
+            image: imageDescription,
+            process: procConfig
+        )
+        
+        // Set resource limits
+        if let cpusString = service.cpus,
+           let cpus = Double(cpusString) {
+            config.resources.cpus = Int(cpus)
+        }
+        
+        if let memoryString = service.memory {
+            config.resources.memoryInBytes = UInt64(try parseMemory(memoryString))
+        }
+        
+        // Set mounts
+        config.mounts = service.volumes.compactMap { mount in
+            createFilesystem(from: mount)
+        }
+        
+        // Set port mappings
+        config.publishedPorts = service.ports.map { port in
+            PublishPort(
+                hostAddress: port.hostIP ?? "0.0.0.0",
+                hostPort: Int(port.hostPort) ?? 0,
+                containerPort: Int(port.containerPort) ?? 0,
+                proto: PublishProtocol(port.portProtocol) ?? .tcp
+            )
+        }
+        
+        // Set labels
+        config.labels = service.labels
+        
+        // Set networks - default network if none specified
+        config.networks = service.networks.isEmpty ? ["default"] : service.networks
+        
+        return config
+    }
+    
+    private func createFilesystem(from volumeMount: VolumeMount) -> Filesystem? {
+        switch volumeMount.type {
+        case .bind:
+            // Check if source exists
+            if !FileManager.default.fileExists(atPath: volumeMount.source) {
+                log.warning("Volume source '\(volumeMount.source)' does not exist, skipping")
+                return nil
+            }
+            
+            let options: MountOptions = volumeMount.readOnly ? ["ro"] : []
+            
+            return Filesystem(
+                type: .virtiofs,
+                source: volumeMount.source,
+                destination: volumeMount.target,
+                options: options
+            )
+            
+        case .tmpfs:
+            // Use tmpfs for ephemeral storage
+            return Filesystem(
+                type: .tmpfs,
+                source: "tmpfs",
+                destination: volumeMount.target,
+                options: []
+            )
+            
+        case .volume:
+            // Named volumes not fully supported yet
+            log.warning("Named volumes not yet supported, skipping")
+            return nil
+        }
+    }
+    
+    private func parseMemory(_ memoryString: String) throws -> Int64 {
+        let pattern = #"^(\d+)([KMGT]?)B?$"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
+              let match = regex.firstMatch(in: memoryString, range: NSRange(memoryString.startIndex..., in: memoryString)),
+              let valueRange = Range(match.range(at: 1), in: memoryString),
+              let value = Int64(memoryString[valueRange]) else {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "Invalid memory specification: \(memoryString)"
+            )
+        }
+        
+        let unitRange = Range(match.range(at: 2), in: memoryString)
+        let unit = unitRange.map { String(memoryString[$0]).uppercased() } ?? ""
+        
+        let multiplier: Int64
+        switch unit {
+        case "K":
+            multiplier = 1024
+        case "M":
+            multiplier = 1024 * 1024
+        case "G":
+            multiplier = 1024 * 1024 * 1024
+        case "T":
+            multiplier = 1024 * 1024 * 1024 * 1024
+        default:
+            multiplier = 1
+        }
+        
+        return value * multiplier
+    }
+    
+    
+    private func stopAndRemoveContainer(containerID: String, containerName: String) async throws {
+        do {
+            let container = try await ClientContainer.get(id: containerID)
+            
+            // Stop if running
+            if container.status == RuntimeStatus.running {
+                let stopOptions = ContainerStopOptions(
+                    timeoutInSeconds: 10,
+                    signal: SIGTERM
+                )
+                try await container.stop(opts: stopOptions)
+            }
+            
+            // Remove
+            try await container.delete()
+        } catch {
+            log.warning("Failed to stop/remove container '\(containerName)': \(error)")
+        }
+    }
+    
+    private func formatPorts(_ ports: [PortMapping]) -> String {
+        return ports.map { port in
+            if let hostIP = port.hostIP {
+                return "\(hostIP):\(port.hostPort):\(port.containerPort)/\(port.portProtocol)"
+            } else {
+                return "\(port.hostPort):\(port.containerPort)/\(port.portProtocol)"
+            }
+        }.joined(separator: ", ")
+    }
+    
+    /// Execute health check for a container.
+    ///
+    /// Runs the health check command inside the container and returns whether it succeeded.
+    /// A health check is considered successful if the command exits with code 0.
+    ///
+    /// - Parameters:
+    ///   - container: The container to check
+    ///   - healthCheck: The health check configuration
+    /// - Returns: `true` if the health check passed (exit code 0), `false` otherwise
+    private func executeHealthCheck(
+        container: ClientContainer,
+        healthCheck: HealthCheck
+    ) async -> Bool {
+        do {
+            // Create a process for the health check command
+            let processId = "healthcheck-\(UUID().uuidString)"
+            
+            let procConfig = ProcessConfiguration(
+                executable: healthCheck.test[0],
+                arguments: Array(healthCheck.test.dropFirst()),
+                environment: [],
+                workingDirectory: "/"
+            )
+            
+            let process = try await container.createProcess(
+                id: processId,
+                configuration: procConfig
+            )
+            
+            // Execute with timeout
+            let timeoutSeconds = Int(healthCheck.timeout ?? 30)
+            
+            // Start process and wait for completion
+            try await process.start([nil, nil, nil])
+            
+            // Wait with timeout
+            let exitCode = try await withTimeout(seconds: timeoutSeconds) {
+                try await process.wait()
+            }
+            
+            return exitCode == 0
+        } catch {
+            log.debug("Health check failed for container \(container.id): \(error)")
+            return false
+        }
+    }
+    
+    /// Helper function to execute with timeout
+    private func withTimeout<T: Sendable>(seconds: Int, operation: @escaping @Sendable () async throws -> T) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask {
+                try await operation()
+            }
+            
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(seconds) * 1_000_000_000)
+                throw ContainerizationError(.timeout, message: "Operation timed out after \(seconds) seconds")
+            }
+            
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
+    }
+    
+    /// Check health of services in a project.
+    ///
+    /// Executes health check commands for specified services (or all services with health checks)
+    /// and returns their current health status. This is a one-time check, not continuous monitoring.
+    ///
+    /// - Parameters:
+    ///   - project: The project containing service definitions
+    ///   - services: Specific services to check (empty means all services with health checks)
+    /// - Returns: Dictionary mapping service names to health status (true = healthy)
+    /// - Throws: `ContainerizationError` if unable to execute health checks
+    public func checkHealth(
+        project: Project,
+        services: [String] = []
+    ) async throws -> [String: Bool] {
+        var healthStatus: [String: Bool] = [:]
+        
+        // Get containers to check
+        let containers = try await ClientContainer.list()
+        let targetServices = services.isEmpty ? Array(project.services.keys) : services
+        
+        for serviceName in targetServices {
+            guard let service = project.services[serviceName],
+                  let healthCheck = service.healthCheck else {
+                continue
+            }
+            
+            let containerName = service.containerName ?? "\(project.name)_\(serviceName)"
+            guard let container = containers.first(where: { $0.id == containerName }),
+                  container.status == RuntimeStatus.running else {
+                continue
+            }
+            
+            // Execute health check
+            let isHealthy = await executeHealthCheck(
+                container: container,
+                healthCheck: healthCheck
+            )
+            
+            healthStatus[serviceName] = isHealthy
+            
+            // Update internal state
+            if var state = projectState[project.name],
+               var containerState = state.containers[serviceName] {
+                containerState.status = isHealthy ? .healthy : .unhealthy
+                state.containers[serviceName] = containerState
+                projectState[project.name] = state
+            }
+        }
+        
+        return healthStatus
+    }
+}
+
+// MARK: - Service Status
+
+public struct ServiceStatus: Sendable {
+    public let name: String
+    public let containerID: String
+    public let containerName: String
+    public let status: String
+    public let ports: String
+    public let image: String
+}
+
+// MARK: - Log Entry
+
+public struct LogEntry: Sendable {
+    public let serviceName: String
+    public let timestamp: Date
+    public let message: String
+    public let stream: LogStream
+    
+    public enum LogStream: Sendable {
+        case stdout
+        case stderr
+    }
+}

--- a/Sources/ContainerCompose/Orchestrator/ProjectConverter.swift
+++ b/Sources/ContainerCompose/Orchestrator/ProjectConverter.swift
@@ -1,0 +1,486 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import ContainerizationError
+import Logging
+
+/// Converts a ComposeFile to a normalized Project structure
+public struct ProjectConverter {
+    private let log: Logger
+    
+    public init(log: Logger) {
+        self.log = log
+    }
+    
+    /// Convert a ComposeFile to a Project
+    public func convert(
+        composeFile: ComposeFile,
+        projectName: String,
+        profiles: [String] = [],
+        selectedServices: [String] = []
+    ) throws -> Project {
+        // First, resolve service inheritance
+        let resolvedServices = try resolveServiceInheritance(composeFile.services)
+        
+        // Filter services by profiles
+        let profileFilteredServices = filterServicesByProfiles(resolvedServices, profiles: profiles)
+        
+        // Filter by selected services if specified
+        let filteredServices = filterSelectedServices(profileFilteredServices, selected: selectedServices)
+        
+        // Convert services
+        var services: [String: Service] = [:]
+        for (name, composeService) in filteredServices {
+            services[name] = try convertService(name: name, service: composeService, projectName: projectName)
+        }
+        
+        // Convert networks
+        var networks: [String: Network] = [:]
+        if let composeNetworks = composeFile.networks {
+            for (name, composeNetwork) in composeNetworks {
+                networks[name] = convertNetwork(name: name, network: composeNetwork)
+            }
+        }
+        
+        // Add default network if no networks specified
+        if networks.isEmpty {
+            networks["default"] = Network(name: "default", driver: "bridge", external: false)
+        }
+        
+        // Convert volumes
+        var volumes: [String: Volume] = [:]
+        if let composeVolumes = composeFile.volumes {
+            for (name, composeVolume) in composeVolumes {
+                volumes[name] = convertVolume(name: name, volume: composeVolume)
+            }
+        }
+        
+        return Project(
+            name: projectName,
+            services: services,
+            networks: networks,
+            volumes: volumes
+        )
+    }
+    
+    // MARK: - Service Inheritance Resolution
+    
+    private func resolveServiceInheritance(_ services: [String: ComposeService]) throws -> [String: ComposeService] {
+        var resolved: [String: ComposeService] = [:]
+        var resolving: Set<String> = []
+        
+        func resolve(name: String, service: ComposeService) throws -> ComposeService {
+            // Check for circular dependencies
+            if resolving.contains(name) {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "Circular service inheritance detected involving '\(name)'"
+                )
+            }
+            
+            // If already resolved, return it
+            if let resolvedService = resolved[name] {
+                return resolvedService
+            }
+            
+            // If no extends, return as is
+            guard let extends = service.extends else {
+                resolved[name] = service
+                return service
+            }
+            
+            // Mark as currently resolving
+            resolving.insert(name)
+            defer { resolving.remove(name) }
+            
+            // Get base service
+            guard let baseService = services[extends.service] else {
+                throw ContainerizationError(
+                    .notFound,
+                    message: "Service '\(name)' extends unknown service '\(extends.service)'"
+                )
+            }
+            
+            // Resolve base service first
+            let resolvedBase = try resolve(name: extends.service, service: baseService)
+            
+            // Merge services
+            let merged = try mergeServices(base: resolvedBase, override: service)
+            resolved[name] = merged
+            
+            return merged
+        }
+        
+        // Resolve all services
+        for (name, service) in services {
+            _ = try resolve(name: name, service: service)
+        }
+        
+        return resolved
+    }
+    
+    private func mergeServices(base: ComposeService, override: ComposeService) throws -> ComposeService {
+        // For scalar values, override wins
+        // For arrays, concatenate base + override
+        // For dictionaries, merge with override winning
+        
+        return ComposeService(
+            image: override.image ?? base.image,
+            build: override.build ?? base.build,
+            command: override.command ?? base.command,
+            entrypoint: override.entrypoint ?? base.entrypoint,
+            workingDir: override.workingDir ?? base.workingDir,
+            environment: mergeEnvironment(base: base.environment, override: override.environment),
+            envFile: mergeStringOrList(base: base.envFile, override: override.envFile),
+            volumes: mergeArrays(base: base.volumes, override: override.volumes),
+            ports: mergeArrays(base: base.ports, override: override.ports),
+            networks: override.networks ?? base.networks,
+            dependsOn: override.dependsOn ?? base.dependsOn,
+            deploy: override.deploy ?? base.deploy,
+            memLimit: override.memLimit ?? base.memLimit,
+            cpus: override.cpus ?? base.cpus,
+            containerName: override.containerName ?? base.containerName,
+            healthcheck: override.healthcheck ?? base.healthcheck,
+            profiles: mergeArrays(base: base.profiles, override: override.profiles),
+            extends: nil, // Don't inherit extends
+            restart: override.restart ?? base.restart,
+            labels: mergeLabels(base: base.labels, override: override.labels)
+        )
+    }
+    
+    private func mergeEnvironment(base: Environment?, override: Environment?) -> Environment? {
+        guard let base = base else { return override }
+        guard let override = override else { return base }
+        
+        let baseDict = base.asDictionary
+        var mergedDict = baseDict
+        
+        for (key, value) in override.asDictionary {
+            mergedDict[key] = value
+        }
+        
+        return .dict(mergedDict)
+    }
+    
+    private func mergeStringOrList(base: StringOrList?, override: StringOrList?) -> StringOrList? {
+        guard let base = base else { return override }
+        guard let override = override else { return base }
+        
+        return .list(base.asArray + override.asArray)
+    }
+    
+    private func mergeArrays<T>(base: [T]?, override: [T]?) -> [T]? {
+        guard let base = base else { return override }
+        guard let override = override else { return base }
+        
+        return base + override
+    }
+    
+    private func mergeLabels(base: Labels?, override: Labels?) -> Labels? {
+        guard let base = base else { return override }
+        guard let override = override else { return base }
+        
+        switch (base, override) {
+        case (.dict(let baseDict), .dict(let overrideDict)):
+            var merged = baseDict
+            for (key, value) in overrideDict {
+                merged[key] = value
+            }
+            return .dict(merged)
+        case (.list(let baseList), .list(let overrideList)):
+            return .list(baseList + overrideList)
+        default:
+            // If types don't match, override wins
+            return override
+        }
+    }
+    
+    // MARK: - Profile Filtering
+    
+    private func filterServicesByProfiles(
+        _ services: [String: ComposeService],
+        profiles: [String]
+    ) -> [String: ComposeService] {
+        if profiles.isEmpty {
+            // No profiles specified, include only services without profiles
+            return services.filter { $0.value.profiles == nil || $0.value.profiles!.isEmpty }
+        }
+        
+        // Include services that have no profiles OR match any of the specified profiles
+        return services.filter { (_, service) in
+            if let serviceProfiles = service.profiles, !serviceProfiles.isEmpty {
+                // Service has profiles, check if any match
+                return !Set(serviceProfiles).isDisjoint(with: Set(profiles))
+            }
+            // Service has no profiles, always include
+            return true
+        }
+    }
+    
+    // MARK: - Service Selection
+    
+    private func filterSelectedServices(
+        _ services: [String: ComposeService],
+        selected: [String]
+    ) -> [String: ComposeService] {
+        if selected.isEmpty {
+            return services
+        }
+        
+        var result: [String: ComposeService] = [:]
+        var toProcess = Set(selected)
+        var processed = Set<String>()
+        
+        // Recursively include dependencies
+        while !toProcess.isEmpty {
+            let current = toProcess.removeFirst()
+            if processed.contains(current) {
+                continue
+            }
+            processed.insert(current)
+            
+            guard let service = services[current] else {
+                log.warning("Selected service '\(current)' not found")
+                continue
+            }
+            
+            result[current] = service
+            
+            // Add dependencies
+            if let deps = service.dependsOn {
+                for dep in deps.asList {
+                    toProcess.insert(dep)
+                }
+            }
+        }
+        
+        return result
+    }
+    
+    // MARK: - Service Conversion
+    
+    private func convertService(name: String, service: ComposeService, projectName: String) throws -> Service {
+        // Parse ports
+        let ports = try (service.ports ?? []).compactMap { portString -> PortMapping? in
+            guard let mapping = PortMapping(from: portString) else {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "Invalid port mapping '\(portString)' in service '\(name)'"
+                )
+            }
+            return mapping
+        }
+        
+        // Parse volumes
+        let volumes = (service.volumes ?? []).compactMap { volumeString -> VolumeMount? in
+            guard let mount = VolumeMount(from: volumeString) else {
+                log.warning("Invalid volume mount '\(volumeString)' in service '\(name)'")
+                return nil
+            }
+            
+            // Convert relative paths to absolute
+            var finalMount = mount
+            if mount.type == .bind && !mount.source.hasPrefix("/") {
+                let currentDir = FileManager.default.currentDirectoryPath
+                let absolutePath = URL(fileURLWithPath: currentDir)
+                    .appendingPathComponent(mount.source)
+                    .standardized
+                    .path
+                finalMount = VolumeMount(
+                    source: absolutePath,
+                    target: mount.target,
+                    readOnly: mount.readOnly,
+                    type: mount.type
+                )
+            }
+            
+            return finalMount
+        }
+        
+        // Get environment variables
+        let environment = service.environment?.asDictionary ?? [:]
+        
+        // Get networks
+        let networks: [String] = {
+            switch service.networks {
+            case .list(let list):
+                return list
+            case .dict(let dict):
+                return Array(dict.keys)
+            case nil:
+                return ["default"]
+            }
+        }()
+        
+        // Get dependencies
+        let dependsOn = service.dependsOn?.asList ?? []
+        
+        // Convert health check
+        let healthCheck: HealthCheck? = {
+            guard let hc = service.healthcheck, !(hc.disable ?? false) else { return nil }
+            
+            return HealthCheck(
+                test: hc.test?.asArray ?? [],
+                interval: parseTimeInterval(hc.interval),
+                timeout: parseTimeInterval(hc.timeout),
+                retries: hc.retries,
+                startPeriod: parseTimeInterval(hc.startPeriod)
+            )
+        }()
+        
+        // Get resource limits
+        let cpus = service.cpus ?? service.deploy?.resources?.limits?.cpus
+        let memory = service.memLimit ?? service.deploy?.resources?.limits?.memory
+        
+        // Container name
+        let containerName = service.containerName ?? "\(projectName)_\(name)"
+        
+        return Service(
+            name: name,
+            image: service.image,
+            command: service.command?.asArray,
+            entrypoint: service.entrypoint?.asArray,
+            workingDir: service.workingDir,
+            environment: environment,
+            ports: ports,
+            volumes: volumes,
+            networks: networks,
+            dependsOn: dependsOn,
+            healthCheck: healthCheck,
+            deploy: convertDeploy(service.deploy),
+            restart: service.restart,
+            containerName: containerName,
+            profiles: service.profiles ?? [],
+            labels: convertLabels(service.labels),
+            cpus: cpus,
+            memory: memory
+        )
+    }
+    
+    // MARK: - Helper Conversions
+    
+    private func convertNetwork(name: String, network: ComposeNetwork) -> Network {
+        let external: Bool = {
+            switch network.external {
+            case .bool(let value):
+                return value
+            case .config(_):
+                return true
+            case nil:
+                return false
+            }
+        }()
+        
+        return Network(
+            name: name,
+            driver: network.driver ?? "bridge",
+            external: external
+        )
+    }
+    
+    private func convertVolume(name: String, volume: ComposeVolume) -> Volume {
+        let external: Bool = {
+            switch volume.external {
+            case .bool(let value):
+                return value
+            case .config(_):
+                return true
+            case nil:
+                return false
+            }
+        }()
+        
+        return Volume(
+            name: name,
+            driver: volume.driver ?? "local",
+            external: external
+        )
+    }
+    
+    private func convertDeploy(_ composeDeploy: DeployConfig?) -> Deploy? {
+        guard let composeDeploy = composeDeploy else { return nil }
+        
+        let resources: ServiceResources? = {
+            guard let composeResources = composeDeploy.resources else { return nil }
+            
+            let limits = composeResources.limits.map { limits in
+                ServiceResourceConfig(
+                    cpus: limits.cpus,
+                    memory: limits.memory
+                )
+            }
+            
+            let reservations = composeResources.reservations.map { reservations in
+                ServiceResourceConfig(
+                    cpus: reservations.cpus,
+                    memory: reservations.memory
+                )
+            }
+            
+            return ServiceResources(
+                limits: limits,
+                reservations: reservations
+            )
+        }()
+        
+        return Deploy(resources: resources)
+    }
+    
+    private func convertLabels(_ labels: Labels?) -> [String: String] {
+        guard let labels = labels else { return [:] }
+        
+        switch labels {
+        case .dict(let dict):
+            return dict
+        case .list(let list):
+            var dict: [String: String] = [:]
+            for item in list {
+                let parts = item.split(separator: "=", maxSplits: 1)
+                if parts.count == 2 {
+                    dict[String(parts[0])] = String(parts[1])
+                }
+            }
+            return dict
+        }
+    }
+    
+    private func parseTimeInterval(_ string: String?) -> TimeInterval? {
+        guard let string = string else { return nil }
+        
+        // Parse duration strings like "30s", "5m", "1h"
+        let pattern = #"^(\d+)([smh])$"#
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: string, range: NSRange(string.startIndex..., in: string)),
+              let valueRange = Range(match.range(at: 1), in: string),
+              let unitRange = Range(match.range(at: 2), in: string),
+              let value = Double(string[valueRange]) else {
+            return nil
+        }
+        
+        let unit = String(string[unitRange])
+        switch unit {
+        case "s":
+            return value
+        case "m":
+            return value * 60
+        case "h":
+            return value * 3600
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/ContainerCompose/Parser/ComposeParser.swift
+++ b/Sources/ContainerCompose/Parser/ComposeParser.swift
@@ -1,0 +1,301 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Yams
+import ContainerizationError
+import Logging
+
+public struct ComposeParser {
+    private let log: Logger
+    
+    public init(log: Logger) {
+        self.log = log
+    }
+    
+    /// Parse a docker-compose.yaml file from the given URL
+    public func parse(from url: URL) throws -> ComposeFile {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw ContainerizationError(
+                .notFound,
+                message: "Compose file not found at path: \(url.path)"
+            )
+        }
+        
+        let data = try Data(contentsOf: url)
+        return try parse(from: data)
+    }
+    
+    /// Parse compose file from data
+    public func parse(from data: Data) throws -> ComposeFile {
+        guard let yamlString = String(data: data, encoding: .utf8) else {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "Unable to decode compose file as UTF-8"
+            )
+        }
+        
+        do {
+            // Decode directly without intermediate dump/reload
+            let decoder = YAMLDecoder()
+            
+            // First try to decode directly (no interpolation needed)
+            if !yamlString.contains("$") {
+                let composeFile = try decoder.decode(ComposeFile.self, from: data)
+                try validate(composeFile)
+                return composeFile
+            }
+            
+            // If we have variables to interpolate, we need to process the YAML
+            // But let's do it more intelligently by working with the string directly
+            let interpolatedYaml = try interpolateYamlString(yamlString)
+            let interpolatedData = interpolatedYaml.data(using: .utf8)!
+            
+            let composeFile = try decoder.decode(ComposeFile.self, from: interpolatedData)
+            try validate(composeFile)
+            
+            return composeFile
+        } catch let error as DecodingError {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "Failed to parse compose file: \(describeDecodingError(error))"
+            )
+        } catch {
+            throw error
+        }
+    }
+    
+    /// Validate the compose file structure
+    private func validate(_ composeFile: ComposeFile) throws {
+        // Check version compatibility
+        if let version = composeFile.version {
+            let supportedVersions = ["2", "2.0", "2.1", "2.2", "2.3", "2.4", 
+                                   "3", "3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9"]
+            let majorVersion = version.split(separator: ".").first.map(String.init) ?? version
+            
+            if !supportedVersions.contains(version) && !supportedVersions.contains(majorVersion) {
+                log.warning("Compose file version '\(version)' may not be fully supported")
+            }
+        }
+        
+        // Validate services
+        guard !composeFile.services.isEmpty else {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "No services defined in compose file"
+            )
+        }
+        
+        for (name, service) in composeFile.services {
+            try validateService(name: name, service: service)
+        }
+        
+        // Validate circular dependencies
+        try validateDependencies(composeFile)
+    }
+    
+    /// Validate individual service configuration
+    private func validateService(name: String, service: ComposeService) throws {
+        // Either image or build must be specified
+        if service.image == nil && service.build == nil {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "Service '\(name)' must specify either 'image' or 'build'"
+            )
+        }
+        
+        // Validate extends configuration
+        if let extends = service.extends {
+            if extends.service.isEmpty {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "Service '\(name)' extends configuration must specify a service"
+                )
+            }
+        }
+        
+        // Validate port mappings
+        if let ports = service.ports {
+            for port in ports {
+                if !isValidPortMapping(port) {
+                    throw ContainerizationError(
+                        .invalidArgument,
+                        message: "Invalid port mapping '\(port)' in service '\(name)'"
+                    )
+                }
+            }
+        }
+        
+        // Validate volume mounts
+        if let volumes = service.volumes {
+            for volume in volumes {
+                if !isValidVolumeMount(volume) {
+                    throw ContainerizationError(
+                        .invalidArgument,
+                        message: "Invalid volume mount '\(volume)' in service '\(name)'"
+                    )
+                }
+            }
+        }
+    }
+    
+    /// Validate dependencies don't have circular references
+    private func validateDependencies(_ composeFile: ComposeFile) throws {
+        var visited = Set<String>()
+        var recursionStack = Set<String>()
+        
+        func hasCycle(service: String) -> Bool {
+            if recursionStack.contains(service) {
+                return true
+            }
+            if visited.contains(service) {
+                return false
+            }
+            
+            visited.insert(service)
+            recursionStack.insert(service)
+            
+            if let serviceConfig = composeFile.services[service],
+               let dependsOn = serviceConfig.dependsOn {
+                for dependency in dependsOn.asList {
+                    if hasCycle(service: dependency) {
+                        return true
+                    }
+                }
+            }
+            
+            recursionStack.remove(service)
+            return false
+        }
+        
+        for serviceName in composeFile.services.keys {
+            if hasCycle(service: serviceName) {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "Circular dependency detected involving service '\(serviceName)'"
+                )
+            }
+        }
+    }
+    
+    /// Check if port mapping is valid
+    private func isValidPortMapping(_ port: String) -> Bool {
+        // Accept formats:
+        // - "8080:80"
+        // - "8080:80/tcp"
+        // - "127.0.0.1:8080:80"
+        // - "127.0.0.1:8080:80/tcp"
+        let components = port.split(separator: ":")
+        return components.count >= 2 && components.count <= 3
+    }
+    
+    /// Check if volume mount is valid
+    private func isValidVolumeMount(_ volume: String) -> Bool {
+        // Accept formats:
+        // - "host_path:container_path"
+        // - "host_path:container_path:ro"
+        // - "volume_name:container_path"
+        // - "volume_name:container_path:ro"
+        let components = volume.split(separator: ":")
+        if components.count < 2 || components.count > 3 {
+            return false
+        }
+        
+        // If there's a third component, it should be a valid mount option
+        if components.count == 3 {
+            let validOptions = ["ro", "rw", "z", "Z"]
+            return validOptions.contains(String(components[2]))
+        }
+        
+        return true
+    }
+    
+    /// Interpolate environment variables directly in YAML string
+    private func interpolateYamlString(_ yaml: String) throws -> String {
+        var result = yaml
+        
+        // Pattern for ${VAR} or ${VAR:-default}
+        let pattern = #"\$\{([^}]+)\}"#
+        let regex = try NSRegularExpression(pattern: pattern)
+        let matches = regex.matches(in: yaml, range: NSRange(yaml.startIndex..., in: yaml))
+        
+        // Process matches in reverse order to maintain correct positions
+        for match in matches.reversed() {
+            guard let range = Range(match.range, in: yaml),
+                  let varRange = Range(match.range(at: 1), in: yaml) else {
+                continue
+            }
+            
+            let varExpression = String(yaml[varRange])
+            let (varName, defaultValue) = parseVarExpression(varExpression)
+            
+            let value = ProcessInfo.processInfo.environment[varName] ?? defaultValue ?? ""
+            result.replaceSubrange(range, with: value)
+        }
+        
+        // Also handle $VAR format
+        let simplePattern = #"\$([A-Za-z_][A-Za-z0-9_]*)"#
+        let simpleRegex = try NSRegularExpression(pattern: simplePattern)
+        let simpleMatches = simpleRegex.matches(in: result, range: NSRange(result.startIndex..., in: result))
+        
+        for match in simpleMatches.reversed() {
+            guard let range = Range(match.range, in: result),
+                  let varRange = Range(match.range(at: 1), in: result) else {
+                continue
+            }
+            
+            let varName = String(result[varRange])
+            if let value = ProcessInfo.processInfo.environment[varName] {
+                result.replaceSubrange(range, with: value)
+            }
+        }
+        
+        return result
+    }
+    
+    
+    /// Parse variable expression like "VAR:-default"
+    private func parseVarExpression(_ expression: String) -> (name: String, defaultValue: String?) {
+        if let colonDashIndex = expression.firstIndex(of: ":") {
+            let name = String(expression[..<colonDashIndex])
+            let afterColon = expression.index(after: colonDashIndex)
+            if afterColon < expression.endIndex && expression[afterColon] == "-" {
+                let defaultStart = expression.index(after: afterColon)
+                let defaultValue = String(expression[defaultStart...])
+                return (name, defaultValue)
+            }
+            return (name, nil)
+        }
+        return (expression, nil)
+    }
+    
+    
+    /// Describe decoding error in a user-friendly way
+    private func describeDecodingError(_ error: DecodingError) -> String {
+        switch error {
+        case .typeMismatch(_, let context):
+            return "Type mismatch at \(context.codingPath.map { $0.stringValue }.joined(separator: ".")): \(context.debugDescription)"
+        case .valueNotFound(_, let context):
+            return "Missing value at \(context.codingPath.map { $0.stringValue }.joined(separator: ".")): \(context.debugDescription)"
+        case .keyNotFound(let key, let context):
+            return "Unknown key '\(key.stringValue)' at \(context.codingPath.map { $0.stringValue }.joined(separator: "."))"
+        case .dataCorrupted(let context):
+            return "Invalid data at \(context.codingPath.map { $0.stringValue }.joined(separator: ".")): \(context.debugDescription)"
+        @unknown default:
+            return "Unknown parsing error: \(error)"
+        }
+    }
+}

--- a/Tests/CLITests/Subcommands/Compose/TestCLICompose.swift
+++ b/Tests/CLITests/Subcommands/Compose/TestCLICompose.swift
@@ -1,0 +1,320 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+class TestCLICompose: CLITest {
+    
+    func createComposeFile(content: String, filename: String = "docker-compose.yml") throws -> URL {
+        let fileURL = testDir.appendingPathComponent(filename)
+        try content.write(to: fileURL, atomically: true, encoding: .utf8)
+        return fileURL
+    }
+    
+    @Test func testComposeValidate() throws {
+        let yaml = """
+        version: '3'
+        services:
+          web:
+            image: nginx:alpine
+            ports:
+              - "8080:80"
+        """
+        
+        let composeFile = try createComposeFile(content: yaml)
+        defer { try? FileManager.default.removeItem(at: testDir) }
+        
+        let (output, error, status) = try run(
+            arguments: ["compose", "-f", composeFile.path, "validate"],
+            currentDirectory: testDir
+        )
+        
+        #expect(status == 0)
+        #expect(output.contains("valid"))
+        #expect(error.isEmpty)
+    }
+    
+    @Test func testComposeValidateInvalid() throws {
+        let yaml = """
+        version: '3'
+        services:
+          web:
+            # Missing image
+            ports:
+              - "8080:80"
+        """
+        
+        let composeFile = try createComposeFile(content: yaml)
+        defer { try? FileManager.default.removeItem(at: testDir) }
+        
+        let (_, error, status) = try run(
+            arguments: ["compose", "-f", composeFile.path, "validate"],
+            currentDirectory: testDir
+        )
+        
+        #expect(status != 0)
+        #expect(error.contains("Service 'web' has no image"))
+    }
+    
+    @Test func testComposeUpDown() throws {
+        // First pull the required image
+        try doPull(imageName: alpine)
+        
+        let yaml = """
+        version: '3'
+        services:
+          app:
+            image: \(alpine)
+            container_name: compose_test_app
+            command: ["sleep", "300"]
+        """
+        
+        let composeFile = try createComposeFile(content: yaml)
+        defer { 
+            try? FileManager.default.removeItem(at: testDir)
+            // Cleanup any leftover containers
+            try? run(arguments: ["rm", "-f", "compose_test_app"])
+        }
+        
+        // Test compose up
+        let (_, _, upStatus) = try run(
+            arguments: ["compose", "-f", composeFile.path, "up", "-d"],
+            currentDirectory: testDir
+        )
+        #expect(upStatus == 0)
+        
+        // Verify container is running
+        let status = try getContainerStatus("compose_test_app")
+        #expect(status == "running")
+        
+        // Test compose down
+        let (_, _, downStatus) = try run(
+            arguments: ["compose", "-f", composeFile.path, "down"],
+            currentDirectory: testDir
+        )
+        #expect(downStatus == 0)
+        
+        // Verify container is removed
+        #expect {
+            _ = try getContainerStatus("compose_test_app")
+        } throws: { _ in true }
+    }
+    
+    @Test func testComposePs() throws {
+        try doPull(imageName: alpine)
+        
+        let yaml = """
+        version: '3'
+        services:
+          web:
+            image: \(alpine)
+            command: ["sleep", "300"]
+          db:
+            image: \(alpine)
+            command: ["sleep", "300"]
+        """
+        
+        let projectName = "testps"
+        let composeFile = try createComposeFile(content: yaml)
+        defer { 
+            try? FileManager.default.removeItem(at: testDir)
+            try? run(arguments: ["compose", "-p", projectName, "-f", composeFile.path, "down"])
+        }
+        
+        // Start services
+        let (_, _, upStatus) = try run(
+            arguments: ["compose", "-p", projectName, "-f", composeFile.path, "up", "-d"],
+            currentDirectory: testDir
+        )
+        #expect(upStatus == 0)
+        
+        // Test ps command
+        let (output, _, psStatus) = try run(
+            arguments: ["compose", "-p", projectName, "-f", composeFile.path, "ps"],
+            currentDirectory: testDir
+        )
+        #expect(psStatus == 0)
+        #expect(output.contains("web"))
+        #expect(output.contains("db"))
+        #expect(output.contains("running"))
+    }
+    
+    @Test func testComposeWithDependencies() throws {
+        try doPull(imageName: alpine)
+        
+        let yaml = """
+        version: '3'
+        services:
+          db:
+            image: \(alpine)
+            command: ["sleep", "300"]
+          app:
+            image: \(alpine)
+            command: ["sleep", "300"]
+            depends_on:
+              - db
+        """
+        
+        let projectName = "testdeps"
+        let composeFile = try createComposeFile(content: yaml)
+        defer { 
+            try? FileManager.default.removeItem(at: testDir)
+            try? run(arguments: ["compose", "-p", projectName, "-f", composeFile.path, "down"])
+        }
+        
+        // Start only app - should also start db
+        let (_, _, status) = try run(
+            arguments: ["compose", "-p", projectName, "-f", composeFile.path, "up", "-d", "app"],
+            currentDirectory: testDir
+        )
+        #expect(status == 0)
+        
+        // Both containers should be running
+        let dbStatus = try getContainerStatus("\(projectName)_db")
+        let appStatus = try getContainerStatus("\(projectName)_app")
+        #expect(dbStatus == "running")
+        #expect(appStatus == "running")
+    }
+    
+    @Test func testComposeStartStop() throws {
+        try doPull(imageName: alpine)
+        
+        let yaml = """
+        version: '3'
+        services:
+          app:
+            image: \(alpine)
+            command: ["sleep", "300"]
+        """
+        
+        let projectName = "teststop"
+        let composeFile = try createComposeFile(content: yaml)
+        defer { 
+            try? FileManager.default.removeItem(at: testDir)
+            try? run(arguments: ["compose", "-p", projectName, "-f", composeFile.path, "down"])
+        }
+        
+        // Start service
+        let (_, _, upStatus) = try run(
+            arguments: ["compose", "-p", projectName, "-f", composeFile.path, "up", "-d"],
+            currentDirectory: testDir
+        )
+        #expect(upStatus == 0)
+        
+        // Stop service
+        let (_, _, stopStatus) = try run(
+            arguments: ["compose", "-p", projectName, "-f", composeFile.path, "stop"],
+            currentDirectory: testDir
+        )
+        #expect(stopStatus == 0)
+        
+        // Container should exist but be stopped
+        let container = try inspectContainer("\(projectName)_app")
+        #expect(container.status != "running")
+        
+        // Start service again
+        let (_, _, startStatus) = try run(
+            arguments: ["compose", "-p", projectName, "-f", composeFile.path, "start"],
+            currentDirectory: testDir
+        )
+        #expect(startStatus == 0)
+        
+        // Container should be running again
+        let status = try getContainerStatus("\(projectName)_app")
+        #expect(status == "running")
+    }
+    
+    @Test func testComposeExec() throws {
+        try doPull(imageName: alpine)
+        
+        let yaml = """
+        version: '3'
+        services:
+          app:
+            image: \(alpine)
+            command: ["sleep", "300"]
+            working_dir: /tmp
+        """
+        
+        let projectName = "testexec"
+        let composeFile = try createComposeFile(content: yaml)
+        defer { 
+            try? FileManager.default.removeItem(at: testDir)
+            try? run(arguments: ["compose", "-p", projectName, "-f", composeFile.path, "down"])
+        }
+        
+        // Start service
+        let (_, _, upStatus) = try run(
+            arguments: ["compose", "-p", projectName, "-f", composeFile.path, "up", "-d"],
+            currentDirectory: testDir
+        )
+        #expect(upStatus == 0)
+        
+        // Execute command
+        let (output, _, execStatus) = try run(
+            arguments: ["compose", "-p", projectName, "-f", composeFile.path, "exec", "app", "pwd"],
+            currentDirectory: testDir
+        )
+        #expect(execStatus == 0)
+        #expect(output.trimmingCharacters(in: .whitespacesAndNewlines) == "/tmp")
+    }
+    
+    @Test func testComposeWithProfiles() throws {
+        try doPull(imageName: alpine)
+        
+        let yaml = """
+        version: '3.9'
+        services:
+          web:
+            image: \(alpine)
+            command: ["sleep", "300"]
+            profiles: ["frontend"]
+          api:
+            image: \(alpine)
+            command: ["sleep", "300"]
+            profiles: ["backend"]
+          db:
+            image: \(alpine)
+            command: ["sleep", "300"]
+        """
+        
+        let projectName = "testprofiles"
+        let composeFile = try createComposeFile(content: yaml)
+        defer { 
+            try? FileManager.default.removeItem(at: testDir)
+            try? run(arguments: ["compose", "-p", projectName, "-f", composeFile.path, "down"])
+        }
+        
+        // Start with frontend profile
+        let (_, _, status) = try run(
+            arguments: ["compose", "-p", projectName, "-f", composeFile.path, "--profile", "frontend", "up", "-d"],
+            currentDirectory: testDir
+        )
+        #expect(status == 0)
+        
+        // Check what's running
+        let dbStatus = try getContainerStatus("\(projectName)_db")
+        let webStatus = try getContainerStatus("\(projectName)_web")
+        #expect(dbStatus == "running") // No profile, always runs
+        #expect(webStatus == "running") // Frontend profile
+        
+        // API should not be running
+        #expect {
+            _ = try getContainerStatus("\(projectName)_api")
+        } throws: { _ in true }
+    }
+}

--- a/Tests/CLITests/Subcommands/Compose/TestCLIComposeHealth.swift
+++ b/Tests/CLITests/Subcommands/Compose/TestCLIComposeHealth.swift
@@ -1,0 +1,161 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import XCTest
+@testable import ContainerCLI
+import Foundation
+import ContainerClient
+
+class TestCLIComposeHealth: CLITest {
+    
+    func testComposeHealthCheck() async throws {
+        // Create compose file with health check
+        let composeContent = """
+        version: '3'
+        services:
+          healthy:
+            image: busybox
+            command: ["sh", "-c", "echo 'healthy' && sleep 3600"]
+            healthcheck:
+              test: ["CMD", "echo", "ok"]
+              interval: 5s
+              timeout: 3s
+              start_period: 2s
+          
+          unhealthy:
+            image: busybox
+            command: ["sh", "-c", "echo 'unhealthy' && sleep 3600"]
+            healthcheck:
+              test: ["CMD", "sh", "-c", "exit 1"]
+              interval: 5s
+              timeout: 3s
+        """
+        
+        let composeFile = tempDir.appendingPathComponent("docker-compose.yml")
+        try composeContent.write(to: composeFile, atomically: true, encoding: .utf8)
+        
+        // Start services
+        try await runCommand(["compose", "up", "-d"])
+        
+        // Wait for health checks to initialize
+        try await Task.sleep(nanoseconds: 3_000_000_000) // 3 seconds
+        
+        // Check health status
+        let output = try await runCommand(["compose", "health"])
+        
+        // Verify output shows correct health status
+        XCTAssertTrue(output.contains("✓ healthy: healthy"))
+        XCTAssertTrue(output.contains("✗ unhealthy: unhealthy"))
+        
+        // Cleanup
+        try await runCommand(["compose", "down"])
+    }
+    
+    func testComposeHealthQuietMode() async throws {
+        // Create compose file with failing health check
+        let composeContent = """
+        version: '3'
+        services:
+          failing:
+            image: busybox
+            command: ["sleep", "3600"]
+            healthcheck:
+              test: ["CMD", "false"]
+              interval: 1s
+        """
+        
+        let composeFile = tempDir.appendingPathComponent("docker-compose.yml")
+        try composeContent.write(to: composeFile, atomically: true, encoding: .utf8)
+        
+        // Start service
+        try await runCommand(["compose", "up", "-d"])
+        
+        // Wait for health check
+        try await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
+        
+        // Check health in quiet mode - should fail
+        do {
+            _ = try await runCommand(["compose", "health", "--quiet"])
+            XCTFail("Expected health check to fail")
+        } catch {
+            // Expected to fail
+        }
+        
+        // Cleanup
+        try await runCommand(["compose", "down"])
+    }
+    
+    func testComposeHealthSpecificService() async throws {
+        // Create compose file with multiple services
+        let composeContent = """
+        version: '3'
+        services:
+          web:
+            image: busybox
+            command: ["sleep", "3600"]
+            healthcheck:
+              test: ["CMD", "true"]
+          
+          db:
+            image: busybox
+            command: ["sleep", "3600"]
+            healthcheck:
+              test: ["CMD", "true"]
+        """
+        
+        let composeFile = tempDir.appendingPathComponent("docker-compose.yml")
+        try composeContent.write(to: composeFile, atomically: true, encoding: .utf8)
+        
+        // Start services
+        try await runCommand(["compose", "up", "-d"])
+        
+        // Check health of specific service
+        let output = try await runCommand(["compose", "health", "web"])
+        
+        // Should only show web service
+        XCTAssertTrue(output.contains("✓ web: healthy"))
+        XCTAssertFalse(output.contains("db"))
+        
+        // Cleanup
+        try await runCommand(["compose", "down"])
+    }
+    
+    func testComposeHealthNoHealthCheck() async throws {
+        // Create compose file without health checks
+        let composeContent = """
+        version: '3'
+        services:
+          app:
+            image: busybox
+            command: ["sleep", "3600"]
+        """
+        
+        let composeFile = tempDir.appendingPathComponent("docker-compose.yml")
+        try composeContent.write(to: composeFile, atomically: true, encoding: .utf8)
+        
+        // Start service
+        try await runCommand(["compose", "up", "-d"])
+        
+        // Check health
+        let output = try await runCommand(["compose", "health"])
+        
+        // Should indicate no health checks
+        XCTAssertTrue(output.contains("No services with health checks found"))
+        
+        // Cleanup
+        try await runCommand(["compose", "down"])
+    }
+}

--- a/Tests/ContainerComposeTests/ComposeParserTests.swift
+++ b/Tests/ContainerComposeTests/ComposeParserTests.swift
@@ -1,0 +1,190 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+import ContainerizationError
+import Logging
+import Yams
+
+@testable import ContainerCompose
+
+struct ComposeParserTests {
+    let log = Logger(label: "test")
+    
+    @Test
+    func testParseBasicComposeFile() throws {
+        let yaml = """
+        version: '3'
+        services:
+          web:
+            image: nginx:latest
+            ports:
+              - "8080:80"
+        """
+        
+        let parser = ComposeParser(log: log)
+        let data = yaml.data(using: .utf8)!
+        let composeFile = try parser.parse(from: data)
+        
+        #expect(composeFile.version == "3")
+        #expect(composeFile.services.count == 1)
+        #expect(composeFile.services["web"]?.image == "nginx:latest")
+        #expect(composeFile.services["web"]?.ports?.count == 1)
+        #expect(composeFile.services["web"]?.ports?[0] == "8080:80")
+    }
+    
+    @Test
+    func testParseWithDefaultValues() throws {
+        let yaml = """
+        version: '3'
+        services:
+          app:
+            image: ${IMAGE_NAME:-ubuntu:latest}
+            environment:
+              DB_PORT: ${DB_PORT:-5432}
+        """
+        
+        let parser = ComposeParser(log: log)
+        let data = yaml.data(using: .utf8)!
+        let composeFile = try parser.parse(from: data)
+        
+        // Should use default values when env vars not set
+        #expect(composeFile.services["app"]?.image == "ubuntu:latest")
+        
+        // Check environment
+        if case .dict(let env) = composeFile.services["app"]?.environment {
+            #expect(env["DB_PORT"] == "5432")
+        } else {
+            Issue.record("Expected environment to be a dictionary")
+        }
+    }
+    
+    @Test
+    func testParsePortFormats() throws {
+        let yaml = """
+        version: '3'
+        services:
+          web:
+            image: nginx
+            ports:
+              - "8080:80"
+              - "127.0.0.1:9000:9000"
+              - "3000:3000"
+        """
+        
+        let parser = ComposeParser(log: log)
+        let data = yaml.data(using: .utf8)!
+        let composeFile = try parser.parse(from: data)
+        
+        let ports = composeFile.services["web"]?.ports ?? []
+        #expect(ports.count == 3)
+        #expect(ports[0] == "8080:80")
+        #expect(ports[1] == "127.0.0.1:9000:9000")
+        #expect(ports[2] == "3000:3000")
+    }
+    
+    @Test
+    func testParseDependencies() throws {
+        let yaml = """
+        version: '3'
+        services:
+          db:
+            image: postgres
+          web:
+            image: nginx
+            depends_on:
+              - db
+          worker:
+            image: worker
+            depends_on:
+              - db
+              - web
+        """
+        
+        let parser = ComposeParser(log: log)
+        let data = yaml.data(using: .utf8)!
+        let composeFile = try parser.parse(from: data)
+        
+        // The parser converts the YAML structure
+        #expect(composeFile.services["db"]?.dependsOn == nil)
+        #expect(composeFile.services["web"]?.dependsOn != nil)
+        #expect(composeFile.services["worker"]?.dependsOn != nil)
+    }
+    
+    @Test
+    func testParseVolumes() throws {
+        let yaml = """
+        version: '3'
+        services:
+          app:
+            image: ubuntu
+            volumes:
+              - /host/path:/container/path
+              - /host/path2:/container/path2:ro
+        """
+        
+        let parser = ComposeParser(log: log)
+        let data = yaml.data(using: .utf8)!
+        let composeFile = try parser.parse(from: data)
+        
+        let volumes = composeFile.services["app"]?.volumes ?? []
+        #expect(volumes.count == 2)
+        #expect(volumes[0] == "/host/path:/container/path")
+        #expect(volumes[1] == "/host/path2:/container/path2:ro")
+    }
+    
+    @Test
+    func testParseInvalidYAML() throws {
+        let yaml = """
+        this is not valid yaml: [
+        """
+        
+        let parser = ComposeParser(log: log)
+        let data = yaml.data(using: .utf8)!
+        
+        #expect {
+            _ = try parser.parse(from: data)
+        } throws: { error in
+            // Can be either ContainerizationError or YamlError
+            return true
+        }
+    }
+    
+    @Test
+    func testParseWithProfiles() throws {
+        let yaml = """
+        version: '3.9'
+        services:
+          web:
+            image: nginx
+            profiles: ["frontend"]
+          api:
+            image: api:latest
+            profiles: ["backend", "api"]
+          db:
+            image: postgres
+        """
+        
+        let parser = ComposeParser(log: log)
+        let data = yaml.data(using: .utf8)!
+        let composeFile = try parser.parse(from: data)
+        
+        #expect(composeFile.services["web"]?.profiles == ["frontend"])
+        #expect(composeFile.services["api"]?.profiles == ["backend", "api"])
+        #expect(composeFile.services["db"]?.profiles == nil)
+    }
+}

--- a/Tests/ContainerComposeTests/DependencyResolverTests.swift
+++ b/Tests/ContainerComposeTests/DependencyResolverTests.swift
@@ -1,0 +1,172 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+import ContainerizationError
+
+@testable import ContainerCompose
+
+struct DependencyResolverTests {
+    
+    @Test
+    func testResolveNoDependencies() throws {
+        let services: [String: Service] = [
+            "web": Service(name: "web", image: "nginx"),
+            "db": Service(name: "db", image: "postgres"),
+            "cache": Service(name: "cache", image: "redis")
+        ]
+        
+        let resolution = try DependencyResolver.resolve(services: services)
+        
+        #expect(resolution.startOrder.count == 3)
+        #expect(resolution.stopOrder.count == 3)
+        #expect(resolution.parallelGroups.count == 1)
+        #expect(resolution.parallelGroups[0].count == 3)
+    }
+    
+    @Test
+    func testResolveLinearDependencies() throws {
+        let services: [String: Service] = [
+            "db": Service(name: "db", image: "postgres"),
+            "cache": Service(name: "cache", image: "redis", dependsOn: ["db"]),
+            "web": Service(name: "web", image: "nginx", dependsOn: ["cache"])
+        ]
+        
+        let resolution = try DependencyResolver.resolve(services: services)
+        
+        #expect(resolution.startOrder == ["db", "cache", "web"])
+        #expect(resolution.stopOrder == ["web", "cache", "db"])
+        #expect(resolution.parallelGroups.count == 3)
+        #expect(resolution.parallelGroups[0] == ["db"])
+        #expect(resolution.parallelGroups[1] == ["cache"])
+        #expect(resolution.parallelGroups[2] == ["web"])
+    }
+    
+    @Test
+    func testResolveComplexDependencies() throws {
+        let services: [String: Service] = [
+            "db": Service(name: "db", image: "postgres"),
+            "cache": Service(name: "cache", image: "redis"),
+            "api1": Service(name: "api1", image: "api", dependsOn: ["db", "cache"]),
+            "api2": Service(name: "api2", image: "api", dependsOn: ["db"]),
+            "web": Service(name: "web", image: "nginx", dependsOn: ["api1", "api2"])
+        ]
+        
+        let resolution = try DependencyResolver.resolve(services: services)
+        
+        // db and cache should start first (parallel)
+        #expect(resolution.parallelGroups[0].contains("db"))
+        #expect(resolution.parallelGroups[0].contains("cache"))
+        
+        // api1 and api2 should start after their dependencies
+        let api1Index = resolution.startOrder.firstIndex(of: "api1")!
+        let api2Index = resolution.startOrder.firstIndex(of: "api2")!
+        let dbIndex = resolution.startOrder.firstIndex(of: "db")!
+        let cacheIndex = resolution.startOrder.firstIndex(of: "cache")!
+        
+        #expect(api1Index > dbIndex)
+        #expect(api1Index > cacheIndex)
+        #expect(api2Index > dbIndex)
+        
+        // web should be last
+        #expect(resolution.startOrder.last == "web")
+        #expect(resolution.stopOrder.first == "web")
+    }
+    
+    @Test
+    func testResolveCircularDependency() throws {
+        let services: [String: Service] = [
+            "a": Service(name: "a", image: "ubuntu", dependsOn: ["b"]),
+            "b": Service(name: "b", image: "ubuntu", dependsOn: ["c"]),
+            "c": Service(name: "c", image: "ubuntu", dependsOn: ["a"])
+        ]
+        
+        #expect {
+            _ = try DependencyResolver.resolve(services: services)
+        } throws: { error in
+            guard let containerError = error as? ContainerizationError else {
+                return false
+            }
+            return containerError.message.contains("Circular dependency")
+        }
+    }
+    
+    @Test
+    func testResolveMissingDependency() throws {
+        let services: [String: Service] = [
+            "web": Service(name: "web", image: "nginx", dependsOn: ["db"]),
+            "worker": Service(name: "worker", image: "worker")
+        ]
+        
+        #expect {
+            _ = try DependencyResolver.resolve(services: services)
+        } throws: { error in
+            guard let containerError = error as? ContainerizationError else {
+                return false
+            }
+            return containerError.message.contains("depends on unknown service")
+        }
+    }
+    
+    @Test
+    func testFilterWithDependencies() {
+        let services: [String: Service] = [
+            "db": Service(name: "db", image: "postgres"),
+            "cache": Service(name: "cache", image: "redis"),
+            "api": Service(name: "api", image: "api", dependsOn: ["db", "cache"]),
+            "web": Service(name: "web", image: "nginx", dependsOn: ["api"]),
+            "worker": Service(name: "worker", image: "worker", dependsOn: ["db"])
+        ]
+        
+        // Select only web - should include all its dependencies
+        let filtered = DependencyResolver.filterWithDependencies(
+            services: services,
+            selected: ["web"]
+        )
+        
+        #expect(filtered.count == 4)
+        #expect(filtered.keys.contains("web"))
+        #expect(filtered.keys.contains("api"))
+        #expect(filtered.keys.contains("db"))
+        #expect(filtered.keys.contains("cache"))
+        #expect(!filtered.keys.contains("worker"))
+    }
+    
+    @Test
+    func testFilterMultipleServices() {
+        let services: [String: Service] = [
+            "db": Service(name: "db", image: "postgres"),
+            "cache": Service(name: "cache", image: "redis"),
+            "api": Service(name: "api", image: "api", dependsOn: ["db"]),
+            "web": Service(name: "web", image: "nginx", dependsOn: ["api"]),
+            "worker": Service(name: "worker", image: "worker", dependsOn: ["cache"])
+        ]
+        
+        // Select web and worker
+        let filtered = DependencyResolver.filterWithDependencies(
+            services: services,
+            selected: ["web", "worker"]
+        )
+        
+        #expect(filtered.count == 5) // All services needed
+        #expect(filtered.keys.contains("web"))
+        #expect(filtered.keys.contains("worker"))
+        #expect(filtered.keys.contains("api"))
+        #expect(filtered.keys.contains("db"))
+        #expect(filtered.keys.contains("cache"))
+    }
+}

--- a/Tests/ContainerComposeTests/HealthCheckTests.swift
+++ b/Tests/ContainerComposeTests/HealthCheckTests.swift
@@ -1,0 +1,168 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import ContainerCompose
+import ContainerizationError
+@testable import ContainerCompose
+
+final class HealthCheckTests: XCTestCase {
+    func testHealthCheckParsing() throws {
+        let yaml = """
+        version: '3'
+        services:
+          web:
+            image: nginx:alpine
+            healthcheck:
+              test: ["CMD", "curl", "-f", "http://localhost"]
+              interval: 30s
+              timeout: 10s
+              retries: 3
+              start_period: 40s
+        """
+        
+        let parser = ComposeParser(log: .test)
+        let composeFile = try parser.parse(from: yaml.data(using: .utf8)!)
+        
+        XCTAssertNotNil(composeFile.services["web"]?.healthcheck)
+        let healthcheck = composeFile.services["web"]!.healthcheck!
+        
+        XCTAssertEqual(healthcheck.test, .list(["CMD", "curl", "-f", "http://localhost"]))
+        XCTAssertEqual(healthcheck.interval, "30s")
+        XCTAssertEqual(healthcheck.timeout, "10s")
+        XCTAssertEqual(healthcheck.retries, 3)
+        XCTAssertEqual(healthcheck.startPeriod, "40s")
+    }
+    
+    func testHealthCheckStringFormat() throws {
+        let yaml = """
+        version: '3'
+        services:
+          app:
+            image: alpine
+            healthcheck:
+              test: "curl -f http://localhost || exit 1"
+        """
+        
+        let parser = ComposeParser(log: .test)
+        let composeFile = try parser.parse(from: yaml.data(using: .utf8)!)
+        
+        let healthcheck = composeFile.services["app"]!.healthcheck!
+        XCTAssertEqual(healthcheck.test, .string("curl -f http://localhost || exit 1"))
+    }
+    
+    func testHealthCheckDisabled() throws {
+        let yaml = """
+        version: '3'
+        services:
+          db:
+            image: postgres
+            healthcheck:
+              disable: true
+        """
+        
+        let parser = ComposeParser(log: .test)
+        let composeFile = try parser.parse(from: yaml.data(using: .utf8)!)
+        
+        let healthcheck = composeFile.services["db"]!.healthcheck!
+        XCTAssertTrue(healthcheck.disable ?? false)
+    }
+    
+    func testProjectConverterHealthCheck() throws {
+        let yaml = """
+        version: '3'
+        services:
+          web:
+            image: nginx
+            healthcheck:
+              test: ["CMD", "wget", "-q", "--spider", "http://localhost"]
+              interval: 30s
+              timeout: 5s
+              retries: 3
+              start_period: 10s
+        """
+        
+        let parser = ComposeParser(log: .test)
+        let composeFile = try parser.parse(from: yaml.data(using: .utf8)!)
+        
+        let converter = ProjectConverter(log: .test)
+        let project = try converter.convert(
+            composeFile: composeFile,
+            projectName: "test",
+            workingDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        
+        let service = project.services["web"]!
+        XCTAssertNotNil(service.healthCheck)
+        
+        let healthCheck = service.healthCheck!
+        XCTAssertEqual(healthCheck.test, ["CMD", "wget", "-q", "--spider", "http://localhost"])
+        XCTAssertEqual(healthCheck.interval, 30)
+        XCTAssertEqual(healthCheck.timeout, 5)
+        XCTAssertEqual(healthCheck.retries, 3)
+        XCTAssertEqual(healthCheck.startPeriod, 10)
+    }
+    
+    func testHealthCheckWithShellFormat() throws {
+        let yaml = """
+        version: '3'
+        services:
+          api:
+            image: node:alpine
+            healthcheck:
+              test: ["CMD-SHELL", "curl -f http://localhost:3000/health || exit 1"]
+              interval: 10s
+        """
+        
+        let parser = ComposeParser(log: .test)
+        let composeFile = try parser.parse(from: yaml.data(using: .utf8)!)
+        
+        let converter = ProjectConverter(log: .test)
+        let project = try converter.convert(
+            composeFile: composeFile,
+            projectName: "test",
+            workingDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        
+        let healthCheck = project.services["api"]!.healthCheck!
+        // CMD-SHELL should be converted to shell command
+        XCTAssertEqual(healthCheck.test, ["/bin/sh", "-c", "curl -f http://localhost:3000/health || exit 1"])
+    }
+    
+    func testHealthCheckNoneDisabled() throws {
+        let yaml = """
+        version: '3'
+        services:
+          worker:
+            image: busybox
+            healthcheck:
+              test: ["NONE"]
+        """
+        
+        let parser = ComposeParser(log: .test)
+        let composeFile = try parser.parse(from: yaml.data(using: .utf8)!)
+        
+        let converter = ProjectConverter(log: .test)
+        let project = try converter.convert(
+            composeFile: composeFile,
+            projectName: "test",
+            workingDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        
+        // NONE should result in no health check
+        XCTAssertNil(project.services["worker"]!.healthCheck)
+    }
+}

--- a/Tests/ContainerComposeTests/ProjectConverterTests.swift
+++ b/Tests/ContainerComposeTests/ProjectConverterTests.swift
@@ -1,0 +1,213 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+import Logging
+
+@testable import ContainerCompose
+
+struct ProjectConverterTests {
+    let log = Logger(label: "test")
+    
+    @Test
+    func testConvertBasicProject() throws {
+        let yaml = """
+        version: '3'
+        services:
+          web:
+            image: nginx:latest
+            ports:
+              - "8080:80"
+        """
+        
+        let parser = ComposeParser(log: log)
+        let data = yaml.data(using: .utf8)!
+        let composeFile = try parser.parse(from: data)
+        
+        let converter = ProjectConverter(log: log)
+        let project = try converter.convert(
+            composeFile: composeFile,
+            projectName: "myapp"
+        )
+        
+        #expect(project.name == "myapp")
+        #expect(project.services.count == 1)
+        #expect(project.services["web"] != nil)
+        
+        let webService = project.services["web"]!
+        #expect(webService.name == "web")
+        #expect(webService.image == "nginx:latest")
+        #expect(webService.containerName == "myapp_web")
+    }
+    
+    @Test
+    func testConvertWithProfiles() throws {
+        let yaml = """
+        version: '3.9'
+        services:
+          web:
+            image: nginx
+            profiles: ["frontend"]
+          api:
+            image: api:latest
+            profiles: ["backend", "api"]
+          db:
+            image: postgres
+        """
+        
+        let parser = ComposeParser(log: log)
+        let data = yaml.data(using: .utf8)!
+        let composeFile = try parser.parse(from: data)
+        let converter = ProjectConverter(log: log)
+        
+        // No profiles - only services without profiles
+        let project1 = try converter.convert(
+            composeFile: composeFile,
+            projectName: "myapp",
+            profiles: []
+        )
+        #expect(project1.services.count == 1)
+        #expect(project1.services.keys.contains("db"))
+        
+        // Frontend profile
+        let project2 = try converter.convert(
+            composeFile: composeFile,
+            projectName: "myapp",
+            profiles: ["frontend"]
+        )
+        #expect(project2.services.count == 2)
+        #expect(project2.services.keys.contains("db"))
+        #expect(project2.services.keys.contains("web"))
+        
+        // Backend profile
+        let project3 = try converter.convert(
+            composeFile: composeFile,
+            projectName: "myapp",
+            profiles: ["backend"]
+        )
+        #expect(project3.services.count == 2)
+        #expect(project3.services.keys.contains("db"))
+        #expect(project3.services.keys.contains("api"))
+    }
+    
+    @Test
+    func testConvertEnvironment() throws {
+        let yaml = """
+        version: '3'
+        services:
+          app:
+            image: ubuntu
+            environment:
+              KEY1: value1
+              KEY2: value2
+        """
+        
+        let parser = ComposeParser(log: log)
+        let data = yaml.data(using: .utf8)!
+        let composeFile = try parser.parse(from: data)
+        
+        let converter = ProjectConverter(log: log)
+        let project = try converter.convert(
+            composeFile: composeFile,
+            projectName: "myapp"
+        )
+        
+        let env = project.services["app"]?.environment ?? [:]
+        #expect(env["KEY1"] == "value1")
+        #expect(env["KEY2"] == "value2")
+    }
+    
+    @Test
+    func testConvertVolumes() throws {
+        let yaml = """
+        version: '3'
+        services:
+          app:
+            image: ubuntu
+            volumes:
+              - /host/path:/container/path
+              - /host/path2:/container/path2:ro
+              - /data:/tmp
+        """
+        
+        let parser = ComposeParser(log: log)
+        let data = yaml.data(using: .utf8)!
+        let composeFile = try parser.parse(from: data)
+        
+        let converter = ProjectConverter(log: log)
+        let project = try converter.convert(
+            composeFile: composeFile,
+            projectName: "myapp"
+        )
+        
+        let volumes = project.services["app"]?.volumes ?? []
+        #expect(volumes.count == 3)
+        
+        // Check first volume
+        let vol1 = volumes[0]
+        #expect(vol1.source == "/host/path")
+        #expect(vol1.target == "/container/path")
+        
+        // Check second volume
+        let vol2 = volumes[1]
+        #expect(vol2.source == "/host/path2")
+        #expect(vol2.target == "/container/path2")
+        #expect(vol2.readOnly == true)
+        
+        // Check third volume
+        let vol3 = volumes[2]
+        #expect(vol3.source == "/data")
+        #expect(vol3.target == "/tmp")
+    }
+    
+    @Test
+    func testConvertPorts() throws {
+        let yaml = """
+        version: '3'
+        services:
+          web:
+            image: nginx
+            ports:
+              - "127.0.0.1:8080:80/tcp"
+              - "8443:443"
+        """
+        
+        let parser = ComposeParser(log: log)
+        let data = yaml.data(using: .utf8)!
+        let composeFile = try parser.parse(from: data)
+        
+        let converter = ProjectConverter(log: log)
+        let project = try converter.convert(
+            composeFile: composeFile,
+            projectName: "myapp"
+        )
+        
+        let ports = project.services["web"]?.ports ?? []
+        #expect(ports.count == 2)
+        
+        let port1 = ports[0]
+        #expect(port1.hostIP == "127.0.0.1")
+        #expect(port1.hostPort == "8080")
+        #expect(port1.containerPort == "80")
+        #expect(port1.portProtocol == "tcp")
+        
+        let port2 = ports[1]
+        #expect(port2.hostIP == nil)
+        #expect(port2.hostPort == "8443")
+        #expect(port2.containerPort == "443")
+    }
+}

--- a/Tests/ContainerComposeTests/VolumeParsingTests.swift
+++ b/Tests/ContainerComposeTests/VolumeParsingTests.swift
@@ -1,0 +1,104 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import ContainerCompose
+@testable import ContainerCompose
+
+final class VolumeParsingTests: XCTestCase {
+    
+    func testEmptyVolumeDefinition() throws {
+        // Test case for volumes defined with empty values (e.g., "postgres-data:")
+        let yaml = """
+        version: '3'
+        services:
+          db:
+            image: postgres
+            volumes:
+              - postgres-data:/var/lib/postgresql/data
+        volumes:
+          postgres-data:
+          redis-data:
+        """
+        
+        let parser = ComposeParser(log: .test)
+        let composeFile = try parser.parse(from: yaml.data(using: .utf8)!)
+        
+        XCTAssertNotNil(composeFile.volumes)
+        XCTAssertEqual(composeFile.volumes?.count, 2)
+        
+        // Check that empty volume definitions are parsed correctly
+        let postgresVolume = composeFile.volumes?["postgres-data"]
+        XCTAssertNotNil(postgresVolume)
+        XCTAssertNil(postgresVolume?.driver)
+        XCTAssertNil(postgresVolume?.external)
+        XCTAssertNil(postgresVolume?.name)
+        
+        let redisVolume = composeFile.volumes?["redis-data"]
+        XCTAssertNotNil(redisVolume)
+        XCTAssertNil(redisVolume?.driver)
+        XCTAssertNil(redisVolume?.external)
+        XCTAssertNil(redisVolume?.name)
+    }
+    
+    func testVolumeWithProperties() throws {
+        let yaml = """
+        version: '3'
+        services:
+          db:
+            image: postgres
+            volumes:
+              - data:/var/lib/postgresql/data
+        volumes:
+          data:
+            driver: local
+            name: my-data-volume
+        """
+        
+        let parser = ComposeParser(log: .test)
+        let composeFile = try parser.parse(from: yaml.data(using: .utf8)!)
+        
+        XCTAssertNotNil(composeFile.volumes)
+        XCTAssertEqual(composeFile.volumes?.count, 1)
+        
+        let dataVolume = composeFile.volumes?["data"]
+        XCTAssertNotNil(dataVolume)
+        XCTAssertEqual(dataVolume?.driver, "local")
+        XCTAssertEqual(dataVolume?.name, "my-data-volume")
+        XCTAssertNil(dataVolume?.external)
+    }
+    
+    func testExternalVolume() throws {
+        let yaml = """
+        version: '3'
+        services:
+          app:
+            image: myapp
+            volumes:
+              - external-vol:/data
+        volumes:
+          external-vol:
+            external: true
+        """
+        
+        let parser = ComposeParser(log: .test)
+        let composeFile = try parser.parse(from: yaml.data(using: .utf8)!)
+        
+        let externalVolume = composeFile.volumes?["external-vol"]
+        XCTAssertNotNil(externalVolume)
+        XCTAssertNotNil(externalVolume?.external)
+    }
+}


### PR DESCRIPTION
Container Compose brings the convenience of docker-compose to Apple Container, enabling the user to:
- Define multi-container applications in a single YAML file
- Manage service dependencies automatically
- Start, stop, and manage entire application stacks with simple commands
- Use environment variable interpolation for flexible configurations

Not all features of the docker compose tool are supported due to limitations of the Apple Container system.

