### PR TITLE
Make "Plugin not found" message more descriptive

### DIFF
--- a/Tests/CLITests/Subcommands/Plugins/TestCLIPluginErrors.swift
+++ b/Tests/CLITests/Subcommands/Plugins/TestCLIPluginErrors.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc.
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+struct TestCLIPluginErrors {
+    @Test
+    func testHelpfulMessageWhenPluginsUnavailable() throws {
+        // Intentionally invoke an unknown plugin command. In CI this should run
+        // without the APIServer started, so DefaultCommand will fail to create
+        // a PluginLoader and emit the improved guidance.
+        let cli = try CLITest()
+        let (_, stderr, status) = try cli.run(arguments: ["nosuchplugin"]) // non-existent plugin name
+
+        #expect(status != 0)
+        #expect(stderr.contains("container system start"))
+        #expect(stderr.contains("Plugins are unavailable") || stderr.contains("Plugin 'container-"))
+        // Should include at least one computed plugin search path hint
+        #expect(stderr.contains("container-plugins") || stderr.contains("container/plugins"))
+    }
+}


### PR DESCRIPTION
## Type of Change
- [X] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Description
Users frequently saw “failed to find plugin …” when the system services weren’t running; the message didn’t explain the root cause or where plugins are looked up. No change to plugin execution flow; only error messaging and path discovery hints are improved for a better UX.

## Motivation and Context
Users frequently saw “failed to find plugin …” when the system services weren’t running; the message didn’t explain the root cause or where plugins are looked up. I was confronted with this several times during plugin development because the container system was not running, but the error message led me to believe the files were missing.

## Testing
- [X] Tested locally
- [X ] Added/updated tests
- [ ] Added/updated docs

