### PR TITLE
Use container-builder-shim 0.7.0, ensures use of Rosetta.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ import PackageDescription
 
 let releaseVersion = ProcessInfo.processInfo.environment["RELEASE_VERSION"] ?? "0.0.0"
 let gitCommit = ProcessInfo.processInfo.environment["GIT_COMMIT"] ?? "unspecified"
-let builderShimVersion = "0.6.3"
+let builderShimVersion = "0.7.0"
 let scVersion = "0.13.0"
 
 let package = Package(

--- a/Sources/ContainerCommands/Builder/BuilderStart.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStart.swift
@@ -140,10 +140,12 @@ extension Application {
                 }
             }
 
-            let shimArguments: [String] = [
+            let useRosetta = DefaultsStore.getBool(key: .buildRosetta) ?? true
+            let shimArguments = [
                 "--debug",
                 "--vsock",
-            ]
+                useRosetta ? nil : "--enable-qemu",
+            ].compactMap { $0 }
 
             let id = "buildkit"
             try ContainerClient.Utility.validEntityName(id)
@@ -202,7 +204,7 @@ extension Application {
                 ),
             ]
             // Enable Rosetta only if the user didn't ask to disable it
-            config.rosetta = DefaultsStore.getBool(key: .buildRosetta) ?? true
+            config.rosetta = useRosetta
 
             let network = try await ClientNetwork.get(id: ClientNetwork.defaultNetworkName)
             guard case .running(_, let networkStatus) = network else {


### PR DESCRIPTION
- Addresses slow cross-platform builds from #68.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
The shim wasn't doing everything needed to ensure the use of Rosetta for `container build`. The new shim adds an `--enable-qemu` option that controls whether `buildkit-qemu-emulator-x86_64 is available; when it is not available, buildkitd will attempt to build natively, meaning Rosetta will execute amd64 binaries.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
