### PR TITLE
Update make-docs.sh to prevent HTML errors

### DIFF
--- a/scripts/make-docs.sh
+++ b/scripts/make-docs.sh
@@ -39,9 +39,11 @@ fi
 echo '{}' > "$1/theme-settings.json"
 
 cat > "$1/index.html" <<'EOF'
+<!DOCTYPE html>
 <html lang="en-US">
   <head>
     <meta charset="utf-8">
+    <title>Redirecting...</title>
     <meta http-equiv="refresh" content="0; url=./documentation/">
   </head>
   <body>


### PR DESCRIPTION
Fix 2 HTML errors:
1) Start tag seen without seeing a doctype first. Expected <!DOCTYPE html>. 
2) Element head is missing a required instance of child element title.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Simple page contains HTML validation errors.
It's easy fix for prevent errors.

<details><summary>Screens from validator.w3.org</summary>
<p>

<img width="1806" height="607" alt="image" src="https://github.com/user-attachments/assets/d18e5a82-6f57-41ef-91ae-c5e4065de3c0" />

<img width="1807" height="315" alt="image" src="https://github.com/user-attachments/assets/a52bd831-ec9c-4b58-8ef7-3ad6c3aa21d1" />

</p>
</details> 



## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
