### PR TITLE
Implement container stats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ integration: init-block
 		$(SWIFT) test -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter TestCLIExecCommand || exit_code=1 ; \
 		$(SWIFT) test -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter TestCLICreateCommand || exit_code=1 ; \
 		$(SWIFT) test -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter TestCLIRunCommand || exit_code=1 ; \
+		$(SWIFT) test -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter TestCLIStatsCommand || exit_code=1 ; \
 		$(SWIFT) test -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter TestCLIImagesCommand || exit_code=1 ; \
 		$(SWIFT) test -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter TestCLIRunBase || exit_code=1 ; \
 		$(SWIFT) test -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter TestCLIBuildBase || exit_code=1 ; \

--- a/Sources/ContainerClient/Core/ClientContainer.swift
+++ b/Sources/ContainerClient/Core/ClientContainer.swift
@@ -314,4 +314,27 @@ extension ClientContainer {
         }
         return fh
     }
+
+    public func stats() async throws -> ContainerStats {
+        let request = XPCMessage(route: .containerStats)
+        request.set(key: .id, value: self.id)
+
+        let client = Self.newXPCClient()
+        do {
+            let response = try await client.send(request)
+            guard let data = response.dataNoCopy(key: .statistics) else {
+                throw ContainerizationError(
+                    .internalError,
+                    message: "no statistics data returned"
+                )
+            }
+            return try JSONDecoder().decode(ContainerStats.self, from: data)
+        } catch {
+            throw ContainerizationError(
+                .internalError,
+                message: "failed to get statistics for container \(self.id)",
+                cause: error
+            )
+        }
+    }
 }

--- a/Sources/ContainerClient/Core/ContainerStats.swift
+++ b/Sources/ContainerClient/Core/ContainerStats.swift
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Statistics for a container suitable for CLI display.
+public struct ContainerStats: Sendable, Codable {
+    /// Container ID
+    public var id: String
+    /// Physical memory usage in bytes
+    public var memoryUsageBytes: UInt64
+    /// Memory limit in bytes
+    public var memoryLimitBytes: UInt64
+    /// CPU usage in microseconds
+    public var cpuUsageUsec: UInt64
+    /// Network received bytes (sum of all interfaces)
+    public var networkRxBytes: UInt64
+    /// Network transmitted bytes (sum of all interfaces)
+    public var networkTxBytes: UInt64
+    /// Block I/O read bytes (sum of all devices)
+    public var blockReadBytes: UInt64
+    /// Block I/O write bytes (sum of all devices)
+    public var blockWriteBytes: UInt64
+    /// Number of processes in the container
+    public var numProcesses: UInt64
+
+    public init(
+        id: String,
+        memoryUsageBytes: UInt64,
+        memoryLimitBytes: UInt64,
+        cpuUsageUsec: UInt64,
+        networkRxBytes: UInt64,
+        networkTxBytes: UInt64,
+        blockReadBytes: UInt64,
+        blockWriteBytes: UInt64,
+        numProcesses: UInt64
+    ) {
+        self.id = id
+        self.memoryUsageBytes = memoryUsageBytes
+        self.memoryLimitBytes = memoryLimitBytes
+        self.cpuUsageUsec = cpuUsageUsec
+        self.networkRxBytes = networkRxBytes
+        self.networkTxBytes = networkTxBytes
+        self.blockReadBytes = blockReadBytes
+        self.blockWriteBytes = blockWriteBytes
+        self.numProcesses = numProcesses
+    }
+}

--- a/Sources/ContainerClient/Core/XPC+.swift
+++ b/Sources/ContainerClient/Core/XPC+.swift
@@ -115,6 +115,9 @@ public enum XPCKeys: String {
     case volumeLabels
     case volumeReadonly
     case volumeContainerId
+
+    /// Container statistics
+    case statistics
 }
 
 public enum XPCRoute: String {
@@ -132,6 +135,7 @@ public enum XPCRoute: String {
     case containerState
     case containerLogs
     case containerEvent
+    case containerStats
 
     case pluginLoad
     case pluginGet

--- a/Sources/ContainerClient/SandboxClient.swift
+++ b/Sources/ContainerClient/SandboxClient.swift
@@ -273,6 +273,30 @@ extension SandboxClient {
             )
         }
     }
+
+    public func statistics() async throws -> ContainerStats {
+        let request = XPCMessage(route: SandboxRoutes.statistics.rawValue)
+
+        let response: XPCMessage
+        do {
+            response = try await self.client.send(request)
+        } catch {
+            throw ContainerizationError(
+                .internalError,
+                message: "failed to get statistics for container \(self.id)",
+                cause: error
+            )
+        }
+
+        guard let data = response.dataNoCopy(key: .statistics) else {
+            throw ContainerizationError(
+                .internalError,
+                message: "no statistics data returned"
+            )
+        }
+
+        return try JSONDecoder().decode(ContainerStats.self, from: data)
+    }
 }
 
 extension XPCMessage {

--- a/Sources/ContainerClient/SandboxRoutes.swift
+++ b/Sources/ContainerClient/SandboxRoutes.swift
@@ -39,4 +39,6 @@ public enum SandboxRoutes: String {
     case dial = "com.apple.container.sandbox/dial"
     /// Shutdown the sandbox service process.
     case shutdown = "com.apple.container.sandbox/shutdown"
+    /// Get statistics for the sandbox.
+    case statistics = "com.apple.container.sandbox/statistics"
 }

--- a/Sources/ContainerCommands/Application.swift
+++ b/Sources/ContainerCommands/Application.swift
@@ -59,6 +59,7 @@ public struct Application: AsyncParsableCommand {
                     ContainerLogs.self,
                     ContainerRun.self,
                     ContainerStart.self,
+                    ContainerStats.self,
                     ContainerStop.self,
                 ]
             ),

