### PR TITLE
ContainerService: Remove lock from list()

### DIFF
--- a/Sources/APIServer/Containers/ContainersService.swift
+++ b/Sources/APIServer/Containers/ContainersService.swift
@@ -84,9 +84,7 @@ actor ContainersService {
     /// List all containers registered with the service.
     public func list() async throws -> [ContainerSnapshot] {
         self.log.debug("\(#function)")
-        return await lock.withLock { context in
-            Array(await self.containers.values)
-        }
+        return Array(self.containers.values)
     }
 
     /// Execute an operation with the current container list while maintaining atomicity


### PR DESCRIPTION
The type is an actor, so we're guaranteed no one intrudes so long as there is no suspension points. There is none here, we're simply returning the current IDs.