### PR TITLE
Fixes for install root and plugin detection.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -223,11 +223,11 @@ let package = Package(
                 .product(name: "ContainerizationOCI", package: "containerization"),
                 .product(name: "ContainerizationOS", package: "containerization"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                "ContainerNetworkService",
-                "ContainerPersistence",
                 "ContainerImagesServiceClient",
-                "TerminalProgress",
+                "ContainerNetworkService",
+                "ContainerPlugin",
                 "ContainerXPC",
+                "TerminalProgress",
             ]
         ),
         .testTarget(

--- a/Sources/APIServer/HealthCheck/HealthCheckHarness.swift
+++ b/Sources/APIServer/HealthCheck/HealthCheckHarness.swift
@@ -23,10 +23,12 @@ import Logging
 
 actor HealthCheckHarness {
     private let appRoot: URL
+    private let installRoot: URL
     private let log: Logger
 
-    public init(appRoot: URL, log: Logger) {
+    public init(appRoot: URL, installRoot: URL, log: Logger) {
         self.appRoot = appRoot
+        self.installRoot = installRoot
         self.log = log
     }
 
@@ -34,6 +36,7 @@ actor HealthCheckHarness {
     func ping(_ message: XPCMessage) async -> XPCMessage {
         let reply = message.reply()
         reply.set(key: .appRoot, value: appRoot.absoluteString)
+        reply.set(key: .installRoot, value: installRoot.absoluteString)
         reply.set(key: .apiServerVersion, value: APIServer.releaseVersion())
         reply.set(key: .apiServerCommit, value: get_git_commit().map { String(cString: $0) } ?? "unknown")
         return reply

--- a/Sources/CLI/Application.swift
+++ b/Sources/CLI/Application.swift
@@ -158,22 +158,19 @@ struct Application: AsyncParsableCommand {
             installRootPluginsURL,
         ].compactMap { $0 }
 
-        let pluginFactories = [
-            DefaultPluginFactory()
+        let pluginFactories: [any PluginFactory] = [
+            DefaultPluginFactory(),
+            AppBundlePluginFactory(),
         ]
 
         guard let systemHealth = try? await ClientHealthCheck.ping(timeout: .seconds(10)) else {
             throw ContainerizationError(.timeout, message: "unable to retrieve application data root from API server")
         }
-        let statePath = PluginLoader.defaultPluginResourcePath(root: systemHealth.appRoot)
-        guard (try? FileManager.default.createDirectory(at: statePath, withIntermediateDirectories: true)) != nil else {
-            throw ContainerizationError(.invalidState, message: "unable to create plugin state directory")
-        }
-        return PluginLoader(
+        return try PluginLoader(
             appRoot: systemHealth.appRoot,
+            installRoot: systemHealth.installRoot,
             pluginDirectories: pluginDirectories,
             pluginFactories: pluginFactories,
-            defaultResourcePath: statePath,
             log: log
         )
     }

--- a/Sources/CLI/System/SystemStatus.swift
+++ b/Sources/CLI/System/SystemStatus.swift
@@ -40,10 +40,10 @@ extension Application {
 
             // Now ping our friendly daemon. Fail after 10 seconds with no response.
             do {
-                print("Verifying apiserver is running...")
                 let systemHealth = try await ClientHealthCheck.ping(timeout: .seconds(10))
                 print("apiserver is running")
                 print("application data root: \(systemHealth.appRoot.path(percentEncoded: false))")
+                print("application install root: \(systemHealth.installRoot.path(percentEncoded: false))")
                 print("container-apiserver version: \(systemHealth.apiServerVersion)")
                 print("container-apiserver commit: \(systemHealth.apiServerCommit)")
             } catch {

--- a/Sources/ContainerClient/Core/ClientHealthCheck.swift
+++ b/Sources/ContainerClient/Core/ClientHealthCheck.swift
@@ -34,12 +34,15 @@ extension ClientHealthCheck {
         guard let appRootValue = reply.string(key: .appRoot), let appRoot = URL(string: appRootValue) else {
             throw ContainerizationError(.internalError, message: "failed to decode appRoot in health check")
         }
+        guard let installRootValue = reply.string(key: .installRoot), let installRoot = URL(string: installRootValue) else {
+            throw ContainerizationError(.internalError, message: "failed to decode installRoot in health check")
+        }
         guard let apiServerVersion = reply.string(key: .apiServerVersion) else {
             throw ContainerizationError(.internalError, message: "failed to decode apiServerVersion in health check")
         }
         guard let apiServerCommit = reply.string(key: .apiServerCommit) else {
             throw ContainerizationError(.internalError, message: "failed to decode apiServerCommit in health check")
         }
-        return .init(appRoot: appRoot, apiServerVersion: apiServerVersion, apiServerCommit: apiServerCommit)
+        return .init(appRoot: appRoot, installRoot: installRoot, apiServerVersion: apiServerVersion, apiServerCommit: apiServerCommit)
     }
 }

--- a/Sources/ContainerClient/Core/SystemHealth.swift
+++ b/Sources/ContainerClient/Core/SystemHealth.swift
@@ -21,6 +21,9 @@ public struct SystemHealth: Sendable, Codable {
     /// The full pathname of the application data root.
     public let appRoot: URL
 
+    /// The full pathname of the application install root.
+    public let installRoot: URL
+
     /// The release version of the container services.
     public let apiServerVersion: String
 

--- a/Sources/ContainerClient/Flags.swift
+++ b/Sources/ContainerClient/Flags.swift
@@ -15,7 +15,6 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
-import ContainerPlugin
 import ContainerizationError
 import Foundation
 

--- a/Sources/ContainerClient/Flags.swift
+++ b/Sources/ContainerClient/Flags.swift
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
+import ContainerPlugin
 import ContainerizationError
 import Foundation
 

--- a/Sources/ContainerClient/XPC+.swift
+++ b/Sources/ContainerClient/XPC+.swift
@@ -54,6 +54,7 @@ public enum XPCKeys: String {
     /// Health check request.
     case ping
     case appRoot
+    case installRoot
     case apiServerVersion
     case apiServerCommit
 

--- a/Sources/ContainerPlugin/InstallRoot.swift
+++ b/Sources/ContainerPlugin/InstallRoot.swift
@@ -16,14 +16,14 @@
 
 import Foundation
 
-/// Provides the application data root path.
-public struct ApplicationRoot {
-    public static let environmentName = "CONTAINER_APP_ROOT"
+/// Provides the application installation root path.
+public struct InstallRoot {
+    public static let environmentName = "CONTAINER_INSTALL_ROOT"
 
-    public static let defaultURL = FileManager.default.urls(
-        for: .applicationSupportDirectory,
-        in: .userDomainMask
-    ).first!.appendingPathComponent("com.apple.container")
+    public static let defaultURL = CommandLine.executablePathUrl
+        .deletingLastPathComponent()
+        .appendingPathComponent("..")
+        .standardized
 
     private static let envPath = ProcessInfo.processInfo.environment[Self.environmentName]
 

--- a/Sources/ContainerPlugin/PluginFactory.swift
+++ b/Sources/ContainerPlugin/PluginFactory.swift
@@ -22,8 +22,10 @@ private let configFilename: String = "config.json"
 
 /// Describes the configuration and binary file locations for a plugin.
 public protocol PluginFactory: Sendable {
-    /// Create a plugin conforming to the layout, if possible.
+    /// Create a plugin from the plugin path, if it conforms to the layout.
     func create(installURL: URL) throws -> Plugin?
+    /// Create a plugin from the plugin parent path and name, if it conforms to the layout.
+    func create(parentURL: URL, name: String) throws -> Plugin?
 }
 
 /// Default layout which uses a Unix-like structure.
@@ -49,6 +51,10 @@ public struct DefaultPluginFactory: PluginFactory {
         }
 
         return Plugin(binaryURL: binaryURL, config: config)
+    }
+
+    public func create(parentURL: URL, name: String) throws -> Plugin? {
+        try create(installURL: parentURL.appendingPathComponent(name))
     }
 }
 
@@ -89,5 +95,9 @@ public struct AppBundlePluginFactory: PluginFactory {
         }
 
         return Plugin(binaryURL: binaryURL, config: config)
+    }
+
+    public func create(parentURL: URL, name: String) throws -> Plugin? {
+        try create(installURL: parentURL.appendingPathComponent("\(name)\(Self.appSuffix)"))
     }
 }

--- a/Tests/ContainerPluginTests/MockPluginFactory.swift
+++ b/Tests/ContainerPluginTests/MockPluginFactory.swift
@@ -48,4 +48,13 @@ struct MockPluginFactory: PluginFactory {
         }
         return plugins[url]
     }
+
+    public func create(parentURL: URL, name: String) throws -> Plugin? {
+        let url = parentURL.appendingPathComponent(name).standardizedFileURL
+        guard url != self.throwingURL else {
+            throw MockPluginError()
+        }
+        return plugins[url]
+    }
+
 }

--- a/Tests/ContainerPluginTests/PluginLoaderTest.swift
+++ b/Tests/ContainerPluginTests/PluginLoaderTest.swift
@@ -39,6 +39,38 @@ struct PluginLoaderTest {
     }
 
     @Test
+    func testFindAllSymlink() async throws {
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+        let factory = try setupMock(tempURL: tempURL)
+
+        // move the CLI plugin elsewhere and symlink it
+        let otherTempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: otherTempURL) }
+        try FileManager.default.createDirectory(at: otherTempURL, withIntermediateDirectories: true)
+        let srcURL = tempURL.appendingPathComponent("cli")
+        let dstURL = otherTempURL.appendingPathComponent("cli")
+        try FileManager.default.moveItem(
+            at: srcURL,
+            to: dstURL
+        )
+        try FileManager.default.createSymbolicLink(
+            at: srcURL,
+            withDestinationURL: dstURL
+        )
+
+        let loader = try PluginLoader(
+            appRoot: tempURL,
+            installRoot: URL(filePath: "/usr/local/"),
+            pluginDirectories: [tempURL],
+            pluginFactories: [factory]
+        )
+        let plugins = loader.findPlugins()
+
+        #expect(Set(plugins.map { $0.name }) == Set(["cli", "service"]))
+    }
+
+    @Test
     func testFindByName() async throws {
         let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         defer { try? FileManager.default.removeItem(at: tempURL) }

--- a/Tests/ContainerPluginTests/PluginLoaderTest.swift
+++ b/Tests/ContainerPluginTests/PluginLoaderTest.swift
@@ -27,10 +27,12 @@ struct PluginLoaderTest {
         let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         defer { try? FileManager.default.removeItem(at: tempURL) }
         let factory = try setupMock(tempURL: tempURL)
-        let loader = PluginLoader(
-            appRoot: URL(filePath: "/foo"),
+        let loader = try PluginLoader(
+            appRoot: tempURL,
+            installRoot: URL(filePath: "/usr/local/"),
             pluginDirectories: [tempURL],
-            pluginFactories: [factory], defaultResourcePath: tempURL)
+            pluginFactories: [factory]
+        )
         let plugins = loader.findPlugins()
 
         #expect(Set(plugins.map { $0.name }) == Set(["cli", "service"]))
@@ -41,10 +43,11 @@ struct PluginLoaderTest {
         let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         defer { try? FileManager.default.removeItem(at: tempURL) }
         let factory = try setupMock(tempURL: tempURL)
-        let loader = PluginLoader(
-            appRoot: URL(filePath: "/foo"),
+        let loader = try PluginLoader(
+            appRoot: tempURL,
+            installRoot: URL(filePath: "/usr/local/"),
             pluginDirectories: [tempURL],
-            pluginFactories: [factory], defaultResourcePath: tempURL
+            pluginFactories: [factory]
         )
 
         #expect(loader.findPlugin(name: "cli")?.name == "cli")


### PR DESCRIPTION
- Sets up API server as source of truth for installation root, similarly to what was done for the data root. `system start` establishes the install root, setting the environment variable `CONTAINER_INSTALL_ROOT` when launching the API server.
- The API server propagates the environment variable when launching helpers, and returns the install root to the CLI via the health check XPC.
- Includes several fixes for detecting plugins that use app bundle layout.