### PR TITLE
Relocate and rename `ClientDefaults`.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -75,6 +75,7 @@ let package = Package(
                 "TerminalProgress",
                 "ContainerBuild",
                 "ContainerClient",
+                "ContainerPersistence",
                 "ContainerPlugin",
                 "ContainerLog",
             ],
@@ -123,8 +124,9 @@ let package = Package(
                 .product(name: "Containerization", package: "containerization"),
                 .product(name: "ContainerizationOS", package: "containerization"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                "ContainerNetworkService",
                 "ContainerClient",
+                "ContainerNetworkService",
+                "ContainerPersistence",
                 "ContainerXPC",
                 "SocketForwarder",
             ],
@@ -152,6 +154,7 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Containerization", package: "containerization"),
                 .product(name: "ContainerizationOS", package: "containerization"),
+                "ContainerPersistence",
                 "ContainerXPC",
             ],
             path: "Sources/Services/ContainerNetworkService"
@@ -221,10 +224,10 @@ let package = Package(
                 .product(name: "ContainerizationOS", package: "containerization"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 "ContainerNetworkService",
+                "ContainerPersistence",
                 "ContainerImagesServiceClient",
                 "TerminalProgress",
                 "ContainerXPC",
-                "CVersion",
             ]
         ),
         .testTarget(
@@ -232,6 +235,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Containerization", package: "containerization"),
                 "ContainerClient",
+                "ContainerPersistence",
             ]
         ),
         .executableTarget(
@@ -331,6 +335,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Containerization", package: "containerization"),
+                "CVersion",
             ]
         ),
         .target(

--- a/Sources/CLI/Builder/BuilderStart.swift
+++ b/Sources/CLI/Builder/BuilderStart.swift
@@ -18,6 +18,7 @@ import ArgumentParser
 import ContainerBuild
 import ContainerClient
 import ContainerNetworkService
+import ContainerPersistence
 import Containerization
 import ContainerizationError
 import ContainerizationExtras
@@ -70,7 +71,7 @@ extension Application {
             let taskManager = ProgressTaskCoordinator()
             let fetchTask = await taskManager.startTask()
 
-            let builderImage: String = ClientDefaults.get(key: .defaultBuilderImage)
+            let builderImage: String = ApplicationDefaults.get(key: .defaultBuilderImage)
             let systemHealth = try await ClientHealthCheck.ping(timeout: .seconds(10))
             let exportsMount: String = systemHealth.appRoot.appendingPathComponent(".build").absolutePath()
 
@@ -196,7 +197,7 @@ extension Application {
                 ),
             ]
             // Enable Rosetta only if the user didn't ask to disable it
-            config.rosetta = ClientDefaults.getBool(key: .buildRosetta) ?? true
+            config.rosetta = ApplicationDefaults.getBool(key: .buildRosetta) ?? true
 
             let network = try await ClientNetwork.get(id: ClientNetwork.defaultNetworkName)
             guard case .running(_, let networkStatus) = network else {

--- a/Sources/CLI/Registry/RegistryDefault.swift
+++ b/Sources/CLI/Registry/RegistryDefault.swift
@@ -16,6 +16,7 @@
 
 import ArgumentParser
 import ContainerClient
+import ContainerPersistence
 import ContainerizationError
 import ContainerizationOCI
 import Foundation
@@ -67,7 +68,7 @@ extension Application {
                     throw err
                 }
             }
-            ClientDefaults.set(value: host, key: .defaultRegistryDomain)
+            ApplicationDefaults.set(value: host, key: .defaultRegistryDomain)
             print("Set default registry to \(host)")
         }
     }
@@ -80,7 +81,7 @@ extension Application {
         )
 
         func run() async throws {
-            ClientDefaults.unset(key: .defaultRegistryDomain)
+            ApplicationDefaults.unset(key: .defaultRegistryDomain)
             print("Unset the default registry domain")
         }
     }
@@ -92,7 +93,7 @@ extension Application {
         )
 
         func run() async throws {
-            print(ClientDefaults.get(key: .defaultRegistryDomain))
+            print(ApplicationDefaults.get(key: .defaultRegistryDomain))
         }
     }
 }

--- a/Sources/CLI/System/DNS/DNSDefault.swift
+++ b/Sources/CLI/System/DNS/DNSDefault.swift
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
-import ContainerClient
+import ContainerPersistence
 
 extension Application {
     struct DNSDefault: AsyncParsableCommand {
@@ -40,7 +40,7 @@ extension Application {
             var domainName: String
 
             func run() async throws {
-                ClientDefaults.set(value: domainName, key: .defaultDNSDomain)
+                ApplicationDefaults.set(value: domainName, key: .defaultDNSDomain)
                 print(domainName)
             }
         }
@@ -53,7 +53,7 @@ extension Application {
             )
 
             func run() async throws {
-                ClientDefaults.unset(key: .defaultDNSDomain)
+                ApplicationDefaults.unset(key: .defaultDNSDomain)
                 print("Unset the default local DNS domain")
             }
         }
@@ -65,7 +65,7 @@ extension Application {
             )
 
             func run() async throws {
-                print(ClientDefaults.getOptional(key: .defaultDNSDomain) ?? "")
+                print(ApplicationDefaults.getOptional(key: .defaultDNSDomain) ?? "")
             }
         }
     }

--- a/Sources/CLI/System/Kernel/KernelSet.swift
+++ b/Sources/CLI/System/Kernel/KernelSet.swift
@@ -16,6 +16,7 @@
 
 import ArgumentParser
 import ContainerClient
+import ContainerPersistence
 import Containerization
 import ContainerizationError
 import ContainerizationExtras
