### PR TITLE
Add --rosetta option for arm64 images

### DIFF
--- a/Sources/ContainerClient/Flags.swift
+++ b/Sources/ContainerClient/Flags.swift
@@ -184,6 +184,9 @@ public struct Flags {
         @Flag(name: [.customLong("rm"), .long], help: "Remove the container after it stops")
         public var remove = false
 
+        @Flag(name: .long, help: "Enable Rosetta in the container")
+        public var rosetta = false
+
         @Flag(name: .long, help: "Forward SSH agent socket to container")
         public var ssh = false
 

--- a/Sources/ContainerClient/Utility.swift
+++ b/Sources/ContainerClient/Utility.swift
@@ -213,8 +213,10 @@ public struct Utility {
             )
         }
 
-        if Platform.current.architecture == "arm64" && requestedPlatform.architecture == "amd64" {
-            config.rosetta = true
+        config.rosetta = management.rosetta || (Platform.current.architecture == "arm64" && requestedPlatform.architecture == "amd64")
+
+        if management.rosetta && Platform.current.architecture != "arm64" {
+            throw ContainerizationError(.unsupported, message: "--rosetta flag requires an arm64 host")
         }
 
         config.labels = try Parser.labels(management.labels)


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
`container` automatically enables Rosetta for amd64 containers. This change allows Rosetta to be enabled for arm64 containers by passing the `--rosetta` flag. This allows native containers to benefit from being able to execute the occasional amd64 executable in niche situations, e.g., containers used for cross-compilation.

Resolves #391.

I considered adding a warning for passing `--rosetta` when it is not necessary, but there wasn't obvious infrastructure for conveying the message.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

I tested by downloading a statically linked x86 binary and running it inside an arm64 Alpine container created with the new `--rosetta` flag.

I attempted to write a test case but I hit [this issue](https://github.com/apple/container/discussions/700) with my Swift toolchain. An ideal test case might involve actually executing an amd64 binary within an arm64 container, but I didn't come up with a simple way to do so.