### PR TITLE
[images]: refactor prune command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ integration: init-block
 		$(SWIFT) test -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter TestCLIVolumes || exit_code=1 ; \
 		$(SWIFT) test -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter TestCLIKernelSet || exit_code=1 ; \
 		$(SWIFT) test -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter TestCLIAnonymousVolumes || exit_code=1 ; \
-		$(SWIFT) test -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --no-parallel --filter TestCLINoParallelCases || exit_code=1 ; \
+		$(SWIFT) test -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter TestCLINoParallelCases || exit_code=1 ; \
 		echo Ensuring apiserver stopped after the CLI integration tests ; \
 		scripts/ensure-container-stopped.sh ; \
 		exit $${exit_code} ; \

--- a/Tests/CLITests/Subcommands/Images/TestCLIImagesCommand.swift
+++ b/Tests/CLITests/Subcommands/Images/TestCLIImagesCommand.swift
@@ -19,12 +19,7 @@ import ContainerizationOCI
 import Foundation
 import Testing
 
-@Suite(.serialized)
 class TestCLIImagesCommand: CLITest {
-    private func getTestName() -> String {
-        Test.current!.name.trimmingCharacters(in: ["(", ")"]).lowercased()
-    }
-
     @Test func testPull() throws {
         do {
             try doPull(imageName: alpine)
@@ -374,78 +369,5 @@ class TestCLIImagesCommand: CLITest {
             Issue.record("failed to save and load image \(error)")
             return
         }
-    }
-    
-    @Test func testImagePruneNoImages() throws {
-        // Prune with no images should succeed
-        let (_, output, error, status) = try run(arguments: ["image", "prune"])
-        if status != 0 {
-            throw CLIError.executionFailed("image prune failed: \(error)")
-        }
-
-        #expect(output.contains("Zero KB"), "should show no space reclaimed")
-    }
-
-    @Test func testImagePruneUnusedImages() throws {
-        // 1. Pull the images
-        try doPull(imageName: alpine)
-        try doPull(imageName: busybox)
-
-        // 2. Verify the images are present
-        let alpinePresent = try isImagePresent(targetImage: alpine)
-        #expect(alpinePresent, "expected to see image \(alpine) pulled")
-        let busyBoxPresent = try isImagePresent(targetImage: busybox)
-        #expect(busyBoxPresent, "expected to see image \(busybox) pulled")
-
-        // 3. Prune with the -a flag should remove all unused images
-        let (_, output, error, status) = try run(arguments: ["image", "prune", "-a"])
-        if status != 0 {
-            throw CLIError.executionFailed("image prune failed: \(error)")
-        }
-        #expect(output.contains(alpine), "should prune alpine image")
-        #expect(output.contains(busybox), "should prune busybox image")
-
-        // 4. Verify the images are gone
-        let alpineRemoved = try !isImagePresent(targetImage: alpine)
-        #expect(alpineRemoved, "expected image \(alpine) to be removed")
-        let busyboxRemoved = try !isImagePresent(targetImage: busybox)
-        #expect(busyboxRemoved, "expected image \(busybox) to be removed")
-    }
-
-    @Test func testImagePruneDanglingImages() throws {
-        let name = getTestName()
-        let containerName = "\(name)_container"
-
-        // 1. Pull the images
-        try doPull(imageName: alpine)
-        try doPull(imageName: busybox)
-
-        // 2. Verify the images are present
-        let alpinePresent = try isImagePresent(targetImage: alpine)
-        #expect(alpinePresent, "expected to see image \(alpine) pulled")
-        let busyBoxPresent = try isImagePresent(targetImage: busybox)
-        #expect(busyBoxPresent, "expected to see image \(busybox) pulled")
-
-        // 3. Create a running container based on alpine
-        try doLongRun(
-            name: containerName,
-            image: alpine
-        )
-        try waitForContainerRunning(containerName)
-
-        // 4. Prune should only remove the dangling image
-        let (_, output, error, status) = try run(arguments: ["image", "prune", "-a"])
-        if status != 0 {
-            throw CLIError.executionFailed("image prune failed: \(error)")
-        }
-        #expect(output.contains(busybox), "should prune busybox image")
-
-        // 5. Verify the busybox image is gone
-        let busyboxRemoved = try !isImagePresent(targetImage: busybox)
-        #expect(busyboxRemoved, "expected image \(busybox) to be removed")
-
-        // 6. Verify the alpine image still exists
-        let alpineStillPresent = try isImagePresent(targetImage: alpine)
-        #expect(alpineStillPresent, "expected image \(alpine) to remain")
     }
 }

--- a/Tests/CLITests/TestCLINoParallelCases.swift
+++ b/Tests/CLITests/TestCLINoParallelCases.swift
@@ -20,7 +20,12 @@ import Foundation
 import Testing
 
 /// Tests that need total control over environment to avoid conflicts.
+@Suite(.serialized)
 class TestCLINoParallelCases: CLITest {
+    private func getTestName() -> String {
+        Test.current!.name.trimmingCharacters(in: ["(", ")"]).lowercased()
+    }
+
     @Test func testImageSingleConcurrentDownload() throws {
         // removing this image during parallel tests breaks stuff!
         _ = try? run(arguments: ["image", "rm", alpine])
@@ -45,5 +50,78 @@ class TestCLINoParallelCases: CLITest {
             Issue.record("failed to pull image with maxConcurrentDownloads flag: \(error)")
             return
         }
+    }
+
+    @Test func testImagePruneNoImages() throws {
+        // Prune with no images should succeed
+        let (_, output, error, status) = try run(arguments: ["image", "prune"])
+        if status != 0 {
+            throw CLIError.executionFailed("image prune failed: \(error)")
+        }
+
+        #expect(output.contains("Zero KB"), "should show no space reclaimed")
+    }
+
+    @Test func testImagePruneUnusedImages() throws {
+        // 1. Pull the images
+        try doPull(imageName: alpine)
+        try doPull(imageName: busybox)
+
+        // 2. Verify the images are present
+        let alpinePresent = try isImagePresent(targetImage: alpine)
+        #expect(alpinePresent, "expected to see image \(alpine) pulled")
+        let busyBoxPresent = try isImagePresent(targetImage: busybox)
+        #expect(busyBoxPresent, "expected to see image \(busybox) pulled")
+
+        // 3. Prune with the -a flag should remove all unused images
+        let (_, output, error, status) = try run(arguments: ["image", "prune", "-a"])
+        if status != 0 {
+            throw CLIError.executionFailed("image prune failed: \(error)")
+        }
+        #expect(output.contains(alpine), "should prune alpine image")
+        #expect(output.contains(busybox), "should prune busybox image")
+
+        // 4. Verify the images are gone
+        let alpineRemoved = try !isImagePresent(targetImage: alpine)
+        #expect(alpineRemoved, "expected image \(alpine) to be removed")
+        let busyboxRemoved = try !isImagePresent(targetImage: busybox)
+        #expect(busyboxRemoved, "expected image \(busybox) to be removed")
+    }
+
+    @Test func testImagePruneDanglingImages() throws {
+        let name = getTestName()
+        let containerName = "\(name)_container"
+
+        // 1. Pull the images
+        try doPull(imageName: alpine)
+        try doPull(imageName: busybox)
+
+        // 2. Verify the images are present
+        let alpinePresent = try isImagePresent(targetImage: alpine)
+        #expect(alpinePresent, "expected to see image \(alpine) pulled")
+        let busyBoxPresent = try isImagePresent(targetImage: busybox)
+        #expect(busyBoxPresent, "expected to see image \(busybox) pulled")
+
+        // 3. Create a running container based on alpine
+        try doLongRun(
+            name: containerName,
+            image: alpine
+        )
+        try waitForContainerRunning(containerName)
+
+        // 4. Prune should only remove the dangling image
+        let (_, output, error, status) = try run(arguments: ["image", "prune", "-a"])
+        if status != 0 {
+            throw CLIError.executionFailed("image prune failed: \(error)")
+        }
+        #expect(output.contains(busybox), "should prune busybox image")
+
+        // 5. Verify the busybox image is gone
+        let busyboxRemoved = try !isImagePresent(targetImage: busybox)
+        #expect(busyboxRemoved, "expected image \(busybox) to be removed")
+
+        // 6. Verify the alpine image still exists
+        let alpineStillPresent = try isImagePresent(targetImage: alpine)
+        #expect(alpineStillPresent, "expected image \(alpine) to remain")
     }
 }


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Updates to `image prune` for consistency with how other `prune` commands are done. Added missing test cases as well for the command

Relates to the discussion from #914

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs
