### PR TITLE
ci: add stale PR management workflow

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -1,6 +1,7 @@
 name: Stale PR Management
 
 on:
+  pull_request:
   schedule:
     - cron: '0 0 * * *' 
   workflow_dispatch:


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [X] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
- PRs inactive for **30 days** → marked as `stale` with friendly reminder
- PRs inactive for **45 days** → automatically closed
- Security, critical, and dependency PRs are **exempt** from auto-closure
- Stale label automatically removed if PR is updated

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
