### PR TITLE
Add a new line to task descriptions

### DIFF
--- a/Sources/TerminalProgress/ProgressBar.swift
+++ b/Sources/TerminalProgress/ProgressBar.swift
@@ -68,9 +68,9 @@ public final class ProgressBar: Sendable {
         let (description, subDescription) = state.withLock { ($0.description, $0.subDescription) }
 
         if subDescription != "" {
-            standardError.write("\(description) \(subDescription)")
+            standardError.write("\(description) \(subDescription)\n")
         } else {
-            standardError.write(description)
+            standardError.write("\(description)\n")
         }
     }
 


### PR DESCRIPTION
At some point, we lost a new line in task descriptions printed with the `--disable-progress-updates` option:

```
% bin/container run -it --rm --disable-progress-updates alpine:latest date
Mon Aug  4 18:11:34 UTC 2025eFetching kernelFetching init imageUnpacking init imageStarting container
```

With this change, we'll get the correct output:

```
% bin/container run -it --rm --disable-progress-updates alpine:latest date
Fetching image
Unpacking image
Fetching kernel
Fetching init image
Unpacking init image
Starting container
Mon Aug  4 18:15:57 UTC 2025
```

Resolves https://github.com/apple/container/issues/396.