### PR TITLE
fix(TerminalProgress): make the progress bar respect locale-specific decimal separator

### DIFF
--- a/Sources/TerminalProgress/ProgressBar.swift
+++ b/Sources/TerminalProgress/ProgressBar.swift
@@ -261,12 +261,13 @@ extension ProgressBar {
     private func adjustFormattedSize(_ size: String) -> String {
         // Ensure we always have one digit after the decimal point to prevent flickering.
         let zero = Int64(0).formattedSize()
-        guard !size.contains("."), let first = size.first, first.isNumber || !size.contains(zero) else {
+        let decimalSep = Locale.current.decimalSeparator ?? "."
+        guard !size.contains(decimalSep), let first = size.first, first.isNumber || !size.contains(zero) else {
             return size
         }
         var size = size
         for unit in ["MB", "GB", "TB"] {
-            size = size.replacingOccurrences(of: " \(unit)", with: ".0 \(unit)")
+            size = size.replacingOccurrences(of: " \(unit)", with: "\(decimalSep)0 \(unit)")
         }
         return size
     }


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
The `ProgressBar#adjustFormattedSize` function currently expects a decimal dot when adding the additional ".0" to the size. This, however, breaks when a region with a non-dot decimal separator is used:

<img width="518" height="41" alt="A screenshot showing kernel download progress with .0 appended to the end while having a decimal part" src="https://github.com/user-attachments/assets/6a0b951b-7621-434c-b33f-0d288fa1ad1e" />


This PR makes the function use the decimal separator of the current locale instead, making it work as intended under environments that don't use the decimal dot:

<img width="491" height="42" alt="A screenshot showing kernel download progress showing the comma " src="https://github.com/user-attachments/assets/89590084-bfdf-47c8-999b-700069bb9717" />

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
