### PR TITLE
Cleans up build subcommand options.

### DIFF
--- a/Sources/ContainerCommands/Builder/BuilderDelete.swift
+++ b/Sources/ContainerCommands/Builder/BuilderDelete.swift
@@ -21,21 +21,21 @@ import Foundation
 
 extension Application {
     public struct BuilderDelete: AsyncParsableCommand {
-        public init() {}
-
         public static var configuration: CommandConfiguration {
             var config = CommandConfiguration()
             config.commandName = "delete"
             config.aliases = ["rm"]
-            config._superCommandName = "builder"
-            config.abstract = "Delete builder"
-            config.usage = "\n\t builder delete [command options]"
-            config.helpNames = NameSpecification(arrayLiteral: .customShort("h"), .customLong("help"))
+            config.abstract = "Delete the builder container"
             return config
         }
 
-        @Flag(name: .shortAndLong, help: "Force delete builder even if it is running")
+        @Flag(name: .shortAndLong, help: "Delete the builder even if it is running")
         var force = false
+
+        @OptionGroup
+        var global: Flags.Global
+
+        public init() {}
 
         public func run() async throws {
             do {

--- a/Sources/ContainerCommands/Builder/BuilderStart.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStart.swift
@@ -28,27 +28,26 @@ import TerminalProgress
 
 extension Application {
     public struct BuilderStart: AsyncParsableCommand {
-        public init() {}
-
         public static var configuration: CommandConfiguration {
             var config = CommandConfiguration()
             config.commandName = "start"
-            config._superCommandName = "builder"
-            config.abstract = "Start builder"
-            config.usage = "\nbuilder start [command options]"
-            config.helpNames = NameSpecification(arrayLiteral: .customShort("h"), .customLong("help"))
+            config.abstract = "Start the builder container"
             return config
         }
 
-        @Option(name: [.customLong("cpus"), .customShort("c")], help: "Number of CPUs to allocate to the container")
+        @Option(name: .shortAndLong, help: "Number of CPUs to allocate to the builder container")
         var cpus: Int64 = 2
 
         @Option(
-            name: [.customLong("memory"), .customShort("m")],
-            help:
-                "Amount of memory in bytes, kilobytes (K), megabytes (M), or gigabytes (G) for the container, with MB granularity (for example, 1024K will result in 1MB being allocated for the container)"
+            name: .shortAndLong,
+            help: "Amount of builder container memory (1MiByte granularity), with optional K, M, G, T, or P suffix"
         )
         var memory: String = "2048MB"
+
+        @OptionGroup
+        var global: Flags.Global
+
+        public init() {}
 
         public func run() async throws {
             let progressConfig = try ProgressConfig(

--- a/Sources/ContainerCommands/Builder/BuilderStop.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStop.swift
@@ -21,17 +21,17 @@ import Foundation
 
 extension Application {
     public struct BuilderStop: AsyncParsableCommand {
-        public init() {}
-
         public static var configuration: CommandConfiguration {
             var config = CommandConfiguration()
             config.commandName = "stop"
-            config._superCommandName = "builder"
-            config.abstract = "Stop builder"
-            config.usage = "\n\t builder stop"
-            config.helpNames = NameSpecification(arrayLiteral: .customShort("h"), .customLong("help"))
+            config.abstract = "Stop the builder container"
             return config
         }
+
+        @OptionGroup
+        var global: Flags.Global
+
+        public init() {}
 
         public func run() async throws {
             do {

--- a/Sources/ContainerCommands/Container/ContainerDelete.swift
+++ b/Sources/ContainerCommands/Container/ContainerDelete.swift
@@ -28,7 +28,7 @@ extension Application {
             abstract: "Delete one or more containers",
             aliases: ["rm"])
 
-        @Flag(name: .shortAndLong, help: "Force the removal of one or more running containers")
+        @Flag(name: .shortAndLong, help: "Delete containers even if they are running")
         var force = false
 
         @Flag(name: .shortAndLong, help: "Remove all containers")


### PR DESCRIPTION
- Part of #515.
- Order options alphabetically.
- Use `container ls` options for `builder status`.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [x] Breaking change - Change options and output of `builder status`.
- [x] Documentation update

## Motivation and Context
See #515.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [x] Added/updated docs
