### PR TITLE
Allow traversing symlink when checking for builtin plugins.

### DIFF
--- a/Sources/ContainerPlugin/PluginLoader.swift
+++ b/Sources/ContainerPlugin/PluginLoader.swift
@@ -97,9 +97,10 @@ extension PluginLoader {
             }
 
             // Get all entries under the parent directory
+            let resolvedPluginDir = pluginDir.resolvingSymlinksInPath()
             guard
                 let urls = try? fm.contentsOfDirectory(
-                    at: pluginDir,
+                    at: resolvedPluginDir,
                     includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
                     options: .skipsHiddenFiles
                 )


### PR DESCRIPTION
- This helps with brew cask packaging, can postflight link libexec/container/plugins to the appropriate cask location, and the plugin discovery will traverse the link.