### PR TITLE
add support for multiple --tag flags in build

### DIFF
--- a/Sources/ContainerBuild/Builder.swift
+++ b/Sources/ContainerBuild/Builder.swift
@@ -243,7 +243,7 @@ public struct Builder: Sendable {
         public let noCache: Bool
         public let platforms: [Platform]
         public let terminal: Terminal?
-        public let tag: String
+        public let tags: [String]
         public let target: String
         public let quiet: Bool
         public let exports: [BuildExport]
@@ -260,7 +260,7 @@ public struct Builder: Sendable {
             noCache: Bool,
             platforms: [Platform],
             terminal: Terminal?,
-            tag: String,
+            tags: [String],
             target: String,
             quiet: Bool,
             exports: [BuildExport],
@@ -276,7 +276,7 @@ public struct Builder: Sendable {
             self.noCache = noCache
             self.platforms = platforms
             self.terminal = terminal
-            self.tag = tag
+            self.tags = tags
             self.target = target
             self.quiet = quiet
             self.exports = exports
@@ -312,9 +312,11 @@ extension CallOptions {
             ("context", URL(filePath: config.contextDir).path(percentEncoded: false)),
             ("dockerfile", config.dockerfile.base64EncodedString()),
             ("progress", config.terminal != nil ? "tty" : "plain"),
-            ("tag", config.tag),
             ("target", config.target),
         ]
+        for tag in config.tags {
+            headers.append(("tag", tag))
+        }
         for platform in config.platforms {
             headers.append(("platforms", platform.description))
         }

--- a/Tests/CLITests/Subcommands/Build/CLIBuildBase.swift
+++ b/Tests/CLITests/Subcommands/Build/CLIBuildBase.swift
@@ -83,7 +83,23 @@ class TestCLIBuildBase: CLITest {
         otherArgs: [String] = []
     ) throws -> String {
         try buildWithPaths(
-            tag: tag,
+            tags: [tag],
+            tempContext: tempDir,
+            tempDockerfileContext: tempDir,
+            buildArgs: buildArgs,
+            otherArgs: otherArgs
+        )
+    }
+
+    @discardableResult
+    func build(
+        tags: [String],
+        tempDir: URL,
+        buildArgs: [String] = [],
+        otherArgs: [String] = []
+    ) throws -> String {
+        try buildWithPaths(
+            tags: tags,
             tempContext: tempDir,
             tempDockerfileContext: tempDir,
             buildArgs: buildArgs,
@@ -95,7 +111,7 @@ class TestCLIBuildBase: CLITest {
     // the dockerfile path. If both paths are the same, use `build` func above.
     @discardableResult
     func buildWithPaths(
-        tag: String,
+        tags: [String],
         tempContext: URL,
         tempDockerfileContext: URL,
         buildArgs: [String] = [],
@@ -107,9 +123,11 @@ class TestCLIBuildBase: CLITest {
             "build",
             "-f",
             tempDockerfileContext.appendingPathComponent("Dockerfile").path,
-            "-t",
-            tag,
         ]
+        for tag in tags {
+            args.append("-t")
+            args.append(tag)
+        }
         for arg in buildArgs {
             args.append("--build-arg")
             args.append(arg)

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -102,7 +102,7 @@ container build [OPTIONS] [CONTEXT-DIR]
 *   `--platform <platform>`: Add the platform to the build (takes precedence over --os and --arch)
 *   `--progress <type>`: Progress type (format: auto|plain|tty)] (default: auto)
 *   `-q, --quiet`: Suppress build output
-*   `-t, --tag <name>`: Name for the built image
+*   `-t, --tag <name>`: Name for the built image (can be specified multiple times)
 *   `--target <stage>`: Set the target build stage
 *   `--vsock-port <port>`: Builder shim vsock port (default: 8088)
 *   `--version`: Show the version.
@@ -122,6 +122,9 @@ container build --build-arg NODE_VERSION=18 -t my-app .
 
 # build the production stage only and disable cache
 container build --target production --no-cache -t my-app:prod .
+
+# build with multiple tags
+container build -t my-app:latest -t my-app:v1.0.0 -t my-app:stable .
 ```
 
 ## Container Management


### PR DESCRIPTION
- Closes #732.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Adds support for specifying multiple `-t` / `--tag` flags with the `build` command. All specified tags will point to the same built image.

Example:
`container build -t myapp:latest -t myapp:v1.0.0 -t myapp:stable .`

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [x] Added/updated docs