### PR TITLE
Add Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## Summary

Add Dependabot configuration to automatically keep GitHub Actions up to date.

## Changes

Adds `.github/dependabot.yml` configured to:
- Check for GitHub Actions updates weekly
- Group all action updates together for easier review
- Use `ci` prefix for commit messages

## Why

As discussed in #958, this helps:
- Keep actions up to date with security patches automatically
- Handle Node runtime deprecations proactively (e.g., Node 20 → Node 24)
- Reduce manual maintenance burden

## Reference

Based on the pattern used in [swift-nio](https://github.com/apple/swift-nio/blob/main/.github/dependabot.yml).