### PR TITLE
Add force option to kernel set and add tests for kernel setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,7 @@ integration: init-block
 		$(SWIFT) test -c $(BUILD_CONFIGURATION) --filter TestCLIRunBase || exit_code=1 ; \
 		$(SWIFT) test -c $(BUILD_CONFIGURATION) --filter TestCLIBuildBase || exit_code=1 ; \
 		$(SWIFT) test -c $(BUILD_CONFIGURATION) --filter TestCLIVolumes || exit_code=1 ; \
+		$(SWIFT) test -c $(BUILD_CONFIGURATION) --filter TestCLIKernelSet || exit_code=1 ; \
 		echo Ensuring apiserver stopped after the CLI integration tests ; \
 		scripts/ensure-container-stopped.sh ; \
 		exit $${exit_code} ; \

--- a/Sources/CLI/System/SystemStart.swift
+++ b/Sources/CLI/System/SystemStart.swift
@@ -146,7 +146,7 @@ extension Application {
                 return
             }
             print("Installing kernel...")
-            try await KernelSet.downloadAndInstallWithProgressBar(tarRemoteURL: defaultKernelURL, kernelFilePath: defaultKernelBinaryPath)
+            try await KernelSet.downloadAndInstallWithProgressBar(tarRemoteURL: defaultKernelURL, kernelFilePath: defaultKernelBinaryPath, force: true)
         }
 
         private func initImageExists() async -> Bool {

--- a/Sources/ContainerClient/Core/ClientKernel.swift
+++ b/Sources/ContainerClient/Core/ClientKernel.swift
@@ -30,23 +30,27 @@ extension ClientKernel {
         XPCClient(service: serviceIdentifier)
     }
 
-    public static func installKernel(kernelFilePath: String, platform: SystemPlatform) async throws {
+    public static func installKernel(kernelFilePath: String, platform: SystemPlatform, force: Bool) async throws {
         let client = newClient()
         let message = XPCMessage(route: .installKernel)
 
         message.set(key: .kernelFilePath, value: kernelFilePath)
+        message.set(key: .kernelForce, value: force)
 
         let platformData = try JSONEncoder().encode(platform)
         message.set(key: .systemPlatform, value: platformData)
         try await client.send(message)
     }
 
-    public static func installKernelFromTar(tarFile: String, kernelFilePath: String, platform: SystemPlatform, progressUpdate: ProgressUpdateHandler? = nil) async throws {
+    public static func installKernelFromTar(tarFile: String, kernelFilePath: String, platform: SystemPlatform, progressUpdate: ProgressUpdateHandler? = nil, force: Bool)
+        async throws
+    {
         let client = newClient()
         let message = XPCMessage(route: .installKernel)
 
         message.set(key: .kernelTarURL, value: tarFile)
         message.set(key: .kernelFilePath, value: kernelFilePath)
+        message.set(key: .kernelForce, value: force)
 
         let platformData = try JSONEncoder().encode(platform)
         message.set(key: .systemPlatform, value: platformData)

--- a/Sources/ContainerClient/FileDownloader.swift
+++ b/Sources/ContainerClient/FileDownloader.swift
@@ -20,7 +20,7 @@ import ContainerizationExtras
 import Foundation
 import TerminalProgress
 
-internal struct FileDownloader {
+public struct FileDownloader {
     public static func downloadFile(url: URL, to destination: URL, progressUpdate: ProgressUpdateHandler? = nil) async throws {
         let request = try HTTPClient.Request(url: url)
 

--- a/Sources/ContainerClient/XPC+.swift
+++ b/Sources/ContainerClient/XPC+.swift
@@ -100,6 +100,7 @@ public enum XPCKeys: String {
     case kernelTarURL
     case kernelFilePath
     case systemPlatform
+    case kernelForce
 
     /// Volume
     case volume

--- a/Tests/CLITests/Subcommands/System/TestKernelSet.swift
+++ b/Tests/CLITests/Subcommands/System/TestKernelSet.swift
@@ -1,0 +1,128 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerClient
+import ContainerPersistence
+import ContainerizationArchive
+import Foundation
+import Testing
+
+// This suite is run serialized since each test modifies the global default kernel
+@Suite(.serialized)
+class TestCLIKernelSet: CLITest {
+    let defaultKernelTar = DefaultsStore.get(key: .defaultKernelURL)
+    var remoteTar: URL! {
+        URL(string: defaultKernelTar)
+    }
+    let defaultBinaryPath = DefaultsStore.get(key: .defaultKernelBinaryPath)
+
+    deinit {
+        try? resetDefaultBinary()
+    }
+
+    func resetDefaultBinary() throws {
+        let arguments: [String] = [
+            "system",
+            "kernel",
+            "set",
+            "--recommended",
+            "--force",
+        ]
+        let (_, error, status) = try run(arguments: arguments)
+        if status != 0 {
+            throw CLIError.executionFailed("failed to reset kernel to recommended: \(error)")
+        }
+    }
+
+    func doKernelSet(extraArgs: [String]) throws {
+        var arguments = [
+            "system",
+            "kernel",
+            "set",
+            "--force",
+        ]
+        arguments.append(contentsOf: extraArgs)
+
+        let (_, error, status) = try run(arguments: arguments)
+        if status != 0 {
+            throw CLIError.executionFailed("failed to set kernel: \(error)")
+        }
+    }
+
+    func validateContainerRun() throws {
+        let name: String! = Test.current?.name.trimmingCharacters(in: ["(", ")"])
+        try doLongRun(name: name, args: [])
+        defer { try? doStop(name: name) }
+
+        _ = try doExec(name: name, cmd: ["date"])
+        try doStop(name: name)
+    }
+
+    @Test func fromLocalTar() async throws {
+        let symlinkBinaryPath: String = URL(filePath: defaultBinaryPath).deletingLastPathComponent().appending(path: "vmlinux.container").relativePath
+
+        try await withTempDir { tempDir in
+            // manually download the tar file
+            let localTarPath = tempDir.appending(path: remoteTar.lastPathComponent)
+            try await ContainerClient.FileDownloader.downloadFile(url: remoteTar, to: localTarPath)
+
+            let extraArgs: [String] = [
+                "--tar",
+                localTarPath.path,
+                "--binary",
+                symlinkBinaryPath,
+            ]
+
+            try doKernelSet(extraArgs: extraArgs)
+            try validateContainerRun()
+        }
+    }
+
+    @Test func fromRemoteTarSymlink() throws {
+        // opt/kata/share/kata-containers/vmlinux.container should point to opt/kata/share/kata-containers/vmlinux-<version> in the archive
+        let symlinkBinaryPath: String = URL(filePath: defaultBinaryPath).deletingLastPathComponent().appending(path: "vmlinux.container").relativePath
+        let extraArgs: [String] = [
+            "--tar",
+            defaultKernelTar,
+            "--binary",
+            symlinkBinaryPath,
+        ]
+
+        try doKernelSet(extraArgs: extraArgs)
+        try validateContainerRun()
+    }
+
+    @Test func fromLocalDisk() async throws {
+        try await withTempDir { tempDir in
+            // manually download the tar file
+            let localTarPath = tempDir.appending(path: remoteTar.lastPathComponent)
+            try await ContainerClient.FileDownloader.downloadFile(url: remoteTar, to: localTarPath)
+
+            // extract just the file we want
+            let targetPath = tempDir.appending(path: URL(string: defaultBinaryPath)!.lastPathComponent)
+            let archiveReader = try ArchiveReader(file: localTarPath)
+            let (_, data) = try archiveReader.extractFile(path: defaultBinaryPath)
+            try data.write(to: targetPath, options: .atomic)
+
+            let extraArgs = [
+                "--binary",
+                targetPath.path,
+            ]
+            try doKernelSet(extraArgs: extraArgs)
+            try validateContainerRun()
+        }
+    }
+}

--- a/Tests/CLITests/Utilities/CLITest.swift
+++ b/Tests/CLITests/Utilities/CLITest.swift
@@ -449,4 +449,15 @@ class CLITest {
         httpConfiguration.proxy = proxyConfig
         return HTTPClient(eventLoopGroupProvider: .singleton, configuration: httpConfiguration)
     }
+
+    func withTempDir<T>(_ body: (URL) async throws -> T) async throws -> T {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        return try await body(tempDir)
+    }
 }


### PR DESCRIPTION
## Type of Change
- [x] New feature  

## Description
Add option to force kernel setting and tests for CLI `kernel set`. Related to https://github.com/apple/container/pull/575. 

## Motivation and Context
This PR adds additional tests to ensure that we can set kernels from local files, remote tar files, and local tar files. A new option `force` is added to the `kernel set` subcommand which will overwrite an existing kernel with the same name if one exists to make testing easier. The tests ensure that a container can be started with the newly set kernel and resets to the default recommended kernel when complete. 

## Testing
- [x] Tested locally
- [x] Added/updated tests

