### PR TITLE
Fix container auto-delete on rapid stop/start

### DIFF
--- a/Sources/Services/ContainerSandboxService/SandboxService.swift
+++ b/Sources/Services/ContainerSandboxService/SandboxService.swift
@@ -272,15 +272,6 @@ public actor SandboxService {
             case .created, .stopped(_), .stopping:
                 await self.setState(.shuttingDown)
 
-                Task {
-                    do {
-                        try await Task.sleep(for: .seconds(5))
-                    } catch {
-                        self.log.error("failed to sleep before shutting down SandboxService: \(error)")
-                    }
-                    self.log.info("Shutting down SandboxService")
-                    exit(0)
-                }
             default:
                 throw ContainerizationError(
                     .invalidState,


### PR DESCRIPTION
- Fixes #833.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Currently, when stopping and immediately restarting a container, it would fail with the error:
`“container expected to be in created state, got: shuttingDown”` and then be automatically deleted.
The `SandboxService` process waits five seconds before exiting after shutdown. During this interval, a rapid restart could reconnect to the still-terminating process in the `shuttingDown` state, triggering a state validation error.

This fix forcefully terminates the `SandboxService` process with `SIGKILL` upon container exit, instead of waiting five seconds. The bootstrap now defensively checks for and cleans up any stale services before registering new ones, preventing reconnections to processes in the `shuttingDown` state.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs