### PR TITLE
Add a build parameter to handle warnings as errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ integration: init-block
 	@echo Ensuring apiserver stopped before the CLI integration tests...
 	@bin/container system stop && sleep 3 && scripts/ensure-container-stopped.sh
 	@echo Running the integration tests...
-	bin/container system start $(SYSTEM_START_OPTS) && \
+	@bin/container system start $(SYSTEM_START_OPTS) && \
 	echo "Starting CLI integration tests" && \
 	{ \
 		exit_code=0; \


### PR DESCRIPTION
To handle warnings as errors when building, use make. To allow warnings, use make WARNINGS_AS_ERRORS=false test.

Also see https://github.com/apple/containerization/pull/271.