### PR TITLE
Allow kernel set with tar to use relative paths to tar file

### DIFF
--- a/Sources/CLI/System/Kernel/KernelSet.swift
+++ b/Sources/CLI/System/Kernel/KernelSet.swift
@@ -74,7 +74,7 @@ extension Application {
                 throw ArgumentParser.ValidationError("Missing argument '--tar")
             }
             let platform = try getSystemPlatform()
-            let localTarPath = URL(fileURLWithPath: tarPath, relativeTo: .currentDirectory()).absoluteString
+            let localTarPath = URL(fileURLWithPath: tarPath, relativeTo: .currentDirectory()).path
             let fm = FileManager.default
             if fm.fileExists(atPath: localTarPath) {
                 try await ClientKernel.installKernelFromTar(tarFile: localTarPath, kernelFilePath: binaryPath, platform: platform)


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Description
Allow kernel set with tar to use relative paths to tar file. Fixes https://github.com/apple/container/issues/573. 

## Motivation and Context
`absoluteString` will prefix a scheme to the file path that looks like "file://". This will cause file manager to fail to find the file at the file path even if it exists. Change to instead just get the `path` of the file, which does not add a scheme prefix. 

## Testing
- [x] Tested locally