### PR TITLE
Clarify container list abstract to mention it shows running containers

### DIFF
--- a/Sources/ContainerCommands/Container/ContainerList.swift
+++ b/Sources/ContainerCommands/Container/ContainerList.swift
@@ -25,7 +25,7 @@ extension Application {
     public struct ContainerList: AsyncParsableCommand {
         public static let configuration = CommandConfiguration(
             commandName: "list",
-            abstract: "List containers",
+            abstract: "List running containers",
             aliases: ["ls"])
 
         @Flag(name: .shortAndLong, help: "Include containers that are not running")


### PR DESCRIPTION
Clarify container list abstract to mention it shows running containers only by default.