### PR TITLE
fix: connect to backend immediately on channel active for server-first protocols(#794)

### DIFF
--- a/Sources/SocketForwarder/ConnectHandler.swift
+++ b/Sources/SocketForwarder/ConnectHandler.swift
@@ -35,9 +35,6 @@ extension ConnectHandler: ChannelInboundHandler {
     typealias OutboundOut = ByteBuffer
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        if self.pendingBytes.isEmpty {
-            self.connectToServer(context: context)
-        }
         self.pendingBytes.append(data)
     }
 
@@ -45,6 +42,12 @@ extension ConnectHandler: ChannelInboundHandler {
         // Add logger metadata.
         self.log?[metadataKey: "proxy"] = "\(context.channel.localAddress?.description ?? "none")"
         self.log?[metadataKey: "server"] = "\(context.channel.remoteAddress?.description ?? "none")"
+    }
+
+    func channelActive(context: ChannelHandlerContext) {
+        self.log?.trace("frontend - channel active, connecting to backend")
+        self.connectToServer(context: context)
+        context.fireChannelActive()
     }
 }
 


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
closes #794 

TCP port forwarding currently fails for server-first protocols (SMTP, FTP, SSH, PostgreSQL) because the backend connection is only established when the client sends data. 

**Current behavior in `ConnectHandler.swift`:**
```swift
func channelRead(context: ChannelHandlerContext, data: NIOAny) {
    if self.pendingBytes.isEmpty {
        self.connectToServer(context: context)  // Only connects on first data!
    }
}
```

This breaks any protocol where the server speaks first.

**The fix:**
Connect to the backend immediately when the channel becomes active, not when data arrives. This allows bidirectional communication from the start.

## Testing
- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
