### PR TITLE
Automatically clean up anonymous volumes for containers   with --rm flag

### DIFF
--- a/Sources/ContainerClient/Core/Volume.swift
+++ b/Sources/ContainerClient/Core/Volume.swift
@@ -62,9 +62,17 @@ extension Volume {
     /// Reserved label key for marking anonymous volumes
     public static let anonymousLabel = "com.apple.container.resource.anonymous"
 
+    /// Reserved label key for storing the container ID that created this volume
+    public static let createdByLabel = "com.apple.container.resource.created-by"
+
     /// Whether this is an anonymous volume (detected via label)
     public var isAnonymous: Bool {
         labels[Self.anonymousLabel] != nil
+    }
+
+    /// The container ID that created this volume
+    public var createdByContainerID: String? {
+        labels[Self.createdByLabel]
     }
 }
 

--- a/Sources/ContainerClient/Utility.swift
+++ b/Sources/ContainerClient/Utility.swift
@@ -168,7 +168,7 @@ public struct Utility {
             case .filesystem(let fs):
                 resolvedMounts.append(fs)
             case .volume(let parsed):
-                let volume = try await getOrCreateVolume(parsed: parsed)
+                let volume = try await getOrCreateVolume(parsed: parsed, containerID: id)
                 let volumeMount = Filesystem.volume(
                     name: parsed.name,
                     format: volume.format,
@@ -315,8 +315,11 @@ public struct Utility {
 
     /// Gets an existing volume or creates it if it doesn't exist.
     /// Shows a warning for named volumes when auto-creating.
-    private static func getOrCreateVolume(parsed: ParsedVolume) async throws -> Volume {
-        let labels = parsed.isAnonymous ? [Volume.anonymousLabel: ""] : [:]
+    private static func getOrCreateVolume(parsed: ParsedVolume, containerID: String) async throws -> Volume {
+        var labels = parsed.isAnonymous ? [Volume.anonymousLabel: ""] : [:]
+        if parsed.isAnonymous {
+            labels[Volume.createdByLabel] = containerID
+        }
 
         let volume: Volume
         do {

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -711,7 +711,7 @@ container run -v $VOL:/data alpine
 container volume rm $VOL
 ```
 
-**Note**: Unlike Docker, anonymous volumes do NOT auto-cleanup with `--rm`. Manual deletion is required.
+**Note**: Anonymous volumes auto-cleanup when containers exit with `--rm` flag. Without `--rm`, they persist and require manual deletion.
 
 ### `container volume delete (rm)`
 


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context
Adds automatic cleanup of anonymous volumes when containers started with the `--rm` flag exit, preventing orphaned volumes from accumulating and consuming disk space.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [x] Added/updated docs
