### PR TITLE
CLI: Send logs to stderr

### DIFF
--- a/Sources/CLI/Application.swift
+++ b/Sources/CLI/Application.swift
@@ -29,14 +29,9 @@ import TerminalProgress
 
 // `log` is updated only once in the `validate()` method.
 nonisolated(unsafe) var log = {
-    LoggingSystem.bootstrap { label in
-        OSLogHandler(
-            label: label,
-            category: "CLI"
-        )
-    }
+    LoggingSystem.bootstrap(StreamLogHandler.standardError)
     var log = Logger(label: "com.apple.container")
-    log.logLevel = .debug
+    log.logLevel = .info
     return log
 }()
 


### PR DESCRIPTION
I'm not sure why we had these going to OSLog, but I'd wager they're a bit more useful being displayed directly to the user during the command they're running.