### PR TITLE
CLI: Defer tty reset immediately

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -240,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "fd6373fad9cf3b3bc4e3c06d92f0cfd60007fa8e",
-        "version" : "602.0.0-prerelease-2025-06-26"
+        "revision" : "21b3b45635decd1a0b89968f81b6d9a93128f773",
+        "version" : "602.0.0-prerelease-2025-08-11"
       }
     },
     {

--- a/Sources/CLI/Application.swift
+++ b/Sources/CLI/Application.swift
@@ -190,9 +190,6 @@ struct Application: AsyncParsableCommand {
             }
 
             try await process.start()
-            defer {
-                try? io.close()
-            }
             try io.closeAfterStart()
 
             if let current = io.console {

--- a/Sources/CLI/Container/ContainerExec.swift
+++ b/Sources/CLI/Container/ContainerExec.swift
@@ -70,6 +70,9 @@ extension Application {
 
             do {
                 let io = try ProcessIO.create(tty: tty, interactive: stdin, detach: false)
+                defer {
+                    try? io.close()
+                }
 
                 if !self.processFlags.tty {
                     var handler = SignalThreshold(threshold: 3, signals: [SIGINT, SIGTERM])

--- a/Sources/CLI/Container/ContainerStart.swift
+++ b/Sources/CLI/Container/ContainerStart.swift
@@ -58,15 +58,15 @@ extension Application {
                     interactive: self.interactive,
                     detach: detach
                 )
+                defer {
+                    try? io.close()
+                }
 
                 let process = try await container.bootstrap(stdio: io.stdio)
                 progress.finish()
 
                 if detach {
                     try await process.start()
-                    defer {
-                        try? io.close()
-                    }
                     try io.closeAfterStart()
                     print(self.containerID)
                     return

--- a/Sources/CLI/RunCommand.swift
+++ b/Sources/CLI/RunCommand.swift
@@ -116,6 +116,9 @@ extension Application {
                     interactive: self.processFlags.interactive,
                     detach: detach
                 )
+                defer {
+                    try? io.close()
+                }
 
                 let process = try await container.bootstrap(stdio: io.stdio)
                 progress.finish()
@@ -138,9 +141,6 @@ extension Application {
 
                 if detach {
                     try await process.start()
-                    defer {
-                        try? io.close()
-                    }
                     try io.closeAfterStart()
                     print(id)
                     return


### PR DESCRIPTION
We were defer closing the IO for run/exec/start fairly late in the container run cycle which had the downside of that if the container run failed your tty would be stuck in raw mode. This change just moves the closing (return tty to origin state) to directly after we create the IO.