### PR TITLE
Docs: Update upgrade process in `README.md`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ You need a Mac with Apple silicon to run `container`. To build it, see the [BUIL
 
 ### Install or upgrade
 
-If you're upgrading, first uninstall your existing `container` while preserving your user data:
+If you're upgrading, first stop and uninstall your existing `container` (the `-k` flag keeps your user data, while `-d` removes it):
 
 ```bash
+container system stop
 uninstall-container.sh -k
 ```
 


### PR DESCRIPTION
- Closes #568.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context
Uninstall script will fail with an informative message if the users doesn't run `container system stop`, but including this step in the upgrade process reinforces the need to do this. Upgrading without restarting the service can lead to unexpected failures due to API or persistent data incompatibility.

## Testing
- [ ] Tested locally
- [ ] Added/updated tests
- [x] Added/updated docs
