### PR TITLE
Add `--labels` for networks.

### DIFF
--- a/Sources/CLI/Network/NetworkCreate.swift
+++ b/Sources/CLI/Network/NetworkCreate.swift
@@ -27,14 +27,18 @@ extension Application {
             commandName: "create",
             abstract: "Create a new network")
 
-        @Argument(help: "Network name")
-        var name: String
-
         @OptionGroup
         var global: Flags.Global
 
+        @Option(name: .customLong("label"), help: "Set metadata on a network")
+        var labels: [String] = []
+
+        @Argument(help: "Network name")
+        var name: String
+
         func run() async throws {
-            let config = NetworkConfiguration(id: self.name, mode: .nat)
+            let parsedLabels = Utility.parseKeyValuePairs(labels)
+            let config = NetworkConfiguration(id: self.name, mode: .nat, labels: parsedLabels)
             let state = try await ClientNetwork.create(configuration: config)
             print(state.id)
         }

--- a/Sources/CLI/Network/NetworkDelete.swift
+++ b/Sources/CLI/Network/NetworkDelete.swift
@@ -27,11 +27,11 @@ extension Application {
             abstract: "Delete one or more networks",
             aliases: ["rm"])
 
-        @Flag(name: .shortAndLong, help: "Remove all networks")
-        var all = false
-
         @OptionGroup
         var global: Flags.Global
+
+        @Flag(name: .shortAndLong, help: "Remove all networks")
+        var all = false
 
         @Argument(help: "Network names")
         var networkNames: [String] = []

--- a/Sources/CLI/Network/NetworkList.swift
+++ b/Sources/CLI/Network/NetworkList.swift
@@ -28,14 +28,14 @@ extension Application {
             abstract: "List networks",
             aliases: ["ls"])
 
+        @OptionGroup
+        var global: Flags.Global
+
         @Flag(name: .shortAndLong, help: "Only output the network name")
         var quiet = false
 
         @Option(name: .long, help: "Format of the output")
         var format: ListFormat = .table
-
-        @OptionGroup
-        var global: Flags.Global
 
         func run() async throws {
             let networks = try await ClientNetwork.list()

--- a/Sources/CLI/Volume/VolumeCreate.swift
+++ b/Sources/CLI/Volume/VolumeCreate.swift
@@ -25,17 +25,17 @@ extension Application.VolumeCommand {
             abstract: "Create a volume"
         )
 
-        @Argument(help: "Volume name")
-        var name: String
-
         @Option(name: .customShort("s"), help: "Size of the volume (default: 512GB). Examples: 1G, 512MB, 2T")
         var size: String?
 
-        @Option(name: .customLong("opt"), parsing: .upToNextOption, help: "Set driver specific options")
+        @Option(name: .customLong("opt"), help: "Set driver specific options")
         var driverOpts: [String] = []
 
-        @Option(name: .customLong("label"), parsing: .upToNextOption, help: "Set metadata on a volume")
+        @Option(name: .customLong("label"), help: "Set metadata on a volume")
         var labels: [String] = []
+
+        @Argument(help: "Volume name")
+        var name: String
 
         func run() async throws {
             var parsedDriverOpts = Utility.parseKeyValuePairs(driverOpts)

--- a/Sources/Services/ContainerNetworkService/NetworkConfiguration.swift
+++ b/Sources/Services/ContainerNetworkService/NetworkConfiguration.swift
@@ -25,14 +25,30 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
     /// The preferred CIDR address for the subnet, if specified
     public let subnet: String?
 
+    /// Key-value labels for the network.
+    public var labels: [String: String] = [:]
+
     /// Creates a network configuration
     public init(
         id: String,
         mode: NetworkMode,
-        subnet: String? = nil
+        subnet: String? = nil,
+        labels: [String: String] = [:]
     ) {
         self.id = id
         self.mode = mode
         self.subnet = subnet
+        self.labels = labels
+    }
+
+    /// Create a configuration from the supplied Decoder, initializing missing
+    /// values where possible to reasonable defaults.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        id = try container.decode(String.self, forKey: .id)
+        mode = try container.decode(NetworkMode.self, forKey: .mode)
+        subnet = try container.decodeIfPresent(String.self, forKey: .subnet)
+        labels = try container.decodeIfPresent([String: String].self, forKey: .labels) ?? [:]
     }
 }

--- a/Tests/CLITests/Utilities/CLITest.swift
+++ b/Tests/CLITests/Utilities/CLITest.swift
@@ -29,6 +29,7 @@ class CLITest {
         let reference: String
     }
 
+    // These structs need to track their counterpart presentation structs in CLI.
     struct ImageInspectOutput: Codable {
         let name: String
         let variants: [variant]
@@ -39,6 +40,13 @@ class CLITest {
                 let architecture: String
             }
         }
+    }
+
+    struct NetworkInspectOutput: Codable {
+        let id: String
+        let state: String
+        let config: NetworkConfiguration
+        let status: NetworkStatus?
     }
 
     init() throws {}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -465,10 +465,13 @@ Creates a new network with the given name.
 **Usage**
 
 ```bash
-container network create NAME
+container network create NAME [OPTIONS]
 ```
 
-No additional flags; uses global options for debugging, version, and help.
+**Options**
+
+*   `--label <key=value>`: set metadata labels on the network
+*   **Global**: `--version`, `-h`/`--help`
 
 ### `container network delete (rm)`
 
@@ -530,8 +533,8 @@ container volume create [OPTIONS] NAME
 **Options**
 
 *   `-s <size>`: size of the volume (default: 512GB). Examples: `1G`, `512MB`, `2T`
-*   `--opt <key=value>`: set driver-specific options (repeatable)
-*   `--label <key=value>`: set metadata labels on the volume (repeatable)
+*   `--opt <key=value>`: set driver-specific options
+*   `--label <key=value>`: set metadata labels on the volume
 *   **Global**: `--version`, `-h`/`--help`
 
 ### `container volume delete (rm)`


### PR DESCRIPTION
- Closes #557.
- Breaking change: removes `.upToNextOption` for labels on volumes as this is not what is done for containers, and it forces the argument to precede the options if a label is supplied, which is non-intuitive.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [x] Breaking change
- [x] Documentation update

## Motivation and Context
Consistent features and UX across managed resources.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [x] Added/updated docs
