### PR TITLE
Remove StandardErrorPath and StandardOutPath from launchd plists

### DIFF
--- a/Sources/ContainerCommands/System/SystemStart.swift
+++ b/Sources/ContainerCommands/System/SystemStart.swift
@@ -75,15 +75,12 @@ extension Application {
             env[ApplicationRoot.environmentName] = appRoot.path(percentEncoded: false)
             env[InstallRoot.environmentName] = installRoot.path(percentEncoded: false)
 
-            let logURL = apiServerDataUrl.appending(path: "apiserver.log")
             let plist = LaunchPlist(
                 label: "com.apple.container.apiserver",
                 arguments: args,
                 environment: env,
                 limitLoadToSessionType: [.Aqua, .Background, .System],
                 runAtLoad: true,
-                stdout: logURL.path,
-                stderr: logURL.path,
                 machServices: ["com.apple.container.apiserver"]
             )
 

--- a/Sources/ContainerPlugin/PluginLoader.swift
+++ b/Sources/ContainerPlugin/PluginLoader.swift
@@ -218,15 +218,12 @@ extension PluginLoader {
         env[ApplicationRoot.environmentName] = appRoot.path(percentEncoded: false)
         env[InstallRoot.environmentName] = installRoot.path(percentEncoded: false)
 
-        let logUrl = rootURL.appendingPathComponent("service.log")
         let plist = LaunchPlist(
             label: id,
             arguments: [plugin.binaryURL.path] + (args ?? serviceConfig.defaultArguments),
             environment: env,
             limitLoadToSessionType: [.Aqua, .Background, .System],
             runAtLoad: serviceConfig.runAtLoad,
-            stdout: logUrl.path,
-            stderr: logUrl.path,
             machServices: plugin.getMachServices(instanceId: instanceId)
         )
 


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context
We setup logging for the services in `container` using OSLog. See [here](https://github.com/apple/container/blob/73709232d2705b7008b7380fe90a373059b6074a/Sources/Helpers/APIServer/APIServer.swift#L31). This makes it unnecessary to redirect stderr and stdio for these services. Additionally, there are some cases where failure to open or write to the path given for StandardErrorPath or StandardOutPath in a service's plist could result in a failure to start a service through `launchctl`. 

Related to https://github.com/apple/container/discussions/713

## Testing
- [x] Tested locally
