### PR TITLE
Cleans up network and volume subcommands.

### DIFF
--- a/Sources/ContainerCommands/Network/NetworkCommand.swift
+++ b/Sources/ContainerCommands/Network/NetworkCommand.swift
@@ -18,7 +18,6 @@ import ArgumentParser
 
 extension Application {
     public struct NetworkCommand: AsyncParsableCommand {
-        public init() {}
         public static let configuration = CommandConfiguration(
             commandName: "network",
             abstract: "Manage container networks",
@@ -30,5 +29,7 @@ extension Application {
             ],
             aliases: ["n"]
         )
+
+        public init() {}
     }
 }

--- a/Sources/ContainerCommands/Network/NetworkCreate.swift
+++ b/Sources/ContainerCommands/Network/NetworkCreate.swift
@@ -23,19 +23,20 @@ import TerminalProgress
 
 extension Application {
     public struct NetworkCreate: AsyncParsableCommand {
-        public init() {}
         public static let configuration = CommandConfiguration(
             commandName: "create",
             abstract: "Create a new network")
 
+        @Option(name: .customLong("label"), help: "Set metadata for a network")
+        var labels: [String] = []
+
         @OptionGroup
         var global: Flags.Global
 
-        @Option(name: .customLong("label"), help: "Set metadata on a network")
-        var labels: [String] = []
-
         @Argument(help: "Network name")
         var name: String
+
+        public init() {}
 
         public func run() async throws {
             let parsedLabels = Utility.parseKeyValuePairs(labels)

--- a/Sources/ContainerCommands/Network/NetworkDelete.swift
+++ b/Sources/ContainerCommands/Network/NetworkDelete.swift
@@ -22,20 +22,21 @@ import Foundation
 
 extension Application {
     public struct NetworkDelete: AsyncParsableCommand {
-        public init() {}
         public static let configuration = CommandConfiguration(
             commandName: "delete",
             abstract: "Delete one or more networks",
             aliases: ["rm"])
 
+        @Flag(name: .shortAndLong, help: "Delete all networks")
+        var all = false
+
         @OptionGroup
         var global: Flags.Global
 
-        @Flag(name: .shortAndLong, help: "Remove all networks")
-        var all = false
-
         @Argument(help: "Network names")
         var networkNames: [String] = []
+
+        public init() {}
 
         public func validate() throws {
             if networkNames.count == 0 && !all {

--- a/Sources/ContainerCommands/Network/NetworkInspect.swift
+++ b/Sources/ContainerCommands/Network/NetworkInspect.swift
@@ -22,16 +22,17 @@ import SwiftProtobuf
 
 extension Application {
     public struct NetworkInspect: AsyncParsableCommand {
-        public init() {}
         public static let configuration = CommandConfiguration(
             commandName: "inspect",
             abstract: "Display information about one or more networks")
 
+        @Argument(help: "Networks to inspect")
+        var networks: [String]
+
         @OptionGroup
         var global: Flags.Global
 
-        @Argument(help: "Networks to inspect")
-        var networks: [String]
+        public init() {}
 
         public func run() async throws {
             let objects: [any Codable] = try await ClientNetwork.list().filter {

--- a/Sources/ContainerCommands/Network/NetworkList.swift
+++ b/Sources/ContainerCommands/Network/NetworkList.swift
@@ -23,20 +23,21 @@ import SwiftProtobuf
 
 extension Application {
     public struct NetworkList: AsyncParsableCommand {
-        public init() {}
         public static let configuration = CommandConfiguration(
             commandName: "list",
             abstract: "List networks",
             aliases: ["ls"])
 
-        @Flag(name: .shortAndLong, help: "Only output the network name")
-        var quiet = false
-
         @Option(name: .long, help: "Format of the output")
         var format: ListFormat = .table
 
+        @Flag(name: .shortAndLong, help: "Only output the network name")
+        var quiet = false
+
         @OptionGroup
         var global: Flags.Global
+
+        public init() {}
 
         public func run() async throws {
             let networks = try await ClientNetwork.list()

--- a/Sources/ContainerCommands/Volume/VolumeCommand.swift
+++ b/Sources/ContainerCommands/Volume/VolumeCommand.swift
@@ -18,7 +18,6 @@ import ArgumentParser
 
 extension Application {
     public struct VolumeCommand: AsyncParsableCommand {
-        public init() {}
         public static let configuration = CommandConfiguration(
             commandName: "volume",
             abstract: "Manage container volumes",
@@ -30,5 +29,7 @@ extension Application {
             ],
             aliases: ["v"]
         )
+
+        public init() {}
     }
 }

--- a/Sources/ContainerCommands/Volume/VolumeCreate.swift
+++ b/Sources/ContainerCommands/Volume/VolumeCreate.swift
@@ -20,23 +20,27 @@ import Foundation
 
 extension Application.VolumeCommand {
     public struct VolumeCreate: AsyncParsableCommand {
-        public init() {}
         public static let configuration = CommandConfiguration(
             commandName: "create",
             abstract: "Create a volume"
         )
 
-        @Option(name: .customShort("s"), help: "Size of the volume (default: 512GB). Examples: 1G, 512MB, 2T")
-        var size: String?
+        @Option(name: .customLong("label"), help: "Set metadata for a volume")
+        var labels: [String] = []
 
         @Option(name: .customLong("opt"), help: "Set driver specific options")
         var driverOpts: [String] = []
 
-        @Option(name: .customLong("label"), help: "Set metadata on a volume")
-        var labels: [String] = []
+        @Option(name: .short, help: "Size of the volume in bytes, with optional K, M, G, T, or P suffix")
+        var size: String?
+
+        @OptionGroup
+        var global: Flags.Global
 
         @Argument(help: "Volume name")
         var name: String
+
+        public init() {}
 
         public func run() async throws {
             var parsedDriverOpts = Utility.parseKeyValuePairs(driverOpts)

--- a/Sources/ContainerCommands/Volume/VolumeInspect.swift
+++ b/Sources/ContainerCommands/Volume/VolumeInspect.swift
@@ -20,14 +20,18 @@ import Foundation
 
 extension Application.VolumeCommand {
     public struct VolumeInspect: AsyncParsableCommand {
-        public init() {}
         public static let configuration = CommandConfiguration(
             commandName: "inspect",
-            abstract: "Display detailed information on one or more volumes"
+            abstract: "Display information about one or more volumes"
         )
 
-        @Argument(help: "Volume name(s)")
+        @OptionGroup
+        var global: Flags.Global
+
+        @Argument(help: "Volume names")
         var names: [String]
+
+        public init() {}
 
         public func run() async throws {
             var volumes: [Volume] = []

--- a/Sources/ContainerCommands/Volume/VolumeList.swift
+++ b/Sources/ContainerCommands/Volume/VolumeList.swift
@@ -21,18 +21,22 @@ import Foundation
 
 extension Application.VolumeCommand {
     public struct VolumeList: AsyncParsableCommand {
-        public init() {}
         public static let configuration = CommandConfiguration(
             commandName: "list",
             abstract: "List volumes",
             aliases: ["ls"]
         )
 
-        @Flag(name: .shortAndLong, help: "Only display volume names")
-        var quiet: Bool = false
-
         @Option(name: .long, help: "Format of the output")
         var format: Application.ListFormat = .table
+
+        @Flag(name: .shortAndLong, help: "Only output the volume name")
+        var quiet: Bool = false
+
+        @OptionGroup
+        var global: Flags.Global
+
+        public init() {}
 
         public func run() async throws {
             let volumes = try await ClientVolume.list()


### PR DESCRIPTION
- Part of #515.
- Order options alphabetically.
- Use consistent delete logic for network and volume delete.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
See #515

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