@@ -44,8 +45,8 @@ extension Application {
 
         func run() async throws {
             if recommended {
-                let url = ClientDefaults.get(key: .defaultKernelURL)
-                let path = ClientDefaults.get(key: .defaultKernelBinaryPath)
+                let url = ApplicationDefaults.get(key: .defaultKernelURL)
+                let path = ApplicationDefaults.get(key: .defaultKernelBinaryPath)
                 print("Installing the recommended kernel from \(url)...")
                 try await Self.downloadAndInstallWithProgressBar(tarRemoteURL: url, kernelFilePath: path)
                 return

--- a/Sources/CLI/System/SystemStart.swift
+++ b/Sources/CLI/System/SystemStart.swift
@@ -16,6 +16,7 @@
 
 import ArgumentParser
 import ContainerClient
+import ContainerPersistence
 import ContainerPlugin
 import ContainerizationError
 import Foundation
@@ -118,7 +119,7 @@ extension Application {
         private func installDefaultKernel() async throws {
             let kernelDependency = Dependencies.kernel
             let defaultKernelURL = kernelDependency.source
-            let defaultKernelBinaryPath = ClientDefaults.get(key: .defaultKernelBinaryPath)
+            let defaultKernelBinaryPath = ApplicationDefaults.get(key: .defaultKernelBinaryPath)
 
             var shouldInstallKernel = false
             if kernelInstall == nil {
@@ -169,9 +170,9 @@ extension Application {
         var source: String {
             switch self {
             case .initFs:
-                return ClientDefaults.get(key: .defaultInitImage)
+                return ApplicationDefaults.get(key: .defaultInitImage)
             case .kernel:
-                return ClientDefaults.get(key: .defaultKernelURL)
+                return ApplicationDefaults.get(key: .defaultKernelURL)
             }
         }
     }

--- a/Sources/ContainerClient/Core/ClientImage.swift
+++ b/Sources/ContainerClient/Core/ClientImage.swift
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import ContainerImagesServiceClient
+import ContainerPersistence
 import ContainerXPC
 import Containerization
 import ContainerizationError
@@ -93,7 +94,7 @@ public struct ClientImage: Sendable {
 
 extension ClientImage {
     private static let serviceIdentifier = "com.apple.container.core.container-core-images"
-    public static let initImageRef = ClientDefaults.get(key: .defaultInitImage)
+    public static let initImageRef = ApplicationDefaults.get(key: .defaultInitImage)
 
     private static func newXPCClient() -> XPCClient {
         XPCClient(service: Self.serviceIdentifier)
@@ -104,7 +105,7 @@ extension ClientImage {
     }
 
     private static var defaultRegistryDomain: String {
-        ClientDefaults.get(key: .defaultRegistryDomain)
+        ApplicationDefaults.get(key: .defaultRegistryDomain)
     }
 }
 

--- a/Sources/ContainerClient/RequestScheme.swift
+++ b/Sources/ContainerClient/RequestScheme.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerPersistence
 import ContainerizationError
 
 /// The URL scheme to be used for a HTTP request.
@@ -64,7 +65,7 @@ public enum RequestScheme: String, Sendable {
         if host.range(of: regex, options: .regularExpression) != nil {
             return true
         }
-        let dnsDomain = ClientDefaults.get(key: .defaultDNSDomain)
+        let dnsDomain = ApplicationDefaults.get(key: .defaultDNSDomain)
         if host.hasSuffix(".\(dnsDomain)") {
             return true
         }

--- a/Sources/ContainerClient/Utility.swift
+++ b/Sources/ContainerClient/Utility.swift
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import ContainerNetworkService
+import ContainerPersistence
 import Containerization
 import ContainerizationError
 import ContainerizationExtras
@@ -24,8 +25,8 @@ import TerminalProgress
 
 public struct Utility {
     private static let infraImages = [
-        ClientDefaults.get(key: .defaultBuilderImage),
-        ClientDefaults.get(key: .defaultInitImage),
+        ApplicationDefaults.get(key: .defaultBuilderImage),
+        ApplicationDefaults.get(key: .defaultInitImage),
     ]
 
     public static func createContainerID(name: String?) -> String {
@@ -198,7 +199,7 @@ public struct Utility {
         if management.dnsDisabled {
             config.dns = nil
         } else {
-            let domain = management.dnsDomain ?? ClientDefaults.getOptional(key: .defaultDNSDomain)
+            let domain = management.dnsDomain ?? ApplicationDefaults.getOptional(key: .defaultDNSDomain)
             config.dns = .init(
                 nameservers: management.dnsNameservers,
                 domain: domain,

--- a/Sources/ContainerPersistence/ApplicationDefaults.swift
+++ b/Sources/ContainerPersistence/ApplicationDefaults.swift
@@ -18,7 +18,7 @@ import CVersion
 import ContainerizationError
 import Foundation
 
-public enum ClientDefaults {
+public enum ApplicationDefaults {
     private static let userDefaultDomain = "com.apple.container.defaults"
 
     public enum Keys: String {
@@ -31,28 +31,28 @@ public enum ClientDefaults {
         case buildRosetta = "build.rosetta"
     }
 
-    public static func set(value: String, key: ClientDefaults.Keys) {
+    public static func set(value: String, key: ApplicationDefaults.Keys) {
         udSuite.set(value, forKey: key.rawValue)
     }
 
-    public static func unset(key: ClientDefaults.Keys) {
+    public static func unset(key: ApplicationDefaults.Keys) {
         udSuite.removeObject(forKey: key.rawValue)
     }
 
-    public static func get(key: ClientDefaults.Keys) -> String {
+    public static func get(key: ApplicationDefaults.Keys) -> String {
         let current = udSuite.string(forKey: key.rawValue)
         return current ?? key.defaultValue
     }
 
-    public static func getOptional(key: ClientDefaults.Keys) -> String? {
+    public static func getOptional(key: ApplicationDefaults.Keys) -> String? {
         udSuite.string(forKey: key.rawValue)
     }
 
-    public static func setBool(value: Bool, key: ClientDefaults.Keys) {
+    public static func setBool(value: Bool, key: ApplicationDefaults.Keys) {
         udSuite.set(value, forKey: key.rawValue)
     }
 
-    public static func getBool(key: ClientDefaults.Keys) -> Bool? {
+    public static func getBool(key: ApplicationDefaults.Keys) -> Bool? {
         guard udSuite.object(forKey: key.rawValue) != nil else { return nil }
         return udSuite.bool(forKey: key.rawValue)
     }
@@ -65,7 +65,7 @@ public enum ClientDefaults {
     }
 }
 
-extension ClientDefaults.Keys {
+extension ApplicationDefaults.Keys {
     fileprivate var defaultValue: String {
         switch self {
         case .defaultKernelURL:

--- a/Sources/Services/ContainerImagesService/Server/SnapshotStore.swift
+++ b/Sources/Services/ContainerImagesService/Server/SnapshotStore.swift
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import ContainerClient
+import ContainerPersistence
 import Containerization
 import ContainerizationError
 import ContainerizationExtras
@@ -38,7 +39,7 @@ public actor SnapshotStore {
             return nil
         }
         var minBlockSize = 512.gib()
-        if image.reference == ClientDefaults.get(key: .defaultInitImage) {
+        if image.reference == ApplicationDefaults.get(key: .defaultInitImage) {
             minBlockSize = 512.mib()
         }
         return EXT4Unpacker(blockSizeInBytes: minBlockSize)

--- a/Sources/Services/ContainerNetworkService/AllocationOnlyVmnetNetwork.swift
+++ b/Sources/Services/ContainerNetworkService/AllocationOnlyVmnetNetwork.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerPersistence
 import ContainerXPC
 import ContainerizationError
 import ContainerizationExtras
@@ -65,7 +66,7 @@ public actor AllocationOnlyVmnetNetwork: Network {
         )
 
         if let suite = UserDefaults.init(suiteName: UserDefaults.appSuiteName) {
-            // TODO: Make the suiteName a constant defined in ClientDefaults and use that.
+            // TODO: Make the suiteName a constant defined in ApplicationDefaults and use that.
             // This will need some re-working of dependencies between NetworkService and Client
             defaultSubnet = suite.string(forKey: "network.subnet") ?? defaultSubnet
         }

--- a/Sources/Services/ContainerSandboxService/SandboxService.swift
+++ b/Sources/Services/ContainerSandboxService/SandboxService.swift
@@ -18,6 +18,7 @@
 
 import ContainerClient
 import ContainerNetworkService
+import ContainerPersistence
 import ContainerXPC
 import Containerization
 import ContainerizationError
@@ -109,7 +110,7 @@ public actor SandboxService {
                     let dnsDomain = suite.string(forKey: "dns.domain"),
                     !hostname.contains(".")
                 {
-                    // TODO: Make the suiteName a constant defined in ClientDefaults and use that.
+                    // TODO: Make the suiteName a constant defined in ApplicationDefaults and use that.
                     // This will need some re-working of dependencies between SandboxService and Client
                     fqdn = "\(hostname).\(dnsDomain)."
                 } else {

--- a/Tests/ContainerClientTests/RequestSchemeTests.swift
+++ b/Tests/ContainerClientTests/RequestSchemeTests.swift
@@ -16,6 +16,7 @@
 
 //
 
+import ContainerPersistence
 import ContainerizationError
 import Foundation
 import Testing
@@ -23,7 +24,7 @@ import Testing
 @testable import ContainerClient
 
 struct RequestSchemeTests {
-    static let defaultDnsDomain = ClientDefaults.get(key: .defaultDNSDomain)
+    static let defaultDnsDomain = ApplicationDefaults.get(key: .defaultDNSDomain)
 
     internal struct TestArg {
         let scheme: String


### PR DESCRIPTION
- Part of #384.
- Rename to reflect that these are not just client defaults.
- Relocate so callers don't need the heavyweight coupling to ContainerClient to access the type.