### PR TITLE
Updates containerization to 0.9.1.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d852788a1449a5b3bdf211eea6fb59f173f6c8b3398bae619b5dc9c591d1620f",
+  "originHash" : "e8a26d708e3d286b0e29d74d94b6ff1539848a7a9fd209a230faedae5e285003",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,14 +15,14 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "511dd59e19a1b71127337639f5db7d7cc952b88c",
-        "version" : "0.8.1"
+        "revision" : "992ed9f5aa3b0e875ef8ac6b605a4c352218463b",
+        "version" : "0.9.1"
       }
     },
     {
       "identity" : "dns",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Bouke/DNS.git",
+      "location" : "https://github.com/Bouke/DNS",
       "state" : {
         "revision" : "78bbd1589890a90b202d11d5f9e1297050cf0eb2",
         "version" : "1.2.0"
@@ -31,7 +31,7 @@
     {
       "identity" : "dnsclient",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/orlandos-nl/DNSClient.git",
+      "location" : "https://github.com/orlandos-nl/DNSClient",
       "state" : {
         "revision" : "551fbddbf4fa728d4cd86f6a5208fe4f925f0549",
         "version" : "2.4.4"

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ import PackageDescription
 let releaseVersion = ProcessInfo.processInfo.environment["RELEASE_VERSION"] ?? "0.0.0"
 let gitCommit = ProcessInfo.processInfo.environment["GIT_COMMIT"] ?? "unspecified"
 let builderShimVersion = "0.6.1"
-let scVersion = "0.8.1"
+let scVersion = "0.9.1"
 
 let package = Package(
     name: "container",

--- a/Sources/ContainerClient/Core/XPC+.swift
+++ b/Sources/ContainerClient/Core/XPC+.swift
@@ -36,6 +36,8 @@ public enum XPCKeys: String {
     case port
     /// Exit code for a process
     case exitCode
+    /// Exit timestamp for a process
+    case exitedAt
     /// An event that occurred in a container
     case containerEvent
     /// Error key.
@@ -207,6 +209,14 @@ extension XPCMessage {
 
     public func set(key: XPCKeys, value: Int) {
         set(key: key.rawValue, value: Int64(value))
+    }
+
+    public func date(key: XPCKeys) -> Date {
+        date(key: key.rawValue)
+    }
+
+    public func set(key: XPCKeys, value: Date) {
+        set(key: key.rawValue, value: value)
     }
 
     public func fileHandle(key: XPCKeys) -> FileHandle? {

--- a/Sources/ContainerClient/ExitMonitor.swift
+++ b/Sources/ContainerClient/ExitMonitor.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import Containerization
 import ContainerizationError
 import ContainerizationExtras
 import Foundation
@@ -22,10 +23,10 @@ import Logging
 /// Track when long running work exits, and notify the caller via a callback.
 public actor ExitMonitor {
     /// A callback that receives the client identifier and exit code.
-    public typealias ExitCallback = @Sendable (String, Int32) async throws -> Void
+    public typealias ExitCallback = @Sendable (String, ExitStatus) async throws -> Void
 
     /// A function that waits for work to complete, returning an exit code.
-    public typealias WaitHandler = @Sendable () async throws -> Int32
+    public typealias WaitHandler = @Sendable () async throws -> ExitStatus
 
     /// Create a new monitor.
     ///
@@ -83,7 +84,7 @@ public actor ExitMonitor {
                 try await onExit(id, exitStatus)
             } catch {
                 self.log?.error("WaitHandler for \(id) threw error \(String(describing: error))")
-                try? await onExit(id, -1)
+                try? await onExit(id, ExitStatus(exitCode: -1))
             }
         }
     }

--- a/Sources/ContainerClient/SandboxClient.swift
+++ b/Sources/ContainerClient/SandboxClient.swift
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import ContainerXPC
+import Containerization
 import ContainerizationError
 import ContainerizationOS
 import Foundation
@@ -217,7 +218,7 @@ extension SandboxClient {
         }
     }
 
-    public func wait(_ id: String) async throws -> Int32 {
+    public func wait(_ id: String) async throws -> ExitStatus {
         let request = XPCMessage(route: SandboxRoutes.wait.rawValue)
         request.set(key: .id, value: id)
 
@@ -232,7 +233,8 @@ extension SandboxClient {
             )
         }
         let code = response.int64(key: .exitCode)
-        return Int32(code)
+        let date = response.date(key: .exitedAt)
+        return ExitStatus(exitCode: Int32(code), exitedAt: date)
     }
 
     public func dial(_ port: UInt32) async throws -> FileHandle {

--- a/Sources/ContainerXPC/XPCMessage.swift
+++ b/Sources/ContainerXPC/XPCMessage.swift
@@ -201,6 +201,20 @@ extension XPCMessage {
         }
     }
 
+    public func date(key: String) -> Date {
+        lock.withLock {
+            let nsSinceEpoch = xpc_dictionary_get_date(self.object, key)
+            return Date(timeIntervalSince1970: TimeInterval(nsSinceEpoch) / 1_000_000_000)
+        }
+    }
+
+    public func set(key: String, value: Date) {
+        lock.withLock {
+            let nsSinceEpoch = Int64(value.timeIntervalSince1970 * 1_000_000_000)
+            xpc_dictionary_set_date(self.object, key, nsSinceEpoch)
+        }
+    }
+
     public func fileHandle(key: String) -> FileHandle? {
         let fd = lock.withLock {
             xpc_dictionary_get_value(self.object, key)

--- a/Sources/Services/ContainerAPIService/Containers/ContainersHarness.swift
+++ b/Sources/Services/ContainerAPIService/Containers/ContainersHarness.swift
@@ -104,9 +104,10 @@ public struct ContainersHarness: Sendable {
             )
         }
 
-        let exitCode = try await service.wait(id: id, processID: processID)
+        let exitStatus = try await service.wait(id: id, processID: processID)
         let reply = message.reply()
-        reply.set(key: .exitCode, value: Int64(exitCode))
+        reply.set(key: .exitCode, value: Int64(exitStatus.exitCode))
+        reply.set(key: .exitedAt, value: exitStatus.exitedAt)
         return reply
     }
 

--- a/Sources/Services/ContainerAPIService/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Containers/ContainersService.swift
@@ -352,7 +352,7 @@ public actor ContainersService {
 
     /// Wait waits for the container's init process or exec to exit and returns the
     /// exit status.
-    public func wait(id: String, processID: String) async throws -> Int32 {
+    public func wait(id: String, processID: String) async throws -> ExitStatus {
         self.log.debug("\(#function)")
 
         let state = try self._getContainerState(id: id)
@@ -423,13 +423,13 @@ public actor ContainersService {
         }
     }
 
-    private func handleContainerExit(id: String, code: Int32? = nil) async throws {
+    private func handleContainerExit(id: String, code: ExitStatus? = nil) async throws {
         try await self.lock.withLock { [self] context in
             try await handleContainerExit(id: id, code: code, context: context)
         }
     }
 
-    private func handleContainerExit(id: String, code: Int32?, context: AsyncLock.Context) async throws {
+    private func handleContainerExit(id: String, code: ExitStatus?, context: AsyncLock.Context) async throws {
         if let code {
             self.log.info("Handling container \(id) exit. Code \(code)")
         }

--- a/Tests/CLITests/Subcommands/Run/TestCLIRunOptions.swift
+++ b/Tests/CLITests/Subcommands/Run/TestCLIRunOptions.swift
@@ -435,7 +435,7 @@ class TestCLIRunCommand: CLITest {
                 "nameserver \(expectedDns)",
                 "domain \(expectedDomain)",
                 "search \(expectedSearch)",
-                "opts \(expectedOption)",
+                "options \(expectedOption)",
             ]
             #expect(expectedLines == actualLines)
         } catch {


### PR DESCRIPTION
- Converts client to work with ExitStatus instead of integer error codes.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [x] Breaking change (SandboxClient.wait() returns ExitStatus instead of Int32, apple/containerization#300)
- [ ] Documentation update

## Motivation and Context
[Why is this change needed?]

## Testing
- [x] Tested locally
- [x] Added/updated tests (fixed DNS test, using correct `options` now, apple/containerization#303).
- [ ] Added/updated docs
