### PR TITLE
fix: persist auto-assigned network subnet across system restarts

### DIFF
--- a/Sources/Services/ContainerNetworkService/ReservedVmnetNetwork.swift
+++ b/Sources/Services/ContainerNetworkService/ReservedVmnetNetwork.swift
@@ -148,6 +148,15 @@ public final class ReservedVmnetNetwork: Network {
         let runningSubnet = try CIDRAddress(lower: lower, upper: upper)
         let runningGateway = IPv4Address(fromValue: runningSubnet.lower.value + 1)
 
+        // Save auto-assigned subnet to persist across restarts (fixes #835)
+        if configuration.subnet == nil {
+            DefaultsStore.setOptional(key: .defaultSubnet, value: runningSubnet.description)
+            log.info(
+                "saved auto-assigned subnet for persistence",
+                metadata: ["subnet": "\(runningSubnet)"]
+            )
+        }
+
         log.info(
             "started vmnet network",
             metadata: [


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Closes #835

In `ReservedVmnetNetwork.swift`, after retrieving the auto-assigned subnet from macOS, save it to `DefaultsStore` so it's reused on subsequent restarts.

**Code Changes:**
```swift
// After getting subnet from macOS, persist it
if configuration.subnet == nil {
    DefaultsStore.setOptional(key: .defaultSubnet, value: runningSubnet.description)
}
```

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
