### PR TITLE
Use new IP/CIDR types from Containerization.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a20d52336b96991c23765c8301254aeff44ab33c0ccc7dee59191e50652f5070",
+  "originHash" : "64cb422fa3914611343af4301e317573002890fea7d174e550cc937a76571515",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "e8aff29be3b97afa18ccc256126466ae5e611bea",
-        "version" : "0.16.2"
+        "revision" : "9ba8267afbdff66e5ddce180312abdb41395292f",
+        "version" : "0.17.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ import PackageDescription
 let releaseVersion = ProcessInfo.processInfo.environment["RELEASE_VERSION"] ?? "0.0.0"
 let gitCommit = ProcessInfo.processInfo.environment["GIT_COMMIT"] ?? "unspecified"
 let builderShimVersion = "0.7.0"
-let scVersion = "0.16.2"
+let scVersion = "0.17.0"
 
 let package = Package(
     name: "container",
@@ -146,6 +146,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Containerization", package: "containerization"),
+                .product(name: "ContainerizationExtras", package: "containerization"),
                 .product(name: "ContainerizationOS", package: "containerization"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 "ContainerClient",

--- a/Sources/ContainerCommands/Builder/BuilderStart.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStart.swift
@@ -230,8 +230,8 @@ extension Application {
                 throw ContainerizationError(.invalidState, message: "default network is not running")
             }
             config.networks = [AttachmentConfiguration(network: network.id, options: AttachmentOptions(hostname: id))]
-            let subnet = try CIDRAddress(networkStatus.address)
-            let nameserver = IPv4Address(fromValue: subnet.lower.value + 1).description
+            let subnet = networkStatus.ipv4Subnet
+            let nameserver = IPv4Address(subnet.lower.value + 1).description
             let nameservers = [nameserver]
             config.dns = ContainerConfiguration.DNSConfiguration(nameservers: nameservers)
 

--- a/Sources/ContainerCommands/Builder/BuilderStatus.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStatus.swift
@@ -94,7 +94,7 @@ extension ClientContainer {
             self.id,
             self.configuration.image.reference,
             self.status.rawValue,
-            self.networks.compactMap { try? CIDRAddress($0.address).address.description }.joined(separator: ","),
+            self.networks.compactMap { $0.ipv4Address.description }.joined(separator: ","),
             "\(self.configuration.resources.cpus)",
             "\(self.configuration.resources.memoryInBytes / (1024 * 1024)) MB",
         ]

--- a/Sources/ContainerCommands/Container/ContainerList.swift
+++ b/Sources/ContainerCommands/Container/ContainerList.swift
@@ -94,7 +94,7 @@ extension ClientContainer {
             self.configuration.platform.os,
             self.configuration.platform.architecture,
             self.status.rawValue,
-            self.networks.compactMap { try? CIDRAddress($0.address).address.description }.joined(separator: ","),
+            self.networks.compactMap { $0.ipv4Address.description }.joined(separator: ","),
             "\(self.configuration.resources.cpus)",
             "\(self.configuration.resources.memoryInBytes / (1024 * 1024)) MB",
         ]

--- a/Sources/ContainerCommands/Network/NetworkCreate.swift
+++ b/Sources/ContainerCommands/Network/NetworkCreate.swift
@@ -18,6 +18,7 @@ import ArgumentParser
 import ContainerClient
 import ContainerNetworkService
 import ContainerizationError
+import ContainerizationExtras
 import Foundation
 import TerminalProgress
 
@@ -43,7 +44,8 @@ extension Application {
 
         public func run() async throws {
             let parsedLabels = Utility.parseKeyValuePairs(labels)
-            let config = try NetworkConfiguration(id: self.name, mode: .nat, subnet: subnet, labels: parsedLabels)
+            let ipv4Subnet = try subnet.map { try CIDRv4($0) }
+            let config = try NetworkConfiguration(id: self.name, mode: .nat, ipv4Subnet: ipv4Subnet, labels: parsedLabels)
             let state = try await ClientNetwork.create(configuration: config)
             print(state.id)
         }

--- a/Sources/ContainerCommands/Network/NetworkList.swift
+++ b/Sources/ContainerCommands/Network/NetworkList.swift
@@ -83,7 +83,7 @@ extension NetworkState {
         case .created(_):
             return [self.id, self.state, "none"]
         case .running(_, let status):
-            return [self.id, self.state, status.address]
+            return [self.id, self.state, status.ipv4Subnet.description]
         }
     }
 }

--- a/Sources/ContainerCommands/System/Property/PropertySet.swift
+++ b/Sources/ContainerCommands/System/Property/PropertySet.swift
@@ -70,7 +70,7 @@ extension Application {
                 DefaultsStore.set(value: value, key: key)
                 return
             case .defaultSubnet:
-                guard (try? CIDRAddress(value)) != nil else {
+                guard (try? CIDRv4(value)) != nil else {
                     throw ContainerizationError(.invalidArgument, message: "invalid CIDRv4 address: \(value)")
                 }
                 DefaultsStore.set(value: value, key: key)

--- a/Sources/Helpers/APIServer/ContainerDNSHandler.swift
+++ b/Sources/Helpers/APIServer/ContainerDNSHandler.swift
@@ -94,15 +94,9 @@ struct ContainerDNSHandler: DNSHandler {
         guard let ipAllocation = try await networkService.lookup(hostname: question.name) else {
             return nil
         }
-
-        let components = ipAllocation.address.split(separator: "/")
-        guard !components.isEmpty else {
-            throw DNSResolverError.serverError("invalid IP format: empty address")
-        }
-
-        let ipString = String(components[0])
-        guard let ip = IPv4(ipString) else {
-            throw DNSResolverError.serverError("failed to parse IP address: \(ipString)")
+        let ipv4 = ipAllocation.ipv4Address.address.description
+        guard let ip = IPv4(ipv4) else {
+            throw DNSResolverError.serverError("failed to parse IP address: \(ipv4)")
         }
 
         return HostRecord<IPv4>(name: question.name, ttl: ttl, ip: ip)

--- a/Sources/Helpers/NetworkVmnet/NetworkVmnetHelper+Start.swift
+++ b/Sources/Helpers/NetworkVmnet/NetworkVmnetHelper+Start.swift
@@ -50,8 +50,8 @@ extension NetworkVmnetHelper {
 
             do {
                 log.info("configuring XPC server")
-                let subnet = try self.subnet.map { try CIDRAddress($0) }
-                let configuration = try NetworkConfiguration(id: id, mode: .nat, subnet: subnet?.description)
+                let ipv4Subnet = try self.subnet.map { try CIDRv4($0) }
+                let configuration = try NetworkConfiguration(id: id, mode: .nat, ipv4Subnet: ipv4Subnet)
                 let network = try Self.createNetwork(configuration: configuration, log: log)
                 try await network.start()
                 let server = try await NetworkService(network: network, log: log)

--- a/Sources/Helpers/RuntimeLinux/IsolatedInterfaceStrategy.swift
+++ b/Sources/Helpers/RuntimeLinux/IsolatedInterfaceStrategy.swift
@@ -24,7 +24,7 @@ import Containerization
 /// works for macOS Sequoia.
 struct IsolatedInterfaceStrategy: InterfaceStrategy {
     public func toInterface(attachment: Attachment, interfaceIndex: Int, additionalData: XPCMessage?) -> Interface {
-        let gateway = interfaceIndex == 0 ? attachment.gateway : nil
-        return NATInterface(address: attachment.address, gateway: gateway, macAddress: attachment.macAddress)
+        let ipv4Gateway = interfaceIndex == 0 ? attachment.ipv4Gateway : nil
+        return NATInterface(ipv4Address: attachment.ipv4Address, ipv4Gateway: ipv4Gateway, macAddress: attachment.macAddress)
     }
 }

--- a/Sources/Helpers/RuntimeLinux/NonisolatedInterfaceStrategy.swift
+++ b/Sources/Helpers/RuntimeLinux/NonisolatedInterfaceStrategy.swift
@@ -43,7 +43,7 @@ struct NonisolatedInterfaceStrategy: InterfaceStrategy {
         }
 
         log.info("creating NATNetworkInterface with network reference")
-        let gateway = interfaceIndex == 0 ? attachment.gateway : nil
-        return NATNetworkInterface(address: attachment.address, gateway: gateway, reference: networkRef, macAddress: attachment.macAddress)
+        let ipv4Gateway = interfaceIndex == 0 ? attachment.ipv4Gateway : nil
+        return NATNetworkInterface(ipv4Address: attachment.ipv4Address, ipv4Gateway: ipv4Gateway, reference: networkRef, macAddress: attachment.macAddress)
     }
 }

--- a/Sources/Services/ContainerNetworkService/AllocationOnlyVmnetNetwork.swift
+++ b/Sources/Services/ContainerNetworkService/AllocationOnlyVmnetNetwork.swift
@@ -35,8 +35,8 @@ public actor AllocationOnlyVmnetNetwork: Network {
             throw ContainerizationError(.unsupported, message: "invalid network mode \(configuration.mode)")
         }
 
-        guard configuration.subnet == nil else {
-            throw ContainerizationError(.unsupported, message: "subnet assignment is not yet implemented")
+        guard configuration.ipv4Subnet == nil else {
+            throw ContainerizationError(.unsupported, message: "IPv4 subnet assignment is not yet implemented")
         }
 
         self.log = log
@@ -65,9 +65,9 @@ public actor AllocationOnlyVmnetNetwork: Network {
         )
 
         let subnet = DefaultsStore.get(key: .defaultSubnet)
-        let subnetCIDR = try CIDRAddress(subnet)
-        let gateway = IPv4Address(fromValue: subnetCIDR.lower.value + 1)
-        self._state = .running(configuration, NetworkStatus(address: subnetCIDR.description, gateway: gateway.description))
+        let subnetCIDR = try CIDRv4(subnet)
+        let gateway = IPv4Address(subnetCIDR.lower.value + 1)
+        self._state = .running(configuration, NetworkStatus(ipv4Subnet: subnetCIDR, ipv4Gateway: gateway))
         log.info(
             "started allocation-only network",
             metadata: [

--- a/Sources/Services/ContainerNetworkService/Attachment.swift
+++ b/Sources/Services/ContainerNetworkService/Attachment.swift
@@ -14,24 +14,58 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerizationExtras
+
 /// A snapshot of a network interface allocated to a sandbox.
 public struct Attachment: Codable, Sendable {
     /// The network ID associated with the attachment.
     public let network: String
     /// The hostname associated with the attachment.
     public let hostname: String
-    /// The subnet CIDR, where the address is the container interface IPv4 address.
-    public let address: String
+    /// The CIDR address describing the interface IPv4 address, with the prefix length of the subnet.
+    public let ipv4Address: CIDRv4
     /// The IPv4 gateway address.
-    public let gateway: String
+    public let ipv4Gateway: IPv4Address
     /// The MAC address associated with the attachment (optional).
     public let macAddress: String?
 
-    public init(network: String, hostname: String, address: String, gateway: String, macAddress: String? = nil) {
+    public init(network: String, hostname: String, ipv4Address: CIDRv4, ipv4Gateway: IPv4Address, macAddress: String? = nil) {
         self.network = network
         self.hostname = hostname
-        self.address = address
-        self.gateway = gateway
+        self.ipv4Address = ipv4Address
+        self.ipv4Gateway = ipv4Gateway
         self.macAddress = macAddress
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case network
+        case hostname
+        case ipv4Address
+        case ipv4Gateway
+        case macAddress
+    }
+
+    /// Create an attachment from the supplied Decoder.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        network = try container.decode(String.self, forKey: .network)
+        hostname = try container.decode(String.self, forKey: .hostname)
+        let addressText = try container.decode(String.self, forKey: .ipv4Address)
+        ipv4Address = try CIDRv4(addressText)
+        let gatewayText = try container.decode(String.self, forKey: .ipv4Gateway)
+        ipv4Gateway = try IPv4Address(gatewayText)
+        macAddress = try container.decodeIfPresent(String.self, forKey: .macAddress)
+    }
+
+    /// Encode the attachment to the supplied Encoder.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(network, forKey: .network)
+        try container.encode(hostname, forKey: .hostname)
+        try container.encode(ipv4Address.description, forKey: .ipv4Address)
+        try container.encode(ipv4Gateway.description, forKey: .ipv4Gateway)
+        try container.encodeIfPresent(macAddress, forKey: .macAddress)
     }
 }

--- a/Sources/Services/ContainerNetworkService/NetworkState.swift
+++ b/Sources/Services/ContainerNetworkService/NetworkState.swift
@@ -14,21 +14,45 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerizationExtras
 import Foundation
 
 public struct NetworkStatus: Codable, Sendable {
     /// The address allocated for the network if no subnet was specified at
     /// creation time; otherwise, the subnet from the configuration.
-    public let address: String
+    public let ipv4Subnet: CIDRv4
     /// The gateway IPv4 address.
-    public let gateway: String
+    public let ipv4Gateway: IPv4Address
 
     public init(
-        address: String,
-        gateway: String
+        ipv4Subnet: CIDRv4,
+        ipv4Gateway: IPv4Address
     ) {
-        self.address = address
-        self.gateway = gateway
+        self.ipv4Subnet = ipv4Subnet
+        self.ipv4Gateway = ipv4Gateway
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case ipv4Subnet
+        case ipv4Gateway
+    }
+
+    /// Create a network status from the supplied Decoder.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let addressText = try container.decode(String.self, forKey: .ipv4Subnet)
+        ipv4Subnet = try CIDRv4(addressText)
+        let gatewayText = try container.decode(String.self, forKey: .ipv4Gateway)
+        ipv4Gateway = try IPv4Address(gatewayText)
+    }
+
+    /// Encode the network status to the supplied Encoder.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(ipv4Subnet.description, forKey: .ipv4Subnet)
+        try container.encode(ipv4Gateway.description, forKey: .ipv4Gateway)
     }
 
 }

--- a/Sources/Services/ContainerSandboxService/SandboxService.swift
+++ b/Sources/Services/ContainerSandboxService/SandboxService.swift
@@ -190,11 +190,10 @@ public actor SandboxService {
                 // a default /etc/hosts.
                 var hostsEntries = [Hosts.Entry.localHostIPV4()]
                 if !interfaces.isEmpty {
-                    let primaryIfaceAddr = interfaces[0].address
-                    let ip = primaryIfaceAddr.split(separator: "/")
+                    let primaryIfaceAddr = interfaces[0].ipv4Address
                     hostsEntries.append(
                         Hosts.Entry(
-                            ipAddress: String(ip[0]),
+                            ipAddress: primaryIfaceAddr.address.description,
                             hostnames: [czConfig.hostname],
                         ))
                 }
@@ -215,7 +214,7 @@ public actor SandboxService {
                 try await container.create()
                 try await self.monitor.registerProcess(id: config.id, onExit: self.onContainerExit)
                 if !container.interfaces.isEmpty {
-                    let firstCidr = try CIDRAddress(container.interfaces[0].address)
+                    let firstCidr = container.interfaces[0].ipv4Address
                     let ipAddress = firstCidr.address.description
                     try await self.startSocketForwarders(containerIpAddress: ipAddress, publishedPorts: config.publishedPorts)
                 }
@@ -865,7 +864,7 @@ public actor SandboxService {
             guard case .running(_, let status) = state else {
                 continue
             }
-            return status.gateway
+            return status.ipv4Gateway.description
         }
 
         return nil

--- a/Sources/SocketForwarder/ConnectHandler.swift
+++ b/Sources/SocketForwarder/ConnectHandler.swift
@@ -81,6 +81,11 @@ extension ConnectHandler {
             .whenComplete { result in
                 switch result {
                 case .success(let channel):
+                    guard context.channel.isActive else {
+                        self.log?.trace("backend - frontend channel closed, closing backend connection")
+                        context.channel.close(promise: nil)
+                        return
+                    }
                     self.log?.trace("backend - connected")
                     self.glue(channel, context: context)
                 case .failure(let error):

--- a/Tests/CLITests/Subcommands/Networks/TestCLINetwork.swift
+++ b/Tests/CLITests/Subcommands/Networks/TestCLINetwork.swift
@@ -61,7 +61,7 @@ class TestCLINetwork: CLITest {
 
             let container = try inspectContainer(name)
             #expect(container.networks.count > 0)
-            let cidrAddress = try CIDRAddress(container.networks[0].address)
+            let cidrAddress = container.networks[0].ipv4Address
             let url = "http://\(cidrAddress.address):\(port)"
             var request = HTTPClientRequest(url: url)
             request.method = .GET

--- a/Tests/CLITests/Subcommands/Run/TestCLIRunCommand.swift
+++ b/Tests/CLITests/Subcommands/Run/TestCLIRunCommand.swift
@@ -400,9 +400,8 @@ class TestCLIRunCommand: CLITest {
                 .map { $0.joined(separator: " ") }
 
             let inspectOutput = try inspectContainer(name)
-            let ip = String(inspectOutput.networks[0].address.split(separator: "/")[0])
-            let ipv4Address = try IPv4Address(ip)
-            let expectedNameserver = IPv4Address(fromValue: ipv4Address.prefix(prefixLength: 24).value + 1).description
+            let ip = inspectOutput.networks[0].ipv4Address.address
+            let expectedNameserver = IPv4Address((ip.value & Prefix(length: 24)!.prefixMask32) + 1).description
             let defaultDomain = try getDefaultDomain()
             let expectedLines: [String] = [
                 "nameserver \(expectedNameserver)",
@@ -463,12 +462,12 @@ class TestCLIRunCommand: CLITest {
             }
 
             let inspectOutput = try inspectContainer(name)
-            let ip = String(inspectOutput.networks[0].address.split(separator: "/")[0])
+            let ip = inspectOutput.networks[0].ipv4Address.address
 
             let output = try doExec(name: name, cmd: ["cat", "/etc/hosts"])
             let lines = output.split(separator: "\n")
 
-            let expectedEntries = [("127.0.0.1", "localhost"), (ip, name)]
+            let expectedEntries = [("127.0.0.1", "localhost"), (ip.description, name)]
 
             for (i, line) in lines.enumerated() {
                 let words = line.split(separator: " ").map { String($0) }

--- a/Tests/ContainerNetworkServiceTests/NetworkConfigurationTest.swift
+++ b/Tests/ContainerNetworkServiceTests/NetworkConfigurationTest.swift
@@ -33,12 +33,12 @@ struct NetworkConfigurationTest {
             "0-_.1",
         ]
         for id in ids {
-            let subnet = "192.168.64.1/24"
+            let ipv4Subnet = try CIDRv4("192.168.64.1/24")
             let labels = [
                 "foo": "bar",
                 "baz": String(repeating: "0", count: 4096 - "baz".count - "=".count),
             ]
-            _ = try NetworkConfiguration(id: id, mode: .nat, subnet: subnet, labels: labels)
+            _ = try NetworkConfiguration(id: id, mode: .nat, ipv4Subnet: ipv4Subnet, labels: labels)
         }
     }
 
@@ -50,35 +50,19 @@ struct NetworkConfigurationTest {
             "Foo",
         ]
         for id in ids {
-            let subnet = "192.168.64.1/24"
+            let ipv4Subnet = try CIDRv4("192.168.64.1/24")
             let labels = [
                 "foo": "bar",
                 "baz": String(repeating: "0", count: 4096 - "baz".count - "=".count),
             ]
             #expect {
-                _ = try NetworkConfiguration(id: id, mode: .nat, subnet: subnet, labels: labels)
+                _ = try NetworkConfiguration(id: id, mode: .nat, ipv4Subnet: ipv4Subnet, labels: labels)
             } throws: { error in
                 guard let err = error as? ContainerizationError else { return false }
                 #expect(err.code == .invalidArgument)
                 #expect(err.message.starts(with: "invalid network ID"))
                 return true
             }
-        }
-    }
-
-    @Test func testValidationBadSubnet() throws {
-        let id = "foo"
-        let subnet = "192.168.64.1"
-        let labels = [
-            "foo": "bar",
-            "baz": String(repeating: "0", count: 4096 - "baz".count - "=".count),
-        ]
-        #expect {
-            _ = try NetworkConfiguration(id: id, mode: .nat, subnet: subnet, labels: labels)
-        } throws: { error in
-            guard let err = error as? NetworkAddressError else { return false }
-            #expect(err.description.starts(with: "invalid CIDR block"))
-            return true
         }
     }
 
@@ -91,8 +75,8 @@ struct NetworkConfigurationTest {
         ]
         for labels in allLabels {
             let id = "foo"
-            let subnet = "192.168.64.1/24"
-            _ = try NetworkConfiguration(id: id, mode: .nat, subnet: subnet, labels: labels)
+            let ipv4Subnet = try CIDRv4("192.168.64.1/24")
+            _ = try NetworkConfiguration(id: id, mode: .nat, ipv4Subnet: ipv4Subnet, labels: labels)
         }
     }
 
@@ -106,9 +90,9 @@ struct NetworkConfigurationTest {
         ]
         for labels in allLabels {
             let id = "foo"
-            let subnet = "192.168.64.1/24"
+            let ipv4Subnet = try CIDRv4("192.168.64.1/24")
             #expect {
-                _ = try NetworkConfiguration(id: id, mode: .nat, subnet: subnet, labels: labels)
+                _ = try NetworkConfiguration(id: id, mode: .nat, ipv4Subnet: ipv4Subnet, labels: labels)
             } throws: { error in
                 guard let err = error as? ContainerizationError else { return false }
                 #expect(err.code == .invalidArgument)


### PR DESCRIPTION
- Part of work for #460.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [x] Breaking change
- [ ] Documentation update

## Motivation and Context
With CZ release 0.17.0, the IP and CIDR address types changed from String to IPv4Address and CIDRv4, respectively. This PR applies the corresponding adaptations to container.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
