### PR TITLE
Moves `.build` directory to `builder`.

### DIFF
--- a/Sources/ContainerCommands/BuildCommand.swift
+++ b/Sources/ContainerCommands/BuildCommand.swift
@@ -186,7 +186,8 @@ extension Application {
 
                 let dockerfile = try Data(contentsOf: URL(filePath: file))
                 let systemHealth = try await ClientHealthCheck.ping(timeout: .seconds(10))
-                let exportPath = systemHealth.appRoot.appendingPathComponent(".build")
+                let exportPath = systemHealth.appRoot
+                    .appendingPathComponent(Application.BuilderCommand.builderResourceDir)
                 let buildID = UUID().uuidString
                 let tempURL = exportPath.appendingPathComponent(buildID)
                 try FileManager.default.createDirectory(at: tempURL, withIntermediateDirectories: true, attributes: nil)

--- a/Sources/ContainerCommands/Builder/Builder.swift
+++ b/Sources/ContainerCommands/Builder/Builder.swift
@@ -20,6 +20,7 @@ extension Application {
     public struct BuilderCommand: AsyncParsableCommand {
         public init() {}
 
+        public static let builderResourceDir = "builder"
         public static let configuration = CommandConfiguration(
             commandName: "builder",
             abstract: "Manage an image builder instance",

--- a/Sources/ContainerCommands/Builder/BuilderStart.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStart.swift
@@ -74,7 +74,9 @@ extension Application {
 
             let builderImage: String = DefaultsStore.get(key: .defaultBuilderImage)
             let systemHealth = try await ClientHealthCheck.ping(timeout: .seconds(10))
-            let exportsMount: String = systemHealth.appRoot.appendingPathComponent(".build").absolutePath()
+            let exportsMount: String = systemHealth.appRoot
+                .appendingPathComponent(Application.BuilderCommand.builderResourceDir)
+                .absolutePath()
 
             if !FileManager.default.fileExists(atPath: exportsMount) {
                 try FileManager.default.createDirectory(


### PR DESCRIPTION
Closes #416.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [x] Breaking change (possibly, I would think we're just going to leave an unused `.build` directory behind which we can document, but can run more tests next week).
- [ ] Documentation update

## Motivation and Context
We have nothing to hide?

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