--- a/Sources/ContainerCommands/Container/ContainerStats.swift
+++ b/Sources/ContainerCommands/Container/ContainerStats.swift
@@ -1,0 +1,262 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ContainerClient
+import ContainerizationError
+import ContainerizationExtras
+import Foundation
+
+extension Application {
+    public struct ContainerStats: AsyncParsableCommand {
+        public static let configuration = CommandConfiguration(
+            commandName: "stats",
+            abstract: "Display resource usage statistics for containers")
+
+        @Argument(help: "Container ID or name (optional, shows all running containers if not specified)")
+        var containers: [String] = []
+
+        @Option(name: .long, help: "Format of the output")
+        var format: ListFormat = .table
+
+        @Flag(name: .long, help: "Disable streaming stats and only pull the first result")
+        var noStream = false
+
+        @OptionGroup
+        var global: Flags.Global
+
+        public init() {}
+
+        public func run() async throws {
+            if format == .json || noStream {
+                // Static mode - get stats once and exit
+                try await runStatic()
+            } else {
+                // Streaming mode - continuously update like top
+                // Enter alternate screen buffer and hide cursor
+                print("\u{001B}[?1049h\u{001B}[?25l", terminator: "")
+                fflush(stdout)
+
+                defer {
+                    // Exit alternate screen buffer and show cursor again
+                    print("\u{001B}[?25h\u{001B}[?1049l", terminator: "")
+                    fflush(stdout)
+                }
+
+                try await runStreaming()
+            }
+        }
+
+        private func runStatic() async throws {
+            let allContainers = try await ClientContainer.list()
+
+            let containersToShow: [ClientContainer]
+            if containers.isEmpty {
+                // No containers specified - show all running containers
+                containersToShow = allContainers.filter { $0.status == .running }
+            } else {
+                // Validate all specified containers exist before proceeding
+                var found: [ClientContainer] = []
+                for containerId in containers {
+                    guard let container = allContainers.first(where: { $0.id == containerId || $0.id.starts(with: containerId) }) else {
+                        throw ContainerizationError(
+                            .notFound,
+                            message: "Error: No such container: \(containerId)"
+                        )
+                    }
+                    found.append(container)
+                }
+                containersToShow = found
+            }
+
+            let statsData = try await collectStats(for: containersToShow)
+
+            if format == .json {
+                let jsonStats = statsData.map { $0.stats2 }
+                let data = try JSONEncoder().encode(jsonStats)
+                print(String(data: data, encoding: .utf8)!)
+                return
+            }
+
+            printStatsTable(statsData)
+        }
+
+        private func runStreaming() async throws {
+            // If containers were specified, validate they all exist upfront
+            if !containers.isEmpty {
+                let allContainers = try await ClientContainer.list()
+                for containerId in containers {
+                    guard allContainers.first(where: { $0.id == containerId || $0.id.starts(with: containerId) }) != nil else {
+                        throw ContainerizationError(
+                            .notFound,
+                            message: "Error: No such container: \(containerId)"
+                        )
+                    }
+                }
+            }
+
+            clearScreen()
+            // Show header right away.
+            printStatsTable([])
+
+            while true {
+                do {
+                    let allContainers = try await ClientContainer.list()
+
+                    let containersToShow: [ClientContainer]
+                    if containers.isEmpty {
+                        containersToShow = allContainers.filter { $0.status == .running }
+                    } else {
+                        var found: [ClientContainer] = []
+                        for containerId in containers {
+                            if let container = allContainers.first(where: { $0.id == containerId || $0.id.starts(with: containerId) }) {
+                                found.append(container)
+                            }
+                        }
+                        containersToShow = found
+                    }
+
+                    let statsData = try await collectStats(for: containersToShow)
+
+                    // Clear screen and reprint
+                    clearScreen()
+                    printStatsTable(statsData)
+
+                    if statsData.isEmpty {
+                        try await Task.sleep(for: .seconds(2))
+                    }
+                } catch {
+                    clearScreen()
+                    print("Error collecting stats: \(error)")
+                    try await Task.sleep(for: .seconds(2))
+                }
+            }
+        }
+
+        private struct StatsSnapshot {
+            let container: ClientContainer
+            let stats1: ContainerClient.ContainerStats
+            let stats2: ContainerClient.ContainerStats
+        }
+
+        private func collectStats(for containers: [ClientContainer]) async throws -> [StatsSnapshot] {
+            var snapshots: [StatsSnapshot] = []
+
+            // First sample
+            for container in containers {
+                guard container.status == .running else { continue }
+                do {
+                    let stats1 = try await container.stats()
+                    snapshots.append(StatsSnapshot(container: container, stats1: stats1, stats2: stats1))
+                } catch {
+                    // Skip containers that error out
+                    continue
+                }
+            }
+
+            // Wait 2 seconds for CPU delta calculation
+            if !snapshots.isEmpty {
+                try await Task.sleep(for: .seconds(2))
+
+                // Second sample
+                for i in 0..<snapshots.count {
+                    do {
+                        let stats2 = try await snapshots[i].container.stats()
+                        snapshots[i] = StatsSnapshot(
+                            container: snapshots[i].container,
+                            stats1: snapshots[i].stats1,
+                            stats2: stats2
+                        )
+                    } catch {
+                        // Keep the original stats if second sample fails
+                        continue
+                    }
+                }
+            }
+
+            return snapshots
+        }
+
+        /// Calculate CPU percentage from two stat snapshots
+        /// - Parameters:
+        ///   - cpuUsageUsec1: CPU usage in microseconds from first sample
+        ///   - cpuUsageUsec2: CPU usage in microseconds from second sample
+        ///   - timeDeltaUsec: Time delta between samples in microseconds
+        /// - Returns: CPU percentage where 100% = one fully utilized core
+        static func calculateCPUPercent(
+            cpuUsageUsec1: UInt64,
+            cpuUsageUsec2: UInt64,
+            timeDeltaUsec: UInt64
+        ) -> Double {
+            let cpuDelta =
+                cpuUsageUsec2 > cpuUsageUsec1
+                ? cpuUsageUsec2 - cpuUsageUsec1
+                : 0
+            return (Double(cpuDelta) / Double(timeDeltaUsec)) * 100.0
+        }
+
+        static func formatBytes(_ bytes: UInt64) -> String {
+            let kib = 1024.0
+            let mib = kib * 1024.0
+            let gib = mib * 1024.0
+
+            let value = Double(bytes)
+
+            if value >= gib {
+                return String(format: "%.2f GiB", value / gib)
+            } else if value >= mib {
+                return String(format: "%.2f MiB", value / mib)
+            } else {
+                return String(format: "%.2f KiB", value / kib)
+            }
+        }
+
+        private func printStatsTable(_ statsData: [StatsSnapshot]) {
+            let header = [["Container ID", "Cpu %", "Memory Usage", "Net Rx/Tx", "Block I/O", "Pids"]]
+            var rows = header
+
+            for snapshot in statsData {
+                let stats1 = snapshot.stats1
+                let stats2 = snapshot.stats2
+
+                let cpuPercent = Self.calculateCPUPercent(
+                    cpuUsageUsec1: stats1.cpuUsageUsec,
+                    cpuUsageUsec2: stats2.cpuUsageUsec,
+                    timeDeltaUsec: 2_000_000  // 2 seconds in microseconds
+                )
+                let cpuStr = String(format: "%.2f%%", cpuPercent)
+
+                let memUsageStr = "\(Self.formatBytes(stats2.memoryUsageBytes)) / \(Self.formatBytes(stats2.memoryLimitBytes))"
+                let netStr = "\(Self.formatBytes(stats2.networkRxBytes)) / \(Self.formatBytes(stats2.networkTxBytes))"
+                let blockStr = "\(Self.formatBytes(stats2.blockReadBytes)) / \(Self.formatBytes(stats2.blockWriteBytes))"
+
+                let pidsStr = "\(stats2.numProcesses)"
+
+                rows.append([snapshot.container.id, cpuStr, memUsageStr, netStr, blockStr, pidsStr])
+            }
+
+            // Always print header, even if no containers
+            let formatter = TableOutput(rows: rows)
+            print(formatter.format())
+        }
+
+        private func clearScreen() {
+            // Move cursor to home position and clear from cursor to end of screen
+            print("\u{001B}[H\u{001B}[J", terminator: "")
+            fflush(stdout)
+        }
+    }
+}

