### PR TITLE
Fix incorrect creationDate for networks.

### DIFF
--- a/Sources/Services/ContainerAPIService/Networks/NetworksService.swift
+++ b/Sources/Services/ContainerAPIService/Networks/NetworksService.swift
@@ -78,7 +78,16 @@ public actor NetworksService {
 
             let client = NetworkClient(id: configuration.id)
             let networkState = try await client.state()
-            networkStates[configuration.id] = networkState
+
+            // FIXME: Temporary workaround for persisted configuration being overwritten
+            // by what comes back from the network helper, which messes up creationDate.
+            switch networkState {
+            case .created(_):
+                networkStates[configuration.id] = NetworkState.created(configuration)
+            case .running(_, let status):
+                networkStates[configuration.id] = NetworkState.running(configuration, status)
+            }
+
             guard case .running = networkState else {
                 log.error(
                     "network failed to start",


### PR DESCRIPTION
- Fixes #925.
- When the API service enumerates creation dates, the configuration value from the network helper is used instead of the persistent config value, so the creation date winds up being the current time. The short term fix is for the API server to return NetworkState values that combine the API server's persistent network config with the network status returned from the helper.
- The longer term refinement could be to define a uniform model for resources where each resource type has Metadata (id/Identifiable, creationDate, labels), and type-specific configuration and state/status.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

See above.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
