### PR TITLE
feat: color and plain modes for --progress flag

### DIFF
--- a/Sources/ContainerBuild/BuildImageResolver.swift
+++ b/Sources/ContainerBuild/BuildImageResolver.swift
@@ -66,7 +66,7 @@ struct BuildImageResolver: BuildPipelineHandler {
                 showProgressBar: true,
                 showSize: true,
                 showSpeed: true,
-                disableProgressUpdates: self.quiet
+                outputMode: self.quiet ? .none : .ansi
             )
             let progress = ProgressBar(config: progressConfig)
             defer { progress.finish() }

--- a/Sources/ContainerClient/Flags.swift
+++ b/Sources/ContainerClient/Flags.swift
@@ -210,9 +210,11 @@ public struct Flags {
         public enum ProgressType: String, ExpressibleByArgument {
             case none
             case ansi
+            case plain
+            case color
         }
 
-        @Option(name: .long, help: ArgumentHelp("Progress type (format: none|ansi)", valueName: "type"))
+        @Option(name: .long, help: ArgumentHelp("Progress type (format: none|ansi|plain|color)", valueName: "type"))
         public var progress: ProgressType = .ansi
     }
 

--- a/Sources/ContainerCommands/Container/ContainerRun.swift
+++ b/Sources/ContainerCommands/Container/ContainerRun.swift
@@ -65,15 +65,14 @@ extension Application {
 
             var progressConfig: ProgressConfig
             switch self.progressFlags.progress {
-            case .none: progressConfig = try ProgressConfig(disableProgressUpdates: true)
+            case .none: progressConfig = try ProgressConfig(outputMode: .none)
             case .ansi, .plain, .color:
                 progressConfig = try ProgressConfig(
                     showTasks: true,
                     showItems: true,
                     ignoreSmallSize: true,
                     totalTasks: 6,
-                    color: self.progressFlags.progress == .color,
-                    plain: self.progressFlags.progress == .plain
+                    outputMode: self.progressFlags.progress.outputMode
                 )
             }
 

--- a/Sources/ContainerCommands/Container/ContainerRun.swift
+++ b/Sources/ContainerCommands/Container/ContainerRun.swift
@@ -66,12 +66,14 @@ extension Application {
             var progressConfig: ProgressConfig
             switch self.progressFlags.progress {
             case .none: progressConfig = try ProgressConfig(disableProgressUpdates: true)
-            case .ansi:
+            case .ansi, .plain, .color:
                 progressConfig = try ProgressConfig(
                     showTasks: true,
                     showItems: true,
                     ignoreSmallSize: true,
-                    totalTasks: 6
+                    totalTasks: 6,
+                    color: self.progressFlags.progress == .color,
+                    plain: self.progressFlags.progress == .plain
                 )
             }
 

--- a/Sources/ContainerCommands/Image/ImagePull.swift
+++ b/Sources/ContainerCommands/Image/ImagePull.swift
@@ -82,15 +82,14 @@ extension Application {
 
             var progressConfig: ProgressConfig
             switch self.progressFlags.progress {
-            case .none: progressConfig = try ProgressConfig(disableProgressUpdates: true)
+            case .none: progressConfig = try ProgressConfig(outputMode: .none)
             case .ansi, .plain, .color:
                 progressConfig = try ProgressConfig(
                     showTasks: true,
                     showItems: true,
                     ignoreSmallSize: true,
                     totalTasks: 2,
-                    color: self.progressFlags.progress == .color,
-                    plain: self.progressFlags.progress == .plain
+                    outputMode: self.progressFlags.progress.outputMode
                 )
             }
 

--- a/Sources/ContainerCommands/Image/ImagePull.swift
+++ b/Sources/ContainerCommands/Image/ImagePull.swift
@@ -83,12 +83,14 @@ extension Application {
             var progressConfig: ProgressConfig
             switch self.progressFlags.progress {
             case .none: progressConfig = try ProgressConfig(disableProgressUpdates: true)
-            case .ansi:
+            case .ansi, .plain, .color:
                 progressConfig = try ProgressConfig(
                     showTasks: true,
                     showItems: true,
                     ignoreSmallSize: true,
-                    totalTasks: 2
+                    totalTasks: 2,
+                    color: self.progressFlags.progress == .color,
+                    plain: self.progressFlags.progress == .plain
                 )
             }
 

--- a/Sources/ContainerCommands/Image/ImagePush.swift
+++ b/Sources/ContainerCommands/Image/ImagePush.swift
@@ -69,7 +69,7 @@ extension Application {
 
             var progressConfig: ProgressConfig
             switch self.progressFlags.progress {
-            case .none: progressConfig = try ProgressConfig(disableProgressUpdates: true)
+            case .none: progressConfig = try ProgressConfig(outputMode: .none)
             case .ansi, .color, .plain:
                 progressConfig = try ProgressConfig(
                     description: "Pushing image \(image.reference)",
@@ -77,8 +77,7 @@ extension Application {
                     showItems: true,
                     showSpeed: false,
                     ignoreSmallSize: true,
-                    color: self.progressFlags.progress == .color,
-                    plain: self.progressFlags.progress == .plain
+                    outputMode: self.progressFlags.progress.outputMode
                 )
             }
 

--- a/Sources/ContainerCommands/Image/ImagePush.swift
+++ b/Sources/ContainerCommands/Image/ImagePush.swift
@@ -70,13 +70,15 @@ extension Application {
             var progressConfig: ProgressConfig
             switch self.progressFlags.progress {
             case .none: progressConfig = try ProgressConfig(disableProgressUpdates: true)
-            case .ansi:
+            case .ansi, .color, .plain:
                 progressConfig = try ProgressConfig(
                     description: "Pushing image \(image.reference)",
                     itemsName: "blobs",
                     showItems: true,
                     showSpeed: false,
-                    ignoreSmallSize: true
+                    ignoreSmallSize: true,
+                    color: self.progressFlags.progress == .color,
+                    plain: self.progressFlags.progress == .plain
                 )
             }
 

--- a/Sources/ContainerCommands/ProgressTypeExtension.swift
+++ b/Sources/ContainerCommands/ProgressTypeExtension.swift
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerClient
+import TerminalProgress
+
+extension Flags.Progress.ProgressType {
+    /// Converts the progress type to a ProgressConfig output mode.
+    var outputMode: ProgressConfig.OutputMode {
+        switch self {
+        case .none: .none
+        case .ansi: .ansi
+        case .plain: .plain
+        case .color: .color
+        }
+    }
+}

--- a/Sources/TerminalProgress/ProgressBar+Terminal.swift
+++ b/Sources/TerminalProgress/ProgressBar+Terminal.swift
@@ -63,7 +63,7 @@ extension ProgressBar {
     }
 
     func displayText(_ text: String, terminating: String = "\r") {
-        if config.plain {
+        if config.outputMode == .plain {
             display(text + "\n")
             return
         }

--- a/Sources/TerminalProgress/ProgressBar.swift
+++ b/Sources/TerminalProgress/ProgressBar.swift
@@ -72,7 +72,7 @@ public final class ProgressBar: Sendable {
             $0.subDescription = ""
             $0.tasks += 1
         }
-        if config.plain {
+        if config.outputMode == .plain {
             render(force: true)
         }
     }
@@ -83,7 +83,7 @@ public final class ProgressBar: Sendable {
         resetCurrentTask()
 
         state.withLock { $0.subDescription = subDescription }
-        if config.plain {
+        if config.outputMode == .plain {
             render(force: true)
         }
     }
@@ -102,7 +102,7 @@ public final class ProgressBar: Sendable {
     /// Starts an animation of the progress bar.
     /// - Parameter intervalSeconds: The time interval between updates in seconds.
     public func start(intervalSeconds: TimeInterval = 0.04) {
-        if config.plain {
+        if config.outputMode == .plain {
             return
         }
         Task(priority: .utility) {
@@ -121,7 +121,7 @@ public final class ProgressBar: Sendable {
         // The last render.
         render(force: true)
 
-        if !config.disableProgressUpdates && !config.clearOnFinish {
+        if config.outputMode != .none && !config.clearOnFinish {
             displayText(state.withLock { $0.output }, terminating: "\n")
         }
 
@@ -143,7 +143,7 @@ extension ProgressBar {
     }
 
     func render(force: Bool = false) {
-        guard term != nil && !config.disableProgressUpdates && (force || !state.withLock { $0.finished }) else {
+        guard term != nil && config.outputMode != .none && (force || !state.withLock { $0.finished }) else {
             return
         }
         let output = draw()
@@ -298,7 +298,7 @@ extension ProgressBar {
     }
 
     private func colorize(_ text: String, _ color: String) -> String {
-        guard config.color else { return text }
+        guard config.outputMode == .color else { return text }
         return "\(color)\(text)\(Color.reset)"
     }
 

--- a/Sources/TerminalProgress/ProgressConfig.swift
+++ b/Sources/TerminalProgress/ProgressConfig.swift
@@ -65,6 +65,10 @@ public struct ProgressConfig: Sendable {
     public let clearOnFinish: Bool
     /// The flag indicating whether to update the progress bar.
     public let disableProgressUpdates: Bool
+    /// The flag indicating whether to use colors.
+    public let color: Bool
+    /// The flag indicating whether to use plain output (no ANSI codes, one line per update).
+    public let plain: Bool
     /// Creates a new instance of `ProgressConfig`.
     /// - Parameters:
     ///   - terminal: The file handle for progress updates. The default value is `FileHandle.standardError`.
@@ -88,6 +92,8 @@ public struct ProgressConfig: Sendable {
     ///   - theme: The theme of the progress bar. The default value is `nil`.
     ///   - clearOnFinish: The flag indicating whether to clear the progress bar before resetting the cursor. The default is `true`.
     ///   - disableProgressUpdates: The flag indicating whether to update the progress bar. The default is `false`.
+    ///   - color: A flag indicating whether to enable ANSI color output. The default value is `false`.
+    ///   - plain: A flag indicating whether to force plain output with no control sequences. The default value is `false`.
     public init(
         terminal: FileHandle = .standardError,
         description: String = "",
@@ -109,7 +115,9 @@ public struct ProgressConfig: Sendable {
         width: Int = 120,
         theme: ProgressTheme? = nil,
         clearOnFinish: Bool = true,
-        disableProgressUpdates: Bool = false
+        disableProgressUpdates: Bool = false,
+        color: Bool = false,
+        plain: Bool = false
     ) throws {
         if let totalTasks {
             guard totalTasks > 0 else {
@@ -132,11 +140,11 @@ public struct ProgressConfig: Sendable {
         self.initialSubDescription = subDescription
         self.initialItemsName = itemsName
 
-        self.showSpinner = showSpinner
+        self.showSpinner = plain ? false : showSpinner
         self.showTasks = showTasks
         self.showDescription = showDescription
         self.showPercent = showPercent
-        self.showProgressBar = showProgressBar
+        self.showProgressBar = plain ? false : showProgressBar
         self.showItems = showItems
         self.showSize = showSize
         self.showSpeed = showSpeed
@@ -151,6 +159,8 @@ public struct ProgressConfig: Sendable {
         self.theme = theme ?? DefaultProgressTheme()
         self.clearOnFinish = clearOnFinish
         self.disableProgressUpdates = disableProgressUpdates
+        self.color = plain ? false : color
+        self.plain = plain
     }
 }
 

--- a/Sources/TerminalProgress/ProgressConfig.swift
+++ b/Sources/TerminalProgress/ProgressConfig.swift
@@ -18,6 +18,17 @@ import Foundation
 
 /// A configuration for displaying a progress bar.
 public struct ProgressConfig: Sendable {
+    /// The output mode for progress display.
+    public enum OutputMode: Sendable {
+        /// No progress output.
+        case none
+        /// ANSI control sequences without color (default).
+        case ansi
+        /// Plain text output, one line per update.
+        case plain
+        /// ANSI control sequences with color.
+        case color
+    }
     /// The file handle for progress updates.
     let terminal: FileHandle
     /// The initial description of the progress bar.
@@ -63,12 +74,8 @@ public struct ProgressConfig: Sendable {
     public let theme: ProgressTheme
     /// The flag indicating whether to clear the progress bar before resetting the cursor.
     public let clearOnFinish: Bool
-    /// The flag indicating whether to update the progress bar.
-    public let disableProgressUpdates: Bool
-    /// The flag indicating whether to use colors.
-    public let color: Bool
-    /// The flag indicating whether to use plain output (no ANSI codes, one line per update).
-    public let plain: Bool
+    /// The output mode for progress display.
+    public let outputMode: OutputMode
     /// Creates a new instance of `ProgressConfig`.
     /// - Parameters:
     ///   - terminal: The file handle for progress updates. The default value is `FileHandle.standardError`.
@@ -91,9 +98,7 @@ public struct ProgressConfig: Sendable {
     ///   - width: The width of the progress bar in characters. The default value is `120`.
     ///   - theme: The theme of the progress bar. The default value is `nil`.
     ///   - clearOnFinish: The flag indicating whether to clear the progress bar before resetting the cursor. The default is `true`.
-    ///   - disableProgressUpdates: The flag indicating whether to update the progress bar. The default is `false`.
-    ///   - color: A flag indicating whether to enable ANSI color output. The default value is `false`.
-    ///   - plain: A flag indicating whether to force plain output with no control sequences. The default value is `false`.
+    ///   - outputMode: The output mode for progress display. The default value is `.ansi`.
     public init(
         terminal: FileHandle = .standardError,
         description: String = "",
@@ -115,9 +120,7 @@ public struct ProgressConfig: Sendable {
         width: Int = 120,
         theme: ProgressTheme? = nil,
         clearOnFinish: Bool = true,
-        disableProgressUpdates: Bool = false,
-        color: Bool = false,
-        plain: Bool = false
+        outputMode: OutputMode = .ansi
     ) throws {
         if let totalTasks {
             guard totalTasks > 0 else {
@@ -140,11 +143,11 @@ public struct ProgressConfig: Sendable {
         self.initialSubDescription = subDescription
         self.initialItemsName = itemsName
 
-        self.showSpinner = plain ? false : showSpinner
+        self.showSpinner = (outputMode == .plain || outputMode == .none) ? false : showSpinner
         self.showTasks = showTasks
         self.showDescription = showDescription
         self.showPercent = showPercent
-        self.showProgressBar = plain ? false : showProgressBar
+        self.showProgressBar = (outputMode == .plain || outputMode == .none) ? false : showProgressBar
         self.showItems = showItems
         self.showSize = showSize
         self.showSpeed = showSpeed
@@ -158,9 +161,7 @@ public struct ProgressConfig: Sendable {
         self.width = width
         self.theme = theme ?? DefaultProgressTheme()
         self.clearOnFinish = clearOnFinish
-        self.disableProgressUpdates = disableProgressUpdates
-        self.color = plain ? false : color
-        self.plain = plain
+        self.outputMode = outputMode
     }
 }
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -84,7 +84,7 @@ container run [<options>] <image> [<arguments> ...]
 
 **Progress Options**
 
-*   `--progress <type>`: Progress type (format: none|ansi) (default: ansi)
+*   `--progress <type>`: Progress type (format: none|ansi|plain|color) (default: ansi)
 
 **Examples**
 
@@ -449,7 +449,7 @@ container image pull [--debug] [--scheme <scheme>] [--progress <type>] [--arch <
 **Options**
 
 *   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https, auto) (default: auto)
-*   `--progress <type>`: Progress type (format: none|ansi) (default: ansi)
+*   `--progress <type>`: Progress type (format: none|ansi|plain|color) (default: ansi)
 *   `-a, --arch <arch>`: Limit the pull to the specified architecture
 *   `--os <os>`: Limit the pull to the specified OS
 *   `--platform <platform>`: Limit the pull to the specified platform (format: os/arch[/variant], takes precedence over --os and --arch)
@@ -471,7 +471,7 @@ container image push [--scheme <scheme>] [--progress <type>] [--arch <arch>] [--
 **Options**
 
 *   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https, auto) (default: auto)
-*   `--progress <type>`: Progress type (format: none|ansi) (default: ansi)
+*   `--progress <type>`: Progress type (format: none|ansi|plain|color) (default: ansi)
 *   `-a, --arch <arch>`: Limit the push to the specified architecture
 *   `--os <os>`: Limit the push to the specified OS
 *   `--platform <platform>`: Limit the push to the specified platform (format: os/arch[/variant], takes precedence over --os and --arch)


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
relevant issue: https://github.com/apple/container/issues/641

Adds two new modes to `--progress`: **plain** and **color**.

* **plain**: Produces simple, line-by-line text output with *no ANSI escape codes*. Ideal for writing to log files or environments that don’t support terminal control sequences.

* **color**: Similar to the existing ANSI mode but with enhanced color usage. This mode provides a more expressive visual display. If it sounds good, we could consider making it the default in this or a follow up pr.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [x] Added/updated docs
