### PR TITLE
ContainerService: Move force delete logic to daemon

### DIFF
--- a/Sources/APIServer/Containers/ContainersHarness.swift
+++ b/Sources/APIServer/Containers/ContainersHarness.swift
@@ -69,7 +69,8 @@ struct ContainersHarness {
         guard let id else {
             throw ContainerizationError(.invalidArgument, message: "id cannot be empty")
         }
-        try await service.delete(id: id)
+        let forceDelete = message.bool(key: .forceDelete)
+        try await service.delete(id: id, force: forceDelete)
         return message.reply()
     }
 

--- a/Sources/ContainerClient/ContainerEvents.swift
+++ b/Sources/ContainerClient/ContainerEvents.swift
@@ -14,8 +14,6 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-//
-
 public enum ContainerEvent: Sendable, Codable {
     case containerStart(id: String)
     case containerExit(id: String, exitCode: Int64)

--- a/Sources/ContainerClient/Core/ClientContainer.swift
+++ b/Sources/ContainerClient/Core/ClientContainer.swift
@@ -165,11 +165,12 @@ extension ClientContainer {
     }
 
     /// Delete the container along with any resources.
-    public func delete() async throws {
+    public func delete(force: Bool = false) async throws {
         do {
             let client = XPCClient(service: Self.serviceIdentifier)
             let request = XPCMessage(route: .deleteContainer)
             request.set(key: .id, value: self.id)
+            request.set(key: .forceDelete, value: force)
             try await client.send(request)
         } catch {
             throw ContainerizationError(

--- a/Sources/ContainerClient/XPC+.swift
+++ b/Sources/ContainerClient/XPC+.swift
@@ -46,6 +46,8 @@ public enum XPCKeys: String {
     case logs
     /// Options for stopping a container key.
     case stopOptions
+    /// Whether to force stop a container when deleting.
+    case forceDelete
     /// Plugins
     case pluginName
     case plugins


### PR DESCRIPTION
Today force deleting (if a container is running then stop()'ing first) is handled entirely in the cli, which is brittle. The CLI doesn't know if the container was started with --rm so it would have to do a weird timeout + list dance to check if the containers gone after stopping. This change remedies this by just having the daemon take in a `force` boolean to the delete rpc. If this is provided and the container is running then we'll stop first, and then cleanup. We can additionally not cleanup if --rm was provided as the daemon has the data to determine if a container asked for autoRemove.