### PR TITLE
Add test for trimDigest utility function

### DIFF
--- a/Tests/ContainerClientTests/UtilityTests.swift
+++ b/Tests/ContainerClientTests/UtilityTests.swift
@@ -51,4 +51,10 @@ struct UtilityTests {
         #expect(result["standalone"] == "")
         #expect(result["key2"] == "value2")
     }
+
+    @Test("Trim digest removes sha256 prefix")
+    func testTrimDigestRemovesPrefix() {
+        let result = Utility.trimDigest(digest: "sha256:abc123")
+        #expect(result == "abc123")
+    }
 }


### PR DESCRIPTION
## Type of Change
- [x] Test addition

## Motivation and Context
The function removes the "sha256:" prefix from digests. This test  ensures the function works correctly and prevents regressions.

## Testing
- [x] Tested locally (verified with standalone test script)
- [x] Added/updated tests (added testTrimDigestRemovesPrefix)

```
Test behavior:
- Input:  `"sha256:abc123"`
- Expected:  `"abc123"` (prefix removed)
- Actual:  `"abc123"` 
```
