### PR TITLE
Remove description field in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,9 +4,6 @@
 - [ ] Breaking change
 - [ ] Documentation update
 
-## Description
-[Brief description]
-
 ## Motivation and Context
 [Why is this change needed?]
 
@@ -14,4 +11,3 @@
 - [ ] Tested locally
 - [ ] Added/updated tests
 - [ ] Added/updated docs
-


### PR DESCRIPTION
## Type of Change
- [x] Process update

## Description
Remove description field in PR template 

## Motivation and Context
I think having separate `Description` and `Motivation and Context` sections have been redundant in recent usage of the PR template. This PR removes the `Description` section. Ideally the PR title should cover the same content previously in the `Description` section. 