### PR TITLE
Fix TestCLICreateCommand failing test

### DIFF
--- a/Tests/CLITests/Subcommands/Containers/TestCLICreate.swift
+++ b/Tests/CLITests/Subcommands/Containers/TestCLICreate.swift
@@ -62,7 +62,7 @@ class TestCLICreateCommand: CLITest {
         args.append("\"hello world\"")
 
         #expect(throws: Never.self, "expected container create maximum port publishes to succeed") {
-            let (_, error, status) = try run(arguments: args)
+            let (_, _, error, status) = try run(arguments: args)
             defer { try? doRemove(name: name) }
             if status != 0 {
                 throw CLIError.executionFailed("command failed: \(error)")
@@ -85,7 +85,7 @@ class TestCLICreateCommand: CLITest {
         args.append("\"hello world\"")
 
         #expect(throws: CLIError.self, "expected container create more than maximum port publishes to fail") {
-            let (_, error, status) = try run(arguments: args)
+            let (_, _, error, status) = try run(arguments: args)
             defer { try? doRemove(name: name) }
             if status != 0 {
                 throw CLIError.executionFailed("command failed: \(error)")


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

`testPublishPortParserMaxPorts` and `testPublishPortParserTooManyPorts` run returns 4 parameters.

<img width="628" height="173" alt="image" src="https://github.com/user-attachments/assets/1c1d1fc2-6b25-41fb-bd29-32b560d390d2" />

Related #872

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