--- a/Sources/Helpers/APIServer/APIServer+Start.swift
+++ b/Sources/Helpers/APIServer/APIServer+Start.swift
@@ -213,6 +213,7 @@ extension APIServer {
             routes[XPCRoute.containerResize] = harness.resize
             routes[XPCRoute.containerWait] = harness.wait
             routes[XPCRoute.containerKill] = harness.kill
+            routes[XPCRoute.containerStats] = harness.stats
 
             return service
         }

--- a/Sources/Helpers/RuntimeLinux/RuntimeLinuxHelper+Start.swift
+++ b/Sources/Helpers/RuntimeLinux/RuntimeLinuxHelper+Start.swift
@@ -97,6 +97,7 @@ extension RuntimeLinuxHelper {
                         SandboxRoutes.start.rawValue: server.startProcess,
                         SandboxRoutes.dial.rawValue: server.dial,
                         SandboxRoutes.shutdown.rawValue: server.shutdown,
+                        SandboxRoutes.statistics.rawValue: server.statistics,
                     ],
                     log: log
                 )

--- a/Sources/Services/ContainerAPIService/Containers/ContainersHarness.swift
+++ b/Sources/Services/ContainerAPIService/Containers/ContainersHarness.swift
@@ -270,4 +270,20 @@ public struct ContainersHarness: Sendable {
         try reply.set(key: .logs, value: fds)
         return reply
     }
+
+    @Sendable
+    public func stats(_ message: XPCMessage) async throws -> XPCMessage {
+        let id = message.string(key: .id)
+        guard let id else {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "id cannot be empty"
+            )
+        }
+        let stats = try await service.stats(id: id)
+        let data = try JSONEncoder().encode(stats)
+        let reply = message.reply()
+        reply.set(key: .statistics, value: data)
+        return reply
+    }
 }

--- a/Sources/Services/ContainerAPIService/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Containers/ContainersService.swift
@@ -400,6 +400,15 @@ public actor ContainersService {
         }
     }
 
