### PR TITLE
Reuse XPC connections across container operations

### DIFF
--- a/Sources/ContainerCommands/BuildCommand.swift
+++ b/Sources/ContainerCommands/BuildCommand.swift
@@ -148,7 +148,8 @@ extension Application {
                     group.addTask { [vsockPort, cpus, memory] in
                         while true {
                             do {
-                                let container = try await ClientContainer.get(id: "buildkit")
+                                let snapshot = try await ClientContainer.get(id: "buildkit")
+                                let container = ClientContainer(snapshot: snapshot)
                                 let fh = try await container.dial(vsockPort)
 
                                 let threadGroup: MultiThreadedEventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)

--- a/Sources/ContainerCommands/Builder/BuilderDelete.swift
+++ b/Sources/ContainerCommands/Builder/BuilderDelete.swift
@@ -39,8 +39,9 @@ extension Application {
 
         public func run() async throws {
             do {
-                let container = try await ClientContainer.get(id: "buildkit")
-                if container.status != .stopped {
+                let snapshot = try await ClientContainer.get(id: "buildkit")
+                let container = ClientContainer(snapshot: snapshot)
+                if snapshot.status != .stopped {
                     guard force else {
                         throw ContainerizationError(.invalidState, message: "BuildKit container is not stopped, use --force to override")
                     }

--- a/Sources/ContainerCommands/Builder/BuilderStop.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStop.swift
@@ -35,7 +35,8 @@ extension Application {
 
         public func run() async throws {
             do {
-                let container = try await ClientContainer.get(id: "buildkit")
+                let snapshot = try await ClientContainer.get(id: "buildkit")
+                let container = ClientContainer(snapshot: snapshot)
                 try await container.stop()
             } catch {
                 if error is ContainerizationError {

--- a/Sources/ContainerCommands/Container/ContainerCreate.swift
+++ b/Sources/ContainerCommands/Container/ContainerCreate.swift
@@ -77,11 +77,11 @@ extension Application {
             )
 
             let options = ContainerCreateOptions(autoRemove: managementFlags.remove)
-            let container = try await ClientContainer.create(configuration: ck.0, options: options, kernel: ck.1)
+            let snapshot = try await ClientContainer.create(configuration: ck.0, options: options, kernel: ck.1)
 
             if !self.managementFlags.cidfile.isEmpty {
                 let path = self.managementFlags.cidfile
-                let data = container.id.data(using: .utf8)
+                let data = snapshot.configuration.id.data(using: .utf8)
                 var attributes = [FileAttributeKey: Any]()
                 attributes[.posixPermissions] = 0o644
                 let success = FileManager.default.createFile(
@@ -96,7 +96,7 @@ extension Application {
             }
             progress.finish()
 
-            print(container.id)
+            print(snapshot.configuration.id)
         }
     }
 }

--- a/Sources/ContainerCommands/Container/ContainerExec.swift
+++ b/Sources/ContainerCommands/Container/ContainerExec.swift
@@ -42,13 +42,14 @@ extension Application {
 
         public func run() async throws {
             var exitCode: Int32 = 127
-            let container = try await ClientContainer.get(id: containerId)
-            try ensureRunning(container: container)
+            let snapshot = try await ClientContainer.get(id: containerId)
+            let container = ClientContainer(snapshot: snapshot)
+            try ensureRunning(snapshot: snapshot)
 
             let stdin = self.processFlags.interactive
             let tty = self.processFlags.tty
 
-            var config = container.configuration.initProcess
+            var config = snapshot.configuration.initProcess
             config.executable = arguments.first!
             config.arguments = [String](self.arguments.dropFirst())
             config.terminal = tty

--- a/Sources/ContainerCommands/Container/ContainerInspect.swift
+++ b/Sources/ContainerCommands/Container/ContainerInspect.swift
@@ -35,7 +35,7 @@ extension Application {
 
         public func run() async throws {
             let objects: [any Codable] = try await ClientContainer.list().filter {
-                containerIds.contains($0.id)
+                containerIds.contains($0.configuration.id)
             }.map {
                 PrintableContainer($0)
             }

--- a/Sources/ContainerCommands/Container/ContainerLogs.swift
+++ b/Sources/ContainerCommands/Container/ContainerLogs.swift
@@ -47,7 +47,8 @@ extension Application {
 
         public func run() async throws {
             do {
-                let container = try await ClientContainer.get(id: containerId)
+                let snapshot = try await ClientContainer.get(id: containerId)
+                let container = ClientContainer(snapshot: snapshot)
                 let fhs = try await container.logs()
                 let fileHandle = boot ? fhs[1] : fhs[0]
 

--- a/Sources/ContainerCommands/Container/ContainerRun.swift
+++ b/Sources/ContainerCommands/Container/ContainerRun.swift
@@ -103,11 +103,12 @@ extension Application {
             progress.set(description: "Starting container")
 
             let options = ContainerCreateOptions(autoRemove: managementFlags.remove)
-            let container = try await ClientContainer.create(
+            let snapshot = try await ClientContainer.create(
                 configuration: ck.0,
                 options: options,
                 kernel: ck.1
             )
+            let container = ClientContainer(snapshot: snapshot)
 
             let detach = self.managementFlags.detach
             do {

--- a/Sources/ContainerCommands/Container/ContainerStart.swift
+++ b/Sources/ContainerCommands/Container/ContainerStart.swift
@@ -53,12 +53,12 @@ extension Application {
             progress.start()
 
             let detach = !self.attach && !self.interactive
-            let container = try await ClientContainer.get(id: containerId)
+            let snapshot = try await ClientContainer.get(id: containerId)
 
             // Bootstrap and process start are both idempotent and don't fail the second time
             // around, however not doing an rpc is always faster :). The other bit is we don't
             // support attach currently, so we can't do `start -a` a second time and have it succeed.
-            if container.status == .running {
+            if snapshot.status == .running {
                 if !detach {
                     throw ContainerizationError(
                         .invalidArgument,
@@ -69,9 +69,11 @@ extension Application {
                 return
             }
 
+            let container = ClientContainer(snapshot: snapshot)
+
             do {
                 let io = try ProcessIO.create(
-                    tty: container.configuration.initProcess.terminal,
+                    tty: snapshot.configuration.initProcess.terminal,
                     interactive: self.interactive,
                     detach: detach
                 )

--- a/Sources/ContainerCommands/Container/ProcessUtils.swift
+++ b/Sources/ContainerCommands/Container/ProcessUtils.swift
@@ -21,9 +21,9 @@ import ContainerizationOS
 import Foundation
 
 extension Application {
-    static func ensureRunning(container: ClientContainer) throws {
-        if container.status != .running {
-            throw ContainerizationError(.invalidState, message: "container \(container.id) is not running")
+    static func ensureRunning(snapshot: ContainerSnapshot) throws {
+        if snapshot.status != .running {
+            throw ContainerizationError(.invalidState, message: "container \(snapshot.configuration.id) is not running")
         }
     }
 }

--- a/Sources/ContainerCommands/System/SystemStop.swift
+++ b/Sources/ContainerCommands/System/SystemStop.swift
@@ -62,10 +62,10 @@ extension Application {
             if running {
                 log.info("stopping containers", metadata: ["stopTimeoutSeconds": "\(Self.stopTimeoutSeconds)"])
                 do {
-                    let containers = try await ClientContainer.list()
+                    let snapshots = try await ClientContainer.list()
                     let signal = try Signals.parseSignal("SIGTERM")
                     let opts = ContainerStopOptions(timeoutInSeconds: Self.stopTimeoutSeconds, signal: signal)
-                    let failed = try await ContainerStop.stopContainers(containers: containers, stopOptions: opts)
+                    let failed = try await ContainerStop.stopContainers(snapshots: snapshots, stopOptions: opts)
                     if !failed.isEmpty {
                         log.warning("some containers could not be stopped gracefully", metadata: ["ids": "\(failed)"])
                     }


### PR DESCRIPTION
- Closes #666.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Currently, `ClientContainer` is overloaded, it's used for both data (during list(), you get given a ClientContainer) and to talk to the daemon. Each container operation creates a new XPC connection, which is pretty wasteful e.g. `container stop --all` with 10 containers creates 11 XPC connections (1 for list and 10 for individual stops)

To address this `list()`, `get()`, and `create()` will now return `ContainerSnapshot` instead of `ClientContainer`, and `ClientContainer` now accepts an optional `XPCClient` parameter for connection reuse so multiple operations can share the same connection. Commands that perform bulk operations now create a single shared `XPCClient` and pass it to all `ClientContainer` instances

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
