### PR TITLE
Fix progress bar crash on cached image rebuilds

### DIFF
--- a/Sources/ContainerBuild/BuildImageResolver.swift
+++ b/Sources/ContainerBuild/BuildImageResolver.swift
@@ -72,10 +72,8 @@ struct BuildImageResolver: BuildPipelineHandler {
             defer { progress.finish() }
             progress.start()
 
-            guard let img = try? await ClientImage.pull(reference: ref, platform: platform, progressUpdate: progress.handler) else {
-                return try await ClientImage.fetch(reference: ref, platform: platform, progressUpdate: progress.handler)
-            }
-            return img
+            // Use fetch() which checks cache first, then pulls if needed
+            return try await ClientImage.fetch(reference: ref, platform: platform, progressUpdate: progress.handler)
         }()
 
         let index: Index = try await img.index()


### PR DESCRIPTION
- Fixes #883.

Changes `BuildImageResolver` to use `fetch()` instead of `pull()`. 

`fetch()` checks the cache first and only pulls if needed, preventing  incorrect progress events (e.g., "1/1 KB" metadata checks) on cached images that caused the progress bar width calculation to produce negative/weird padding counts, triggering "Fatal error: Negative count not allowed" crashes during rebuilds.