+    /// Get statistics for the container.
+    public func stats(id: String) async throws -> ContainerStats {
+        self.log.debug("\(#function)")
+
+        let state = try self._getContainerState(id: id)
+        let client = try state.getClient()
+        return try await client.statistics()
+    }
+
     /// Delete a container and its resources.
     public func delete(id: String, force: Bool) async throws {
         self.log.debug("\(#function)")

--- a/Tests/CLITests/Subcommands/Containers/TestCLIStats.swift
+++ b/Tests/CLITests/Subcommands/Containers/TestCLIStats.swift
@@ -1,0 +1,224 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerClient
+import Foundation
+import Testing
+
+class TestCLIStatsCommand: CLITest {
+    private func getTestName() -> String {
+        Test.current!.name.trimmingCharacters(in: ["(", ")"]).lowercased()
+    }
+
+    @Test func testStatsNoStreamJSONFormat() throws {
+        let name = getTestName()
+        #expect(throws: Never.self, "expected stats command to succeed") {
+            try doLongRun(name: name)
+            defer {
+                try? doStop(name: name)
+                try? doRemove(name: name)
+            }
+            try waitForContainerRunning(name)
+
+            let (output, error, status) = try run(arguments: [
+                "stats",
+                "--format", "json",
+                "--no-stream",
+                name,
+            ])
+
+            try #require(status == 0, "stats command should succeed, error: \(error)")
+
+            guard let jsonData = output.data(using: .utf8) else {
+                throw CLIError.invalidOutput("stats output invalid")
+            }
+
+            let decoder = JSONDecoder()
+            let stats = try decoder.decode([ContainerStats].self, from: jsonData)
+
+            #expect(stats.count == 1, "expected stats for one container")
+            #expect(stats[0].id == name, "container ID should match")
+            #expect(stats[0].memoryUsageBytes > 0, "memory usage should be non-zero")
+            #expect(stats[0].numProcesses >= 1, "should have at least one process")
+        }
+    }
+
+    @Test func testStatsIdleCPUPercentage() throws {
+        let name = getTestName()
+        #expect(throws: Never.self, "expected stats to show low CPU for idle container") {
+            try doLongRun(name: name, containerArgs: ["sleep", "3600"])
+            defer {
+                try? doStop(name: name)
+                try? doRemove(name: name)
+            }
+            try waitForContainerRunning(name)
+
+            // Get stats in table format
+            let (output, _, status) = try run(arguments: [
+                "stats",
+                "--no-stream",
+                name,
+            ])
+            try #require(status == 0, "stats command should succeed")
+
+            // Parse the table output
+            let lines = output.components(separatedBy: .newlines)
+            #expect(lines.count >= 2, "should have at least header and one data row")
+
+            // Find the data row (not the header)
+            let dataLine = lines.first { $0.contains(name) }
+            try #require(dataLine != nil, "should find container data row")
+
+            // Extract CPU percentage - it should be in the second column
+            let columns = dataLine!.split(separator: " ").filter { !$0.isEmpty }
+            #expect(columns.count >= 2, "should have at least 2 columns")
+
+            // Second column is CPU%
+            let cpuString = String(columns[1])
+            #expect(cpuString.hasSuffix("%"), "CPU column should end with %")
+
+            // Parse the percentage
+            let cpuValue = Double(cpuString.dropLast())
+            try #require(cpuValue != nil, "should be able to parse CPU percentage")
+
+            // Idle container should use very little CPU (less than 5%)
+            #expect(cpuValue! < 5.0, "idle container CPU should be < 5%, got \(cpuValue!)%")
+        }
+    }
+
+    @Test func testStatsHighCPUPercentage() throws {
+        let name = getTestName()
+        #expect(throws: Never.self, "expected stats to show high CPU for busy container") {
+            // Run a container with a busy loop
+            try doLongRun(name: name, containerArgs: ["sh", "-c", "while true; do :; done"])
+            defer {
+                try? doStop(name: name)
+                try? doRemove(name: name)
+            }
+            try waitForContainerRunning(name)
+
+            // Get stats in table format
+            let (output, _, status) = try run(arguments: [
+                "stats",
+                "--no-stream",
+                name,
+            ])
+            try #require(status == 0, "stats command should succeed")
+
+            // Parse the table output
+            let lines = output.components(separatedBy: .newlines)
+            #expect(lines.count >= 2, "should have at least header and one data row")
+
+            // Find the data row (not the header)
+            let dataLine = lines.first { $0.contains(name) }
+            try #require(dataLine != nil, "should find container data row")
+
+            // Extract CPU percentage - it should be in the second column
+            // Format is like: "container_id   95.23%   ..."
+            let columns = dataLine!.split(separator: " ").filter { !$0.isEmpty }
+            #expect(columns.count >= 2, "should have at least 2 columns")
+
+            // Second column is CPU%
+            let cpuString = String(columns[1])
+            #expect(cpuString.hasSuffix("%"), "CPU column should end with %")
+
+            // Parse the percentage
+            let cpuValue = Double(cpuString.dropLast())
+            try #require(cpuValue != nil, "should be able to parse CPU percentage")
+
+            // Busy loop should use significant CPU (at least 50% of one core)
+            #expect(cpuValue! > 50.0, "busy container CPU should be > 50%, got \(cpuValue!)%")
+            // Should not exceed reasonable limits (one core doing while loop = ~100%)
+            #expect(cpuValue! < 150.0, "single busy loop should not exceed 150%, got \(cpuValue!)%")
+        }
+    }
+
+    @Test func testStatsTableFormat() throws {
+        let name = getTestName()
+        #expect(throws: Never.self, "expected stats table format to work") {
+            try doLongRun(name: name)
+            defer {
+                try? doStop(name: name)
+                try? doRemove(name: name)
+            }
+            try waitForContainerRunning(name)
+
+            // Get stats in table format
+            let (output, error, status) = try run(arguments: [
+                "stats",
+                "--no-stream",
+                name,
+            ])
+
+            try #require(status == 0, "stats command should succeed, error: \(error)")
+            #expect(output.contains("Container ID"), "output should contain table header")
+            #expect(output.contains("Cpu %"), "output should contain CPU column")
+            #expect(output.contains("Memory Usage"), "output should contain Memory column")
+            #expect(output.contains(name), "output should contain container name")
+        }
+    }
+
+    @Test func testStatsAllContainers() throws {
+        let name1 = getTestName() + "-1"
+        let name2 = getTestName() + "-2"
+        #expect(throws: Never.self, "expected stats for all containers") {
+            try doLongRun(name: name1)
+            try doLongRun(name: name2)
+            defer {
+                try? doStop(name: name1)
+                try? doStop(name: name2)
+                try? doRemove(name: name1)
+                try? doRemove(name: name2)
+            }
+            try waitForContainerRunning(name1)
+            try waitForContainerRunning(name2)
+
+            // Get stats for all containers (no name specified)
+            let (output, error, status) = try run(arguments: [
+                "stats",
+                "--format", "json",
+                "--no-stream",
+            ])
+
+            try #require(status == 0, "stats command should succeed, error: \(error)")
+
+            guard let jsonData = output.data(using: .utf8) else {
+                throw CLIError.invalidOutput("stats output invalid")
+            }
+
+            let stats = try JSONDecoder().decode([ContainerStats].self, from: jsonData)
+
+            // Should have stats for both containers
+            try #require(stats.count >= 2, "should have stats for at least 2 containers")
+
+            let containerIds = stats.map { $0.id }
+            #expect(containerIds.contains(name1), "should include first container")
+            #expect(containerIds.contains(name2), "should include second container")
+        }
+    }
+
+    @Test func testStatsNonExistentContainer() throws {
+        #expect(throws: Never.self, "expected stats to fail for non-existent container") {
+            let (_, _, status) = try run(arguments: [
+                "stats",
+                "--no-stream",
+                "nonexistent-container-xyz",
+            ])
+
+            #expect(status != 0, "stats command should fail for non-existent container")
+        }
+    }
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -370,6 +370,41 @@ container inspect [--debug] <container-ids> ...
 
 No options.
 
