### PR TITLE
Add app bundle Info.plist as a system property source.

### DIFF
--- a/Sources/ContainerPersistence/DefaultsStore.swift
+++ b/Sources/ContainerPersistence/DefaultsStore.swift
@@ -41,8 +41,9 @@ public enum DefaultsStore {
     }
 
     public static func get(key: DefaultsStore.Keys) -> String {
-        let current = udSuite.string(forKey: key.rawValue)
-        return current ?? key.defaultValue
+        udSuite.string(forKey: key.rawValue)
+            ?? Bundle.main.infoDictionary?["\(Self.userDefaultDomain).\(key.rawValue)"] as? String
+            ?? key.defaultValue
     }
 
     public static func getOptional(key: DefaultsStore.Keys) -> String? {
@@ -54,8 +55,11 @@ public enum DefaultsStore {
     }
 
     public static func getBool(key: DefaultsStore.Keys) -> Bool? {
-        guard udSuite.object(forKey: key.rawValue) != nil else { return nil }
-        return udSuite.bool(forKey: key.rawValue)
+        if udSuite.object(forKey: key.rawValue) != nil {
+            return udSuite.bool(forKey: key.rawValue)
+        }
+        return Bundle.main.infoDictionary?["\(Self.userDefaultDomain).\(key.rawValue)"] as? Bool
+            ?? Bool(key.defaultValue)
     }
 
     public static func allValues() -> [DefaultsStoreValue] {


### PR DESCRIPTION
- Closes #708.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Allows `container` and services/plugins to get backstop defaults from `Info.plist` properties if repackaged into a signed app bundle.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
