### PR TITLE
Fix races in the `SandboxService` actor due to reentrancy after `await` calls

### DIFF
--- a/Sources/Services/ContainerSandboxService/SandboxService.swift
+++ b/Sources/Services/ContainerSandboxService/SandboxService.swift
@@ -615,7 +615,6 @@ public actor SandboxService {
         }
 
         let exitCode = await withCheckedContinuation { cc in
-            // Is this safe since we are in an actor? :(
             self.addWaiter(id: id, cont: cc)
         }
         let reply = message.reply()


### PR DESCRIPTION
This PR fixes several races with the `stop()` and `shutdown()` methods without moving all state transitions inside a lock. The alternative approach: https://github.com/apple/container/pull/684.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Improve the stability of container.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