+### `container stats`
+
+Displays real-time resource usage statistics for containers. Shows CPU percentage, memory usage, network I/O, block I/O, and process count. By default, continuously updates statistics in an interactive display (like `top`). Use `--no-stream` for a single snapshot.
+
+**Usage**
+
+```bash
+container stats [--format <format>] [--no-stream] [--debug] [<container-ids> ...]
+```
+
+**Arguments**
+
+*   `<container-ids>`: Container IDs or names (optional, shows all running containers if not specified)
+
+**Options**
+
+*   `--format <format>`: Format of the output (values: json, table; default: table)
+*   `--no-stream`: Disable streaming stats and only pull the first result
+
+**Examples**
+
+```bash
+# show stats for all running containers (interactive)
+container stats
+
+# show stats for specific containers
+container stats web db cache
+
+# get a single snapshot of stats (non-interactive)
+container stats --no-stream web
+
+# output stats as JSON
+container stats --format json --no-stream web
+```
+
 ## Image Management
 
 ### `container image list (ls)`

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -356,6 +356,64 @@ Use the `--boot` option to see the logs for the virtual machine boot and init pr
 %
 </pre>
 
+## Monitor container resource usage
+
+The `container stats` command displays real-time resource usage statistics for your running containers, similar to the `top` command for processes. This is useful for:
+- Monitoring CPU and memory consumption
+- Tracking network and disk I/O
+- Identifying resource-intensive containers
+- Verifying container resource limits are appropriate
+
+By default, `container stats` shows live statistics for all running containers in an interactive display:
+
+```console
+% container stats
+Container ID    Cpu %    Memory Usage           Net Rx/Tx              Block I/O               Pids
+my-web-server   2.45%    45.23 MiB / 1.00 GiB   1.23 MiB / 856.00 KiB  4.50 MiB / 2.10 MiB     3
+db              125.12%  512.50 MiB / 2.00 GiB  5.67 MiB / 3.21 MiB    125.00 MiB / 89.00 MiB  12
+```
+
+To monitor specific containers, provide their names or IDs:
+
+```console
+% container stats my-web-server db
+```
+
+For a single snapshot (non-interactive), use the `--no-stream` flag:
+
+```console
+% container stats --no-stream my-web-server
+Container ID    Cpu %    Memory Usage          Net Rx/Tx              Block I/O              Pids
+my-web-server   30.45%    45.23 MiB / 1.00 GiB  1.23 MiB / 856.00 KiB  4.50 MiB / 2.10 MiB    3
+```
+
+You can also output statistics in JSON format for scripting:
+
+```console
+% container stats --format json --no-stream my-web-server | jq
+[
+  {
+    "id": "my-web-server",
+    "memoryUsageBytes": 47431680,
+    "memoryLimitBytes": 1073741824,
+    "cpuUsageUsec": 1234567,
+    "networkRxBytes": 1289011,
+    "networkTxBytes": 876544,
+    "blockReadBytes": 4718592,
+    "blockWriteBytes": 2202009,
+    "numProcesses": 3
+  }
+]
+```
+
+**Understanding the metrics:**
+
+- **Cpu %**: Percentage of CPU usage. ~100% = one fully utilized core. A multi-core container can show > 100%.
+- **Memory Usage**: Current memory usage vs. the container's memory limit.
+- **Net Rx/Tx**: Network bytes received and transmitted.
+- **Block I/O**: Disk bytes read and written.
+- **Pids**: Number of processes running in the container.
+
 ## Expose virtualization capabilities to a container
 
 > [!NOTE]

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -194,6 +194,26 @@ If you configured the local domain `test` earlier in the tutorial, you can also 
 open http://my-web-server.test
 ```
 
+### Monitor container resource usage
+
+Now that your web server is running, you can monitor its resource usage with the `container stats` command:
+
+```bash
+container stats my-web-server
+```
+
+This displays real-time statistics about CPU usage, memory consumption, network traffic, disk I/O, and the number of running processes:
+
+<pre>
+% container stats --no-stream my-web-server
+Container ID    Cpu %   Memory Usage          Net Rx/Tx            Block I/O            Pids
+my-web-server   0.23%   12.45 MiB / 1.00 GiB  856.00 KiB / 1.2 KiB 2.10 MiB / 512 KiB   2
+%
+</pre>
+
+> [!NOTE]
+> Without the `--no-stream` flag, `container stats` continuously updates the display in real-time, similar to the `top` command. Press Ctrl+C to exit the live view.
+
 ### Run other commands in the container
 
 You can run other commands in `my-web-server` by using the `container exec` command. To list the files under the content directory, run an `ls` command:


### PR DESCRIPTION
Closes #824

This implements statistics gathering across the various components, but ultimately this is for implementing a new CLI command: `container stats`. This shows memory usage, cpu usage, network and block i/o and the number of processes in the container. The new command can inspect stats for 1-N containers and by default continuously updates in a `top` like stream.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [x] Added/updated docs
