### PR TITLE
APIServer: Make container deletes a little more robust

### DIFF
--- a/Sources/ContainerClient/SandboxClient.swift
+++ b/Sources/ContainerClient/SandboxClient.swift
@@ -175,6 +175,15 @@ extension SandboxClient {
         return fh
     }
 
+    package func shutdown() async throws {
+        let request = XPCMessage(route: SandboxRoutes.shutdown.rawValue)
+
+        let client = createClient()
+        defer { client.close() }
+
+        _ = try await client.send(request)
+    }
+
     private func createClient() -> XPCClient {
         XPCClient(service: machServiceLabel)
     }

--- a/Sources/ContainerClient/SandboxRoutes.swift
+++ b/Sources/ContainerClient/SandboxRoutes.swift
@@ -35,4 +35,6 @@ public enum SandboxRoutes: String {
     case exec = "com.apple.container.sandbox/exec"
     /// Dial a vsock port in the sandbox.
     case dial = "com.apple.container.sandbox/dial"
+    /// Shutdown the sandbox service process.
+    case shutdown = "com.apple.container.sandbox/shutdown"
 }

--- a/Sources/ContainerXPC/XPCClient.swift
+++ b/Sources/ContainerXPC/XPCClient.swift
@@ -56,7 +56,10 @@ extension XPCClient {
                 group.addTask {
                     try await Task.sleep(for: responseTimeout)
                     let route = message.string(key: XPCMessage.routeKey) ?? "nil"
-                    throw ContainerizationError(.internalError, message: "XPC timeout for request to \(self.service)/\(route)")
+                    throw ContainerizationError(
+                        .internalError,
+                        message: "XPC timeout for request to \(self.service)/\(route)"
+                    )
                 }
             }
 

--- a/Sources/Helpers/RuntimeLinux/RuntimeLinuxHelper.swift
+++ b/Sources/Helpers/RuntimeLinux/RuntimeLinuxHelper.swift
@@ -83,6 +83,7 @@ struct RuntimeLinuxHelper: AsyncParsableCommand {
                     SandboxRoutes.wait.rawValue: server.wait,
                     SandboxRoutes.start.rawValue: server.startProcess,
                     SandboxRoutes.dial.rawValue: server.dial,
+                    SandboxRoutes.shutdown.rawValue: server.shutdown,
                 ],
                 log: log
             )


### PR DESCRIPTION
Today it's possible we receive the container exit event sent to the daemon after a user might've invoked `container delete`. The aftermath of that unfortunate scenario is that you would be met with an error stating we can't delete the container because it is running. This is not really common unless someone was doing kill/stop+delete in some script, but it still is an issue that needs to be fixed. The true source of truth for state is actually the sandboxservice hosting the container, so if we were guaranteed that that is still alive, we can query and take some action based on the possible mismatch in current snapshot state and what the sb service is telling us.

To make this possible I've introduced a new rpc on the sandbox service named shutdown. Shutdown's purpose is to run some cleanup code (if there is any) and then to wind down the process. Prior to this RPC the sandbox service would basically just call exit(0) on its own accord after the container exited. Now this process is driven by the APIServer instead, which I like a little bit more. The true win here though is that because we know as long as we haven't sent the shutdown RPC that the process is alive (barring a bug), we can query the state of the container the whole time.
