### PR TITLE
misc: update default dns command in tutorial

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -98,7 +98,7 @@ Use the `--help` flag to see which abbreviations exist.
 
 ```bash
 sudo container system dns create test
-container system property set dns.domain test
+container system dns default set test
 ```
 
 Enter your administrator password when prompted. The first command requires administrator privileges to create a file containing the domain configuration under the `/etc/resolver` directory, and to tell the macOS DNS resolver to reload its configuration files.


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context
The tutorial.md file is very useful in getting started with `container`, but there is a command that might be outdated because it doesn't currently work (at least to me). The command present in the tutorial for setting the default DNS is this `container system property set dns.domain test`, but according to the --help flag of `container`, the current command to set the default DNS is as follows: `container system dns default set test`

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [x] Added/updated docs
