### PR TITLE
Remove images alias for image subcommand.

### DIFF
--- a/Sources/CLI/Application.swift
+++ b/Sources/CLI/Application.swift
@@ -67,7 +67,7 @@ struct Application: AsyncParsableCommand {
                 name: "Image",
                 subcommands: [
                     BuildCommand.self,
-                    ImagesCommand.self,
+                    ImageCommand.self,
                     RegistryCommand.self,
                 ]
             ),

--- a/Sources/CLI/Image/ImageCommand.swift
+++ b/Sources/CLI/Image/ImageCommand.swift
@@ -17,9 +17,9 @@
 import ArgumentParser
 
 extension Application {
-    struct ImagesCommand: AsyncParsableCommand {
+    struct ImageCommand: AsyncParsableCommand {
         static let configuration = CommandConfiguration(
-            commandName: "images",
+            commandName: "image",
             abstract: "Manage images",
             subcommands: [
                 ImageInspect.self,
@@ -32,7 +32,7 @@ extension Application {
                 ImageSave.self,
                 ImageTag.self,
             ],
-            aliases: ["image", "i"]
+            aliases: ["i"]
         )
     }
 }

--- a/Tests/CLITests/Subcommands/Images/TestCLIImages.swift
+++ b/Tests/CLITests/Subcommands/Images/TestCLIImages.swift
@@ -21,7 +21,7 @@ import Testing
 class TestCLIImagesCommand: CLITest {
     func doRemoveImages(images: [String]? = nil) throws {
         var args = [
-            "images",
+            "image",
             "rm",
         ]
 
@@ -49,7 +49,7 @@ class TestCLIImagesCommand: CLITest {
 
     func doListImages() throws -> [Image] {
         let (output, error, status) = try run(arguments: [
-            "images",
+            "image",
             "list",
             "--format",
             "json",
@@ -68,7 +68,7 @@ class TestCLIImagesCommand: CLITest {
 
     func doImageTag(image: String, newName: String) throws {
         let tagArgs = [
-            "images",
+            "image",
             "tag",
             image,
             newName,
@@ -261,7 +261,7 @@ extension TestCLIImagesCommand {
             }
             let tempFile = tempDir.appendingPathComponent(UUID().uuidString)
             let saveArgs = [
-                "images",
+                "image",
                 "save",
                 alpineTagged,
                 busyboxTagged,
@@ -284,7 +284,7 @@ extension TestCLIImagesCommand {
 
             // 6. load the tarball
             let loadArgs = [
-                "images",
+                "image",
                 "load",
                 "-i",
                 tempFile.path(),

--- a/Tests/CLITests/Utilities/CLITest.swift
+++ b/Tests/CLITests/Utilities/CLITest.swift
@@ -318,7 +318,7 @@ class CLITest {
 
     func inspectImage(_ name: String) throws -> String {
         let response = try run(arguments: [
-            "images",
+            "image",
             "inspect",
             name,
         ])
@@ -349,7 +349,7 @@ class CLITest {
 
     func doPull(imageName: String, args: [String]? = nil) throws {
         var pullArgs = [
-            "images",
+            "image",
             "pull",
         ]
         if let args {
@@ -365,7 +365,7 @@ class CLITest {
 
     func doImageListQuite() throws -> [String] {
         let args = [
-            "images",
+            "image",
             "list",
             "-q",
         ]
@@ -379,7 +379,7 @@ class CLITest {
 
     func doInspectImages(image: String) throws -> [ImageInspectOutput] {
         let (output, error, status) = try run(arguments: [
-            "images",
+            "image",
             "inspect",
             image,
         ])

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -84,17 +84,17 @@ Linux c0376e0a-0bfd-4eea-9e9e-9f9a2c327051 6.1.68 #1 SMP Mon Mar 31 18:27:51 UTC
 The command to push your multiplatform image to a registry is no different than that for a single-platform image:
 
 ```bash
-container images push registry.example.com/fido/web-test:latest
+container image push registry.example.com/fido/web-test:latest
 ```
 
 ## Get container or image details
 
-`container images list` and `container list` provide basic information for all of your images and containers. You can also use `list` and `inspect` commands to print detailed JSON output for one or more resources.
+`container image list` and `container list` provide basic information for all of your images and containers. You can also use `list` and `inspect` commands to print detailed JSON output for one or more resources.
 
 Use the `inspect` command and send the result to the `jq` command to get pretty-printed JSON for the images or containers that you specify:
 
 <pre>
-% container images inspect web-test | jq
+% container image inspect web-test | jq
 [
   {
     "name": "web-test:latest",

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -70,7 +70,7 @@ CONTAINER SUBCOMMANDS:
 
 IMAGE SUBCOMMANDS:
   build                   Build an image from a Dockerfile
-  images, image, i        Manage images
+  image, i                Manage images
   registry, r             Manage registry configurations
 
 SYSTEM SUBCOMMANDS:
@@ -151,7 +151,7 @@ The last argument `.` tells the builder to use the current directory (`web-test`
 After the build completes, list the images. You should see both the base image and the image that you built in the results:
 
 <pre>
-% container images list
+% container image list
 NAME      TAG     DIGEST
 python    alpine  b4d299311845147e7e47c970...
 web-test  latest  25b99501f174803e21c58f9c...
@@ -269,13 +269,13 @@ container registry login {registry.example.com}
 Create another name for your image that includes the registry name, your repository name, and the image name, with the tag `latest`:
 
 ```bash
-container images tag web-test {registry.example.com/fido}/web-test:latest
+container image tag web-test {registry.example.com/fido}/web-test:latest
 ```
 
 Then, push the image:
 
 ```bash
-container images push {registry.example.com/fido}/web-test:latest
+container image push {registry.example.com/fido}/web-test:latest
 ```
 
 ### Pull and run your image
@@ -284,7 +284,7 @@ To validate your published image, stop your current web server container, remove
 
 ```bash
 container stop my-web-server
-container images delete web-test {registry.example.com/fido}/web-test:latest
+container image delete web-test {registry.example.com/fido}/web-test:latest
 container run --name my-web-server --detach --rm {registry.example.com/fido}/web-test:latest
 ```
 


### PR DESCRIPTION
- Closes #596.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [x] Breaking change
- [ ] Documentation update

## Motivation and Context
- All other resource subcommands are singular and have no plural alias.
- `container image` corresponds to `docker image`; `container images` does not.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [x] Added/updated docs
