### PR TITLE
CLI: Timeout if container.stop doesn't return in time

### DIFF
--- a/Sources/CLI/System/SystemStop.swift
+++ b/Sources/CLI/System/SystemStop.swift
@@ -54,7 +54,6 @@ extension Application {
                 if !failed.isEmpty {
                     log.warning("some containers could not be stopped gracefully", metadata: ["ids": "\(failed)"])
                 }
-
             } catch {
                 log.warning("failed to stop all containers", metadata: ["error": "\(error)"])
             }


### PR DESCRIPTION
There's been bugs during dev where stop is hosed for one reason or another. To be safe as most folks will likely run `system stop` as a destructive "turn it off and on again" toggle, let's ensure we always make forward progress if something in stop is awry.