### PR TITLE
[build-command]: refactor --progress option

### DIFF
--- a/Sources/ContainerCommands/BuildCommand.swift
+++ b/Sources/ContainerCommands/BuildCommand.swift
@@ -38,6 +38,12 @@ extension Application {
             return config
         }
 
+        enum ProgressType: String, ExpressibleByArgument {
+            case auto
+            case plain
+            case tty
+        }
+
         @Option(
             name: .shortAndLong,
             help: ArgumentHelp("Add the architecture type to the build", valueName: "value"),
@@ -99,8 +105,8 @@ extension Application {
         )
         var platform: [[String]] = [[]]
 
-        @Option(name: .long, help: ArgumentHelp("Progress type (format: auto|plain|tty)]", valueName: "type"))
-        var progress: String = "auto"
+        @Option(name: .long, help: ArgumentHelp("Progress type (format: auto|plain|tty)", valueName: "type"))
+        var progress: ProgressType = .auto
 
         @Flag(name: .shortAndLong, help: "Suppress build output")
         var quiet: Bool = false
@@ -221,14 +227,12 @@ extension Application {
 
                 var terminal: Terminal?
                 switch self.progress {
-                case "tty":
+                case .tty:
                     terminal = try Terminal(descriptor: STDERR_FILENO)
-                case "auto":
+                case .auto:
                     terminal = try? Terminal(descriptor: STDERR_FILENO)
-                case "plain":
+                case .plain:
                     terminal = nil
-                default:
-                    throw ContainerizationError(.invalidArgument, message: "invalid progress mode \(self.progress)")
                 }
 
                 defer { terminal?.tryReset() }


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context

Relates to #808

This PR is a refactor to add the `ProgressType` enum for the `--progress` option + fixing a typo in the command help.

## Testing
- [ ] Tested locally
- [ ] Added/updated tests
- [x] Added/updated docs
