### PR TITLE
Show image download progress during builds

### DIFF
--- a/Sources/ContainerBuild/BuildPipelineHandler.swift
+++ b/Sources/ContainerBuild/BuildPipelineHandler.swift
@@ -30,7 +30,7 @@ public actor BuildPipeline {
             [
                 try BuildFSSync(URL(filePath: config.contextDir)),
                 try BuildRemoteContentProxy(config.contentStore),
-                try BuildImageResolver(config.contentStore),
+                try BuildImageResolver(config.contentStore, quiet: config.quiet, output: config.terminal?.handle ?? FileHandle.standardError),
                 try BuildStdio(quiet: config.quiet, output: config.terminal?.handle ?? FileHandle.standardError),
             ]
     }


### PR DESCRIPTION
- Closes #710.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Fetching images during builds currently show just a 0.0s timer, and no other info making builds appear hung. This adds a realtime download progress bar with info, when pulling base images during builds.

<img width="1133" height="640" alt="Screenshot 2025-11-04 at 2 54 33 PM" src="https://github.com/user-attachments/assets/200d8485-a956-4ce1-bbfe-d7406bd85774" />

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
