### PR TITLE
Native Builder: Add parser support for ENTRYPOINT instruction

### DIFF
--- a/Sources/NativeBuilder/ContainerBuildParser/Docker/DockerInstructionVisitor.swift
+++ b/Sources/NativeBuilder/ContainerBuildParser/Docker/DockerInstructionVisitor.swift
@@ -23,6 +23,7 @@ protocol InstructionVisitor {
     func visit(_ cmd: CMDInstruction) throws
     func visit(_ label: LabelInstruction) throws
     func visit(_ expose: ExposeInstruction) throws
+    func visit(_ entrypoint: EntrypointInstruction) throws
 }
 
 /// DockerInstructionVisitor visits each provided DockerInstruction and builds a
@@ -150,5 +151,9 @@ extension DockerInstructionVisitor {
 
     func visit(_ expose: ExposeInstruction) throws {
         try graphBuilder.expose(expose.ports)
+    }
+
+    func visit(_ entrypoint: EntrypointInstruction) throws {
+        try graphBuilder.entrypoint(entrypoint.command)
     }
 }

--- a/Sources/NativeBuilder/ContainerBuildParser/Docker/DockerfileParser.swift
+++ b/Sources/NativeBuilder/ContainerBuildParser/Docker/DockerfileParser.swift
@@ -71,6 +71,8 @@ public struct DockerfileParser: BuildParser {
             return try tokensToLabelInstruction(tokens: tokens)
         case .EXPOSE:
             return try tokensToExposeInstruction(tokens: tokens)
+        case .ENTRYPOINT:
+            return try tokensToEntrypointInstruction(tokens: tokens)
         default:
             throw ParseError.invalidInstruction(value)
         }
@@ -362,5 +364,18 @@ public struct DockerfileParser: BuildParser {
         }
 
         return try ExposeInstruction(rawPorts)
+    }
+
+    internal func tokensToEntrypointInstruction(tokens: [Token]) throws -> EntrypointInstruction {
+        var index = tokens.startIndex + 1  // skip the instruction
+
+        let (newIndex, cmd) = getCommand(start: index, tokens: tokens)
+        index = newIndex
+
+        if index < tokens.endIndex {
+            throw ParseError.unexpectedValue
+        }
+
+        return EntrypointInstruction(command: cmd)
     }
 }

--- a/Sources/NativeBuilder/ContainerBuildParser/Docker/Instructions/DockerInstruction.swift
+++ b/Sources/NativeBuilder/ContainerBuildParser/Docker/Instructions/DockerInstruction.swift
@@ -59,6 +59,7 @@ enum DockerInstructionName: String {
     case CMD = "cmd"
     case LABEL = "label"
     case EXPOSE = "expose"
+    case ENTRYPOINT = "entrypoint"
 }
 
 /// DockerKeyword defines words that are used as keywords within a line of a dockerfile
@@ -77,6 +78,14 @@ struct CMDInstruction: DockerInstruction {
 
 struct LabelInstruction: DockerInstruction {
     let labels: [String: String]
+    func accept(_ visitor: DockerInstructionVisitor) throws {
+        try visitor.visit(self)
+    }
+}
+
+struct EntrypointInstruction: DockerInstruction {
+    let command: Command
+
     func accept(_ visitor: DockerInstructionVisitor) throws {
         try visitor.visit(self)
     }

--- a/Tests/NativeBuilderTests/ContainerBuildParserTests/ParserTests.swift
+++ b/Tests/NativeBuilderTests/ContainerBuildParserTests/ParserTests.swift
@@ -244,6 +244,62 @@ import Testing
             return
         }
     }
+
+    @Test func testSimpleDockerfileEntrypointShell() throws {
+        let dockerfile =
+            #"""
+            FROM alpine:latest AS build
+
+            ENTRYPOINT ./entrypoint.sh --verbose
+            """#
+        let parser = DockerfileParser()
+        let actualGraph = try parser.parse(dockerfile)
+
+        #expect(!actualGraph.stages.isEmpty)
+
+        let stages = actualGraph.stages
+        #expect(stages.count == 1, "expected 1 stage, instead got \(actualGraph.stages.count)")
+
+        let stage = stages[0]
+        #expect(stage.nodes.count == 1, "expected 1 node, instead got \(stage.nodes.count)")
+
+        let entrypoint = stage.nodes[0].operation as! MetadataOperation
+        switch entrypoint.action {
+        case .setEntrypoint(let command):
+            #expect(command.displayString == "./entrypoint.sh --verbose")
+        default:
+            Issue.record("expected .setEntrypoint action type, instead got \(entrypoint.action)")
+            return
+        }
+    }
+
+    @Test func testSimpleDockerfileEntrypointExec() throws {
+        let dockerfile =
+            #"""
+            FROM alpine:latest AS build
+
+            ENTRYPOINT ["./entrypoint.sh", "--verbose"]
+            """#
+        let parser = DockerfileParser()
+        let actualGraph = try parser.parse(dockerfile)
+
+        #expect(!actualGraph.stages.isEmpty)
+
+        let stages = actualGraph.stages
+        #expect(stages.count == 1, "expected 1 stage, instead got \(actualGraph.stages.count)")
+
+        let stage = stages[0]
+        #expect(stage.nodes.count == 1, "expected 1 node, instead got \(stage.nodes.count)")
+
+        let entrypoint = stage.nodes[0].operation as! MetadataOperation
+        switch entrypoint.action {
+        case .setEntrypoint(let command):
+            #expect(command.displayString == "./entrypoint.sh --verbose")
+        default:
+            Issue.record("expected .setEntrypoint action type, instead got \(entrypoint.action)")
+            return
+        }
+    }
 }
 
 // tests for parsing options for the different instructions


### PR DESCRIPTION
Closes #433 

This PR adds support for ENTRYPOINT instruction in the native builder's parser.