### PR TITLE
Raise createEndpoint response timeout

### DIFF
--- a/Sources/ContainerClient/SandboxClient.swift
+++ b/Sources/ContainerClient/SandboxClient.swift
@@ -52,7 +52,7 @@ public struct SandboxClient: Sendable {
 
         let response: XPCMessage
         do {
-            response = try await client.send(request, responseTimeout: .seconds(3))
+            response = try await client.send(request, responseTimeout: .seconds(5))
         } catch {
             throw ContainerizationError(
                 .internalError,


### PR DESCRIPTION
We unfortunately hold some rather large locks in container svc, and I'm curious to see if this has any effect on the sporadic ep timeout we've seen the last day or so in the meantime while we pick apart the large locks.
