### PR TITLE
Revert "Integration: Log container bootlog in run test failures (#541)"

### DIFF
--- a/Tests/CLITests/Subcommands/Build/CLIBuilderTest.swift
+++ b/Tests/CLITests/Subcommands/Build/CLIBuilderTest.swift
@@ -333,7 +333,7 @@ extension TestCLIBuildBase {
             try self.build(tag: imageName, tempDir: tempDir)
             #expect(try self.inspectImage(imageName) == imageName, "expected to have successfully built \(imageName)")
             // Check if the image we built is actually in the image store, and can be used.
-            try self.doLongRun(name: containerName, image: imageName, autoRemove: true)
+            try self.doLongRun(name: containerName, image: imageName)
             defer {
                 try? self.doStop(name: containerName)
             }

--- a/Tests/CLITests/Subcommands/Networks/TestCLINetwork.swift
+++ b/Tests/CLITests/Subcommands/Networks/TestCLINetwork.swift
@@ -48,9 +48,7 @@ class TestCLINetwork: CLITest {
                 name: name,
                 image: "docker.io/library/python:alpine",
                 args: ["--network", name],
-                containerArgs: ["python3", "-m", "http.server", "--bind", "0.0.0.0", "\(port)"],
-                autoRemove: true,
-            )
+                containerArgs: ["python3", "-m", "http.server", "--bind", "0.0.0.0", "\(port)"])
             defer {
                 try? doStop(name: name)
             }

--- a/Tests/CLITests/Subcommands/Run/TestCLIRunLifecycle.swift
+++ b/Tests/CLITests/Subcommands/Run/TestCLIRunLifecycle.swift
@@ -27,12 +27,12 @@ class TestCLIRunLifecycle: CLITest {
             name,
         ]
         #expect(throws: CLIError.self, "expect container to fail with invalid user") {
-            try self.doLongRun(name: name, args: badArgs, autoRemove: true)
+            try self.doLongRun(name: name, args: badArgs)
         }
 
         // try to create a container with the same name but no user that should succeed
         #expect(throws: Never.self, "expected container run to succeed") {
-            try self.doLongRun(name: name, args: [], autoRemove: true)
+            try self.doLongRun(name: name, args: [])
             defer {
                 try? self.doStop(name: name)
             }

--- a/Tests/CLITests/Subcommands/Run/TestCLIRunOptions.swift
+++ b/Tests/CLITests/Subcommands/Run/TestCLIRunOptions.swift
@@ -14,6 +14,8 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+//
+
 import AsyncHTTPClient
 import ContainerClient
 import ContainerizationExtras
@@ -22,80 +24,61 @@ import Foundation
 import Testing
 
 class TestCLIRunCommand: CLITest {
-    func runHelper(name: String, testCase: () throws -> Void) {
-        defer {
-            try? doStop(name: name)
-            try? doRemove(name: name)
-        }
-        do {
-            try testCase()
-            try doStop(name: name)
-            try doRemove(name: name)
-        } catch {
-            // Try and glean some info from the boot log.
-            if let bootLog = try? doLogs(name: name, boot: true) {
-                Issue.record("failed to run container (Error: \(error)) (Boot log: \(bootLog))")
-            } else {
-                Issue.record("failed to run container (Error: \(error))")
-            }
-        }
-    }
-
-    func runHelperAsync(name: String, testCase: () async throws -> Void) async {
-        defer {
-            try? doStop(name: name)
-            try? doRemove(name: name)
-        }
-        do {
-            try await testCase()
-            try doStop(name: name)
-            try doRemove(name: name)
-        } catch {
-            // Try and glean some info from the boot log.
-            if let bootLog = try? doLogs(name: name, boot: true) {
-                Issue.record("failed to run container (Error: \(error)) (Boot log: \(bootLog))")
-            } else {
-                Issue.record("failed to run container (Error: \(error))")
-            }
-        }
-    }
-
     @Test func testRunCommand() throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        runHelper(name: name) {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
             try doLongRun(name: name, args: [])
+            defer {
+                try? doStop(name: name)
+            }
             let _ = try doExec(name: name, cmd: ["date"])
+            try doStop(name: name)
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 
     @Test func testRunCommandCWD() throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        runHelper(name: name) {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
             let expectedCWD = "/tmp"
             try doLongRun(name: name, args: ["--cwd", expectedCWD])
-
+            defer {
+                try? doStop(name: name)
+            }
             var output = try doExec(name: name, cmd: ["pwd"])
             output = output.trimmingCharacters(in: .whitespacesAndNewlines)
             #expect(output == expectedCWD, "expected current working directory to be \(expectedCWD), instead got \(output)")
+            try doStop(name: name)
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 
     @Test func testRunCommandEnv() throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        runHelper(name: name) {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
             let envData = "FOO=bar"
             try doLongRun(name: name, args: ["--env", envData])
-
+            defer {
+                try? doStop(name: name)
+            }
             let inspectResp = try inspectContainer(name)
             #expect(
                 inspectResp.configuration.initProcess.environment.contains(envData),
                 "environment variable \(envData) not set in container configuration")
+            try doStop(name: name)
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 
     @Test func testRunCommandEnvFile() throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        runHelper(name: name) {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
             let envData = "FOO=bar"
             let tempFile = FileManager.default.temporaryDirectory.appendingPathComponent("test.env")
             guard FileManager.default.createFile(atPath: tempFile.path(), contents: Data(envData.utf8)) else {
@@ -106,66 +89,97 @@ class TestCLIRunCommand: CLITest {
                 try? FileManager.default.removeItem(at: tempFile)
             }
             try doLongRun(name: name, args: ["--env-file", tempFile.path()])
-
+            defer {
+                try? doStop(name: name)
+            }
             let inspectResp = try inspectContainer(name)
             #expect(
                 inspectResp.configuration.initProcess.environment.contains(envData),
                 "environment variable \(envData) not set in container configuration")
+            try doStop(name: name)
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 
     @Test func testRunCommandUserIDGroupID() throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        runHelper(name: name) {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
             let uid = "10"
             let gid = "100"
             try doLongRun(name: name, args: ["--uid", uid, "--gid", gid])
+            defer {
+                try? doStop(name: name)
+            }
 
             var output = try doExec(name: name, cmd: ["id"])
             output = output.trimmingCharacters(in: .whitespacesAndNewlines)
             try #expect(output.contains(Regex("uid=\(uid).*?gid=\(gid).*")), "invalid user/group id, got \(output)")
+            try doStop(name: name)
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 
     @Test func testRunCommandUser() throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        runHelper(name: name) {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
             let user = "nobody"
             try doLongRun(name: name, args: ["--user", user])
-
+            defer {
+                try? doStop(name: name)
+            }
             var output = try doExec(name: name, cmd: ["whoami"])
             output = output.trimmingCharacters(in: .whitespacesAndNewlines)
             #expect(output == user, "expected user \(user), got \(output)")
+            try doStop(name: name)
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 
     @Test func testRunCommandCPUs() throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        runHelper(name: name) {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
             let cpus = "2"
             try doLongRun(name: name, args: ["--cpus", cpus])
-
+            defer {
+                try? doStop(name: name)
+            }
             var output = try doExec(name: name, cmd: ["nproc"])
             output = output.trimmingCharacters(in: .whitespacesAndNewlines)
             #expect(output == cpus, "expected \(cpus), instead got \(output)")
+            try doStop(name: name)
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 
     @Test func testRunCommandMemory() throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        runHelper(name: name) {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
             let expectedMBs = 1024
             try doLongRun(name: name, args: ["--memory", "\(expectedMBs)M"])
-
+            defer {
+                try? doStop(name: name)
+            }
             let inspectResp = try inspectContainer(name)
             let actualInBytes = inspectResp.configuration.resources.memoryInBytes
             #expect(actualInBytes == expectedMBs.mib(), "expected \(expectedMBs.mib()) bytes, instead got \(actualInBytes) bytes")
+            try doStop(name: name)
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 
     @Test func testRunCommandMount() throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        runHelper(name: name) {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
             let targetContainerPath = "/tmp/testmount"
             let testData = "hello world"
             let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
@@ -179,16 +193,22 @@ class TestCLIRunCommand: CLITest {
                 try? FileManager.default.removeItem(at: tempDir)
             }
             try doLongRun(name: name, args: ["--mount", "type=virtiofs,source=\(tempDir.path()),target=\(targetContainerPath),readonly"])
-
+            defer {
+                try? doStop(name: name)
+            }
             var output = try doExec(name: name, cmd: ["cat", "\(targetContainerPath)/\(tempFile.lastPathComponent)"])
             output = output.trimmingCharacters(in: .whitespacesAndNewlines)
             #expect(output == testData, "expected file with content '\(testData)', instead got '\(output)'")
+            try doStop(name: name)
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 
     @Test func testRunCommandUnixSocketMount() throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        runHelper(name: name) {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
             let socketPath = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
 
             let socketType = try UnixType(path: socketPath.path, unlinkExisting: true)
@@ -203,7 +223,9 @@ class TestCLIRunCommand: CLITest {
                 name: name,
                 args: ["-v", "\(socketPath.path):/woo"]
             )
-
+            defer {
+                try? doStop(name: name)
+            }
             let output = try doExec(name: name, cmd: ["ls", "-alh", "woo"])
             let splitOutput = output.components(separatedBy: .whitespaces)
             #expect(splitOutput.count > 0, "expected split output of 'ls -alh' to be at least 1, instead got \(splitOutput.count)")
@@ -211,42 +233,58 @@ class TestCLIRunCommand: CLITest {
             let perms = splitOutput[0]
             let firstChar = perms[perms.startIndex]
             #expect(firstChar == "s", "expected file in guest to be of type socket, instead got '\(firstChar)'")
+            try doStop(name: name)
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 
     @Test func testRunCommandTmpfs() throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        runHelper(name: name) {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
             let targetContainerPath = "/tmp/testtmpfs"
             let expectedFilesystem = "tmpfs"
             try doLongRun(name: name, args: ["--tmpfs", targetContainerPath])
-
+            defer {
+                try? doStop(name: name)
+            }
             let output = try doExec(name: name, cmd: ["df", targetContainerPath])
             let lines = output.split(separator: "\n")
             #expect(lines.count == 2, "expected only two rows of output, instead got \(lines.count)")
             let words = lines[1].split(separator: " ")
             #expect(words.count > 1, "expected information to contain multiple words, got \(words.count)")
             #expect(words[0].lowercased() == expectedFilesystem, "expected filesystem type to be \(expectedFilesystem), instead got \(output)")
+            try doStop(name: name)
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 
     @Test func testRunCommandOSArch() throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        runHelper(name: name) {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
             let os = "linux"
             let arch = "amd64"
             let expectedArch = "x86_64"
             try doLongRun(name: name, args: ["--os", os, "--arch", arch])
-
+            defer {
+                try? doStop(name: name)
+            }
             var output = try doExec(name: name, cmd: ["uname", "-sm"])
             output = output.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
             #expect(output == "\(os) \(expectedArch)", "expected container to use '\(os) \(expectedArch)', instead got '\(output)'")
+            try doStop(name: name)
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 
     @Test func testRunCommandVolume() throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        runHelper(name: name) {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
             let targetContainerPath = "/tmp/testvolume"
             let testData = "one small step"
             let volume = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
@@ -260,59 +298,82 @@ class TestCLIRunCommand: CLITest {
                 try? FileManager.default.removeItem(at: volume)
             }
             try doLongRun(name: name, args: ["--volume", "\(volume.path):\(targetContainerPath)"])
-
+            defer {
+                try? doStop(name: name)
+            }
             var output = try doExec(name: name, cmd: ["cat", "\(targetContainerPath)/\(volumeFile.lastPathComponent)"])
             output = output.trimmingCharacters(in: .whitespacesAndNewlines)
             #expect(output == testData, "expected file with content '\(testData)', instead got '\(output)'")
+            try doStop(name: name)
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 
     @Test func testRunCommandCidfile() throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        runHelper(name: name) {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
             let filePath = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
             defer {
                 try? FileManager.default.removeItem(at: filePath)
             }
             try doLongRun(name: name, args: ["--cidfile", filePath.path()])
-
+            defer {
+                try? doStop(name: name)
+            }
             let actualID = try String(contentsOf: filePath, encoding: .utf8)
             #expect(actualID == name, "expected container ID '\(name!)', instead got '\(actualID)'")
+            try doStop(name: name)
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 
     @Test func testRunCommandNoDNS() throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        runHelper(name: name) {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
             try doLongRun(name: name, args: ["--no-dns"])
-
+            defer {
+                try? doStop(name: name)
+            }
             #expect(throws: (any Error).self) {
                 try doExec(name: name, cmd: ["cat", "/etc/resolv.conf"])
             }
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 
     @Test func testRunCommandDNS() throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        runHelper(name: name) {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
             let dns = "8.8.8.8"
             try doLongRun(name: name, args: ["--dns", dns])
-
+            defer {
+                try? doStop(name: name)
+            }
             var output = try doExec(name: name, cmd: ["cat", "/etc/resolv.conf"])
             output = output.trimmingCharacters(in: .whitespacesAndNewlines)
             let words = output.split(separator: " ")
             #expect(words.count == 2, "expected 'nameserver \(dns)', instead got '\(output)'")
             #expect(words[1].lowercased() == dns, "expected 'nameserver \(dns)', instead got '\(output)'")
-
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 
     @Test func testRunCommandDNSDomain() throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        runHelper(name: name) {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
             let dnsDomain = "example.com"
             try doLongRun(name: name, args: ["--dns-domain", dnsDomain])
-
+            defer {
+                try? doStop(name: name)
+            }
             let output = try doExec(name: name, cmd: ["cat", "/etc/resolv.conf"])
             let lines = output.split(separator: "\n")
             #expect(lines.count == 2, "expected two lines of info in /etc/resolv.conf, got \(output)")
@@ -320,15 +381,20 @@ class TestCLIRunCommand: CLITest {
             #expect(words.count == 2, "expected 'domain \(dnsDomain)', instead got '\(lines[1])'")
             #expect(words[0].lowercased() == "domain", "expected entry to list domain, instead got '\(words[0])'")
             #expect(words[1].lowercased() == dnsDomain, "expected '\(dnsDomain)' search domain, instead got '\(words[1])'")
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 
     @Test func testRunCommandDNSSearch() throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        runHelper(name: name) {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
             let dnsSearch = "test.com"
             try doLongRun(name: name, args: ["--dns-search", dnsSearch])
-
+            defer {
+                try? doStop(name: name)
+            }
             let output = try doExec(name: name, cmd: ["cat", "/etc/resolv.conf"])
             let lines = output.split(separator: "\n")
             #expect(lines.count == 2, "expected two lines of info in /etc/resolv.conf, got \(output)")
@@ -336,13 +402,19 @@ class TestCLIRunCommand: CLITest {
             #expect(words.count == 2, "expected 'search \(dnsSearch)', instead got '\(lines[1])'")
             #expect(words[0].lowercased() == "search", "expected entry to list search domains, instead got '\(words[0])'")
             #expect(words[1].lowercased() == dnsSearch, "expected '\(dnsSearch)' search domain, instead got '\(words[1])'")
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 
     @Test func testRunDefaultHostsEntries() throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        runHelper(name: name) {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
             try doLongRun(name: name)
+            defer {
+                try? doStop(name: name)
+            }
 
             let inspectOutput = try inspectContainer(name)
             let ip = String(inspectOutput.networks[0].address.split(separator: "/")[0])
@@ -359,15 +431,20 @@ class TestCLIRunCommand: CLITest {
                 #expect(expected.0 == words[0], "expected /etc/hosts entries IP to be \(expected.0), instead got \(words[0])")
                 #expect(expected.1 == words[1], "expected /etc/hosts entries host to be \(expected.1), instead got \(words[1])")
             }
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 
     @Test func testRunCommandDNSOption() throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        runHelper(name: name) {
+        do {
+            let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
             let dnsOption = "debug"
             try doLongRun(name: name, args: ["--dns-option", dnsOption])
-
+            defer {
+                try? doStop(name: name)
+            }
             let output = try doExec(name: name, cmd: ["cat", "/etc/resolv.conf"])
             let lines = output.split(separator: "\n")
             #expect(lines.count == 2, "expected two lines of info in /etc/resolv.conf, got \(output)")
@@ -375,14 +452,17 @@ class TestCLIRunCommand: CLITest {
             #expect(words.count == 2, "expected 'opts \(dnsOption)', instead got '\(lines[1])'")
             #expect(words[0].lowercased() == "opts", "expected entry to list dns options, instead got '\(words[0])'")
             #expect(words[1].lowercased() == dnsOption, "expected option '\(dnsOption)', instead got '\(words[1])'")
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 
     @Test func testForwardTCP() async throws {
-        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
-        await runHelperAsync(name: name) {
-            let retries = 10
-            let retryDelaySeconds = Int64(3)
+        let retries = 10
+        let retryDelaySeconds = Int64(3)
+        do {
+            let name = Test.current!.name.trimmingCharacters(in: ["(", ")"])
             let proxyIp = "127.0.0.1"
             let proxyPort = UInt16.random(in: 50000..<55000)
             let serverPort = UInt16.random(in: 55000..<60000)
@@ -390,8 +470,10 @@ class TestCLIRunCommand: CLITest {
                 name: name,
                 image: "docker.io/library/python:alpine",
                 args: ["--publish", "\(proxyIp):\(proxyPort):\(serverPort)/tcp"],
-                containerArgs: ["python3", "-m", "http.server", "--bind", "0.0.0.0", "\(serverPort)"]
-            )
+                containerArgs: ["python3", "-m", "http.server", "--bind", "0.0.0.0", "\(serverPort)"])
+            defer {
+                try? doStop(name: name)
+            }
 
             let url = "http://\(proxyIp):\(proxyPort)"
             var request = HTTPClientRequest(url: url)
@@ -413,6 +495,10 @@ class TestCLIRunCommand: CLITest {
                 retriesRemaining -= 1
             }
             #expect(success, "Request to \(url) failed after \(retries - retriesRemaining) retries")
+            try doStop(name: name)
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
         }
     }
 }

--- a/Tests/CLITests/Subcommands/Volumes/TestCLIVolumes.swift
+++ b/Tests/CLITests/Subcommands/Volumes/TestCLIVolumes.swift
@@ -78,7 +78,7 @@ class TestCLIVolumes: CLITest {
         try doVolumeCreate(name: volumeName)
 
         // Run first container with volume, write data, then stop
-        try doLongRun(name: container1Name, args: ["-v", "\(volumeName):/data"], autoRemove: true)
+        try doLongRun(name: container1Name, args: ["-v", "\(volumeName):/data"])
         try waitForContainerRunning(container1Name)
 
         // Write test data to the volume
@@ -88,7 +88,7 @@ class TestCLIVolumes: CLITest {
         try doStop(name: container1Name)
 
         // Run second container with same volume
-        try doLongRun(name: container2Name, args: ["-v", "\(volumeName):/data"], autoRemove: true)
+        try doLongRun(name: container2Name, args: ["-v", "\(volumeName):/data"])
         try waitForContainerRunning(container2Name)
 
         // Verify data persisted
@@ -125,7 +125,7 @@ class TestCLIVolumes: CLITest {
         try doVolumeCreate(name: volumeName)
 
         // Run first container with volume
-        try doLongRun(name: container1Name, args: ["-v", "\(volumeName):/data"], autoRemove: true)
+        try doLongRun(name: container1Name, args: ["-v", "\(volumeName):/data"])
         try waitForContainerRunning(container1Name)
 
         // Try to run second container with same volume - should fail
@@ -159,7 +159,7 @@ class TestCLIVolumes: CLITest {
         try doVolumeCreate(name: volumeName)
 
         // Run container with volume
-        try doLongRun(name: containerName, args: ["-v", "\(volumeName):/data"], autoRemove: true)
+        try doLongRun(name: containerName, args: ["-v", "\(volumeName):/data"])
         try waitForContainerRunning(containerName)
 
         // Try to delete volume while container is running - should fail

--- a/Tests/CLITests/Utilities/CLITest.swift
+++ b/Tests/CLITests/Utilities/CLITest.swift
@@ -167,18 +167,15 @@ class CLITest {
         name: String,
         image: String? = nil,
         args: [String]? = nil,
-        containerArgs: [String]? = nil,
-        autoRemove: Bool = false
+        containerArgs: [String]? = nil
     ) throws {
         var runArgs = [
             "run",
+            "--rm",
             "--name",
             name,
             "-d",
         ]
-        if autoRemove {
-            runArgs.append("--rm")
-        }
         if let args {
             runArgs.append(contentsOf: args)
         }
@@ -254,19 +251,6 @@ class CLITest {
         if status != 0 {
             throw CLIError.executionFailed("command failed: \(error)")
         }
-    }
-
-    func doLogs(name: String, boot: Bool) throws -> String {
-        var args = ["logs"]
-        if boot {
-            args.append("--boot")
-        }
-        args.append(name)
-        let (stdout, stderr, status) = try run(arguments: args)
-        if status != 0 {
-            throw CLIError.executionFailed("command failed: \(stderr)")
-        }
-        return stdout
     }
 
     func doStart(name: String) throws {


### PR DESCRIPTION
This reverts commit 41add2967347afec3d25886d852aa519bb73c687.

We've discovered a quite fun issue with some of our rpcs (stop+delete) in sequence when done fast enough. It needs a bit of reworking to get into shape. While the work here is very useful, we can add this back after the rpc ordering is solved.