### PR TITLE
Add support for reading env from named pipes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a20d52336b96991c23765c8301254aeff44ab33c0ccc7dee59191e50652f5070",
+  "originHash" : "64cb422fa3914611343af4301e317573002890fea7d174e550cc937a76571515",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "e8aff29be3b97afa18ccc256126466ae5e611bea",
-        "version" : "0.16.2"
+        "revision" : "9ba8267afbdff66e5ddce180312abdb41395292f",
+        "version" : "0.17.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ import PackageDescription
 let releaseVersion = ProcessInfo.processInfo.environment["RELEASE_VERSION"] ?? "0.0.0"
 let gitCommit = ProcessInfo.processInfo.environment["GIT_COMMIT"] ?? "unspecified"
 let builderShimVersion = "0.7.0"
-let scVersion = "0.16.2"
+let scVersion = "0.17.0"
 
 let package = Package(
     name: "container",
@@ -146,6 +146,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Containerization", package: "containerization"),
+                .product(name: "ContainerizationExtras", package: "containerization"),
                 .product(name: "ContainerizationOS", package: "containerization"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 "ContainerClient",

--- a/Sources/ContainerCommands/Builder/BuilderStart.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStart.swift
@@ -230,8 +230,8 @@ extension Application {
                 throw ContainerizationError(.invalidState, message: "default network is not running")
             }
             config.networks = [AttachmentConfiguration(network: network.id, options: AttachmentOptions(hostname: id))]
-            let subnet = try CIDRAddress(networkStatus.address)
-            let nameserver = IPv4Address(fromValue: subnet.lower.value + 1).description
+            let subnet = networkStatus.ipv4Subnet
+            let nameserver = IPv4Address(subnet.lower.value + 1).description
             let nameservers = [nameserver]
             config.dns = ContainerConfiguration.DNSConfiguration(nameservers: nameservers)
 

--- a/Sources/ContainerCommands/Builder/BuilderStatus.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStatus.swift
@@ -94,7 +94,7 @@ extension ClientContainer {
             self.id,
             self.configuration.image.reference,
             self.status.rawValue,
-            self.networks.compactMap { try? CIDRAddress($0.address).address.description }.joined(separator: ","),
+            self.networks.compactMap { $0.ipv4Address.description }.joined(separator: ","),
             "\(self.configuration.resources.cpus)",
             "\(self.configuration.resources.memoryInBytes / (1024 * 1024)) MB",
         ]

--- a/Sources/ContainerCommands/Container/ContainerList.swift
+++ b/Sources/ContainerCommands/Container/ContainerList.swift
@@ -94,7 +94,7 @@ extension ClientContainer {
             self.configuration.platform.os,
             self.configuration.platform.architecture,
             self.status.rawValue,
-            self.networks.compactMap { try? CIDRAddress($0.address).address.description }.joined(separator: ","),
+            self.networks.compactMap { $0.ipv4Address.description }.joined(separator: ","),
             "\(self.configuration.resources.cpus)",
             "\(self.configuration.resources.memoryInBytes / (1024 * 1024)) MB",
         ]

--- a/Sources/ContainerCommands/Network/NetworkCommand.swift
+++ b/Sources/ContainerCommands/Network/NetworkCommand.swift
@@ -26,6 +26,7 @@ extension Application {
                 NetworkDelete.self,
                 NetworkList.self,
                 NetworkInspect.self,
+                NetworkPrune.self,
             ],
             aliases: ["n"]
         )

--- a/Sources/ContainerCommands/Network/NetworkCreate.swift
+++ b/Sources/ContainerCommands/Network/NetworkCreate.swift
@@ -18,6 +18,7 @@ import ArgumentParser
 import ContainerClient
 import ContainerNetworkService
 import ContainerizationError
+import ContainerizationExtras
 import Foundation
 import TerminalProgress
 
@@ -43,7 +44,8 @@ extension Application {
 
         public func run() async throws {
             let parsedLabels = Utility.parseKeyValuePairs(labels)
-            let config = try NetworkConfiguration(id: self.name, mode: .nat, subnet: subnet, labels: parsedLabels)
+            let ipv4Subnet = try subnet.map { try CIDRv4($0) }
+            let config = try NetworkConfiguration(id: self.name, mode: .nat, ipv4Subnet: ipv4Subnet, labels: parsedLabels)
             let state = try await ClientNetwork.create(configuration: config)
             print(state.id)
         }

--- a/Sources/ContainerCommands/Network/NetworkList.swift
+++ b/Sources/ContainerCommands/Network/NetworkList.swift
@@ -83,7 +83,7 @@ extension NetworkState {
         case .created(_):
             return [self.id, self.state, "none"]
         case .running(_, let status):
-            return [self.id, self.state, status.address]
+            return [self.id, self.state, status.ipv4Subnet.description]
         }
     }
 }

--- a/Sources/ContainerCommands/Network/NetworkPrune.swift
+++ b/Sources/ContainerCommands/Network/NetworkPrune.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ContainerClient
+import Foundation
+
+extension Application.NetworkCommand {
+    public struct NetworkPrune: AsyncParsableCommand {
+        public init() {}
+        public static let configuration = CommandConfiguration(
+            commandName: "prune",
+            abstract: "Remove networks with no container connections"
+        )
+
+        @OptionGroup
+        var global: Flags.Global
+
+        public func run() async throws {
+            let allContainers = try await ClientContainer.list()
+            let allNetworks = try await ClientNetwork.list()
+
+            var networksInUse = Set<String>()
+            for container in allContainers {
+                for network in container.configuration.networks {
+                    networksInUse.insert(network.network)
+                }
+            }
+
+            let networksToPrune = allNetworks.filter { network in
+                network.id != ClientNetwork.defaultNetworkName && !networksInUse.contains(network.id)
+            }
+
+            var prunedNetworks = [String]()
+
+            for network in networksToPrune {
+                do {
+                    try await ClientNetwork.delete(id: network.id)
+                    prunedNetworks.append(network.id)
+                } catch {
+                    // Note: This failure may occur due to a race condition between the network/
+                    // container collection above and a container run command that attaches to a
+                    // network listed in the networksToPrune collection.
+                    log.error("Failed to prune network \(network.id): \(error)")
+                }
+            }
+
+            for name in prunedNetworks {
+                print(name)
+            }
+        }
+    }
+}

--- a/Sources/ContainerCommands/System/Property/PropertySet.swift
+++ b/Sources/ContainerCommands/System/Property/PropertySet.swift
@@ -70,7 +70,7 @@ extension Application {
                 DefaultsStore.set(value: value, key: key)
                 return
             case .defaultSubnet:
-                guard (try? CIDRAddress(value)) != nil else {
+                guard (try? CIDRv4(value)) != nil else {
                     throw ContainerizationError(.invalidArgument, message: "invalid CIDRv4 address: \(value)")
                 }
                 DefaultsStore.set(value: value, key: key)

--- a/Sources/Helpers/APIServer/ContainerDNSHandler.swift
+++ b/Sources/Helpers/APIServer/ContainerDNSHandler.swift
@@ -94,15 +94,9 @@ struct ContainerDNSHandler: DNSHandler {
         guard let ipAllocation = try await networkService.lookup(hostname: question.name) else {
             return nil
         }
-
-        let components = ipAllocation.address.split(separator: "/")
-        guard !components.isEmpty else {
-            throw DNSResolverError.serverError("invalid IP format: empty address")
-        }
-
-        let ipString = String(components[0])
-        guard let ip = IPv4(ipString) else {
-            throw DNSResolverError.serverError("failed to parse IP address: \(ipString)")
+        let ipv4 = ipAllocation.ipv4Address.address.description
+        guard let ip = IPv4(ipv4) else {
+            throw DNSResolverError.serverError("failed to parse IP address: \(ipv4)")
         }
 
         return HostRecord<IPv4>(name: question.name, ttl: ttl, ip: ip)

--- a/Sources/Helpers/NetworkVmnet/NetworkVmnetHelper+Start.swift
+++ b/Sources/Helpers/NetworkVmnet/NetworkVmnetHelper+Start.swift
@@ -50,8 +50,8 @@ extension NetworkVmnetHelper {
 
             do {
                 log.info("configuring XPC server")
-                let subnet = try self.subnet.map { try CIDRAddress($0) }
-                let configuration = try NetworkConfiguration(id: id, mode: .nat, subnet: subnet?.description)
+                let ipv4Subnet = try self.subnet.map { try CIDRv4($0) }
+                let configuration = try NetworkConfiguration(id: id, mode: .nat, ipv4Subnet: ipv4Subnet)
                 let network = try Self.createNetwork(configuration: configuration, log: log)
                 try await network.start()
                 let server = try await NetworkService(network: network, log: log)

--- a/Sources/Helpers/RuntimeLinux/IsolatedInterfaceStrategy.swift
+++ b/Sources/Helpers/RuntimeLinux/IsolatedInterfaceStrategy.swift
@@ -24,7 +24,7 @@ import Containerization
 /// works for macOS Sequoia.
 struct IsolatedInterfaceStrategy: InterfaceStrategy {
     public func toInterface(attachment: Attachment, interfaceIndex: Int, additionalData: XPCMessage?) -> Interface {
-        let gateway = interfaceIndex == 0 ? attachment.gateway : nil
-        return NATInterface(address: attachment.address, gateway: gateway, macAddress: attachment.macAddress)
+        let ipv4Gateway = interfaceIndex == 0 ? attachment.ipv4Gateway : nil
+        return NATInterface(ipv4Address: attachment.ipv4Address, ipv4Gateway: ipv4Gateway, macAddress: attachment.macAddress)
     }
 }

--- a/Sources/Helpers/RuntimeLinux/NonisolatedInterfaceStrategy.swift
+++ b/Sources/Helpers/RuntimeLinux/NonisolatedInterfaceStrategy.swift
@@ -43,7 +43,7 @@ struct NonisolatedInterfaceStrategy: InterfaceStrategy {
         }
 
         log.info("creating NATNetworkInterface with network reference")
-        let gateway = interfaceIndex == 0 ? attachment.gateway : nil
-        return NATNetworkInterface(address: attachment.address, gateway: gateway, reference: networkRef, macAddress: attachment.macAddress)
+        let ipv4Gateway = interfaceIndex == 0 ? attachment.ipv4Gateway : nil
+        return NATNetworkInterface(ipv4Address: attachment.ipv4Address, ipv4Gateway: ipv4Gateway, reference: networkRef, macAddress: attachment.macAddress)
     }
 }

--- a/Sources/Services/ContainerNetworkService/AllocationOnlyVmnetNetwork.swift
+++ b/Sources/Services/ContainerNetworkService/AllocationOnlyVmnetNetwork.swift
@@ -35,8 +35,8 @@ public actor AllocationOnlyVmnetNetwork: Network {
             throw ContainerizationError(.unsupported, message: "invalid network mode \(configuration.mode)")
         }
 
-        guard configuration.subnet == nil else {
-            throw ContainerizationError(.unsupported, message: "subnet assignment is not yet implemented")
+        guard configuration.ipv4Subnet == nil else {
+            throw ContainerizationError(.unsupported, message: "IPv4 subnet assignment is not yet implemented")
         }
 
         self.log = log
@@ -65,9 +65,9 @@ public actor AllocationOnlyVmnetNetwork: Network {
         )
 
         let subnet = DefaultsStore.get(key: .defaultSubnet)
-        let subnetCIDR = try CIDRAddress(subnet)
-        let gateway = IPv4Address(fromValue: subnetCIDR.lower.value + 1)
-        self._state = .running(configuration, NetworkStatus(address: subnetCIDR.description, gateway: gateway.description))
+        let subnetCIDR = try CIDRv4(subnet)
+        let gateway = IPv4Address(subnetCIDR.lower.value + 1)
+        self._state = .running(configuration, NetworkStatus(ipv4Subnet: subnetCIDR, ipv4Gateway: gateway))
         log.info(
             "started allocation-only network",
             metadata: [

--- a/Sources/Services/ContainerNetworkService/Attachment.swift
+++ b/Sources/Services/ContainerNetworkService/Attachment.swift
@@ -14,24 +14,58 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerizationExtras
+
 /// A snapshot of a network interface allocated to a sandbox.
 public struct Attachment: Codable, Sendable {
     /// The network ID associated with the attachment.
     public let network: String
     /// The hostname associated with the attachment.
     public let hostname: String
-    /// The subnet CIDR, where the address is the container interface IPv4 address.
-    public let address: String
+    /// The CIDR address describing the interface IPv4 address, with the prefix length of the subnet.
+    public let ipv4Address: CIDRv4
     /// The IPv4 gateway address.
-    public let gateway: String
+    public let ipv4Gateway: IPv4Address
     /// The MAC address associated with the attachment (optional).
     public let macAddress: String?
 
-    public init(network: String, hostname: String, address: String, gateway: String, macAddress: String? = nil) {
+    public init(network: String, hostname: String, ipv4Address: CIDRv4, ipv4Gateway: IPv4Address, macAddress: String? = nil) {
         self.network = network
         self.hostname = hostname
-        self.address = address
-        self.gateway = gateway
+        self.ipv4Address = ipv4Address
+        self.ipv4Gateway = ipv4Gateway
         self.macAddress = macAddress
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case network
+        case hostname
+        case ipv4Address
+        case ipv4Gateway
+        case macAddress
+    }
+
+    /// Create an attachment from the supplied Decoder.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        network = try container.decode(String.self, forKey: .network)
+        hostname = try container.decode(String.self, forKey: .hostname)
+        let addressText = try container.decode(String.self, forKey: .ipv4Address)
+        ipv4Address = try CIDRv4(addressText)
+        let gatewayText = try container.decode(String.self, forKey: .ipv4Gateway)
+        ipv4Gateway = try IPv4Address(gatewayText)
+        macAddress = try container.decodeIfPresent(String.self, forKey: .macAddress)
+    }
+
+    /// Encode the attachment to the supplied Encoder.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(network, forKey: .network)
+        try container.encode(hostname, forKey: .hostname)
+        try container.encode(ipv4Address.description, forKey: .ipv4Address)
+        try container.encode(ipv4Gateway.description, forKey: .ipv4Gateway)
+        try container.encodeIfPresent(macAddress, forKey: .macAddress)
     }
 }

--- a/Sources/Services/ContainerNetworkService/NetworkState.swift
+++ b/Sources/Services/ContainerNetworkService/NetworkState.swift
@@ -14,21 +14,45 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerizationExtras
 import Foundation
 
 public struct NetworkStatus: Codable, Sendable {
     /// The address allocated for the network if no subnet was specified at
     /// creation time; otherwise, the subnet from the configuration.
-    public let address: String
+    public let ipv4Subnet: CIDRv4
     /// The gateway IPv4 address.
-    public let gateway: String
+    public let ipv4Gateway: IPv4Address
 
     public init(
-        address: String,
-        gateway: String
+        ipv4Subnet: CIDRv4,
+        ipv4Gateway: IPv4Address
     ) {
-        self.address = address
-        self.gateway = gateway
+        self.ipv4Subnet = ipv4Subnet
+        self.ipv4Gateway = ipv4Gateway
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case ipv4Subnet
+        case ipv4Gateway
+    }
+
+    /// Create a network status from the supplied Decoder.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let addressText = try container.decode(String.self, forKey: .ipv4Subnet)
+        ipv4Subnet = try CIDRv4(addressText)
+        let gatewayText = try container.decode(String.self, forKey: .ipv4Gateway)
+        ipv4Gateway = try IPv4Address(gatewayText)
+    }
+
+    /// Encode the network status to the supplied Encoder.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(ipv4Subnet.description, forKey: .ipv4Subnet)
+        try container.encode(ipv4Gateway.description, forKey: .ipv4Gateway)
     }
 
 }

--- a/Sources/Services/ContainerSandboxService/SandboxService.swift
+++ b/Sources/Services/ContainerSandboxService/SandboxService.swift
@@ -120,8 +120,10 @@ public actor SandboxService {
 
             var config = try bundle.configuration
 
+            var kernel = try bundle.kernel
+            kernel.commandLine.kernelArgs.append("oops=panic")
             let vmm = VZVirtualMachineManager(
-                kernel: try bundle.kernel,
+                kernel: kernel,
                 initialFilesystem: bundle.initialFilesystem.asMount,
                 rosetta: config.rosetta,
                 logger: self.log
@@ -190,11 +192,10 @@ public actor SandboxService {
                 // a default /etc/hosts.
                 var hostsEntries = [Hosts.Entry.localHostIPV4()]
                 if !interfaces.isEmpty {
-                    let primaryIfaceAddr = interfaces[0].address
-                    let ip = primaryIfaceAddr.split(separator: "/")
+                    let primaryIfaceAddr = interfaces[0].ipv4Address
                     hostsEntries.append(
                         Hosts.Entry(
-                            ipAddress: String(ip[0]),
+                            ipAddress: primaryIfaceAddr.address.description,
                             hostnames: [czConfig.hostname],
                         ))
                 }
@@ -215,7 +216,7 @@ public actor SandboxService {
                 try await container.create()
                 try await self.monitor.registerProcess(id: config.id, onExit: self.onContainerExit)
                 if !container.interfaces.isEmpty {
-                    let firstCidr = try CIDRAddress(container.interfaces[0].address)
+                    let firstCidr = container.interfaces[0].ipv4Address
                     let ipAddress = firstCidr.address.description
                     try await self.startSocketForwarders(containerIpAddress: ipAddress, publishedPorts: config.publishedPorts)
                 }
@@ -865,7 +866,7 @@ public actor SandboxService {
             guard case .running(_, let status) = state else {
                 continue
             }
-            return status.gateway
+            return status.ipv4Gateway.description
         }
 
         return nil

--- a/Sources/SocketForwarder/ConnectHandler.swift
+++ b/Sources/SocketForwarder/ConnectHandler.swift
@@ -81,6 +81,11 @@ extension ConnectHandler {
             .whenComplete { result in
                 switch result {
                 case .success(let channel):
+                    guard context.channel.isActive else {
+                        self.log?.trace("backend - frontend channel closed, closing backend connection")
+                        context.channel.close(promise: nil)
+                        return
+                    }
                     self.log?.trace("backend - connected")
                     self.glue(channel, context: context)
                 case .failure(let error):

--- a/Tests/CLITests/Subcommands/Networks/TestCLINetwork.swift
+++ b/Tests/CLITests/Subcommands/Networks/TestCLINetwork.swift
@@ -61,7 +61,7 @@ class TestCLINetwork: CLITest {
 
             let container = try inspectContainer(name)
             #expect(container.networks.count > 0)
-            let cidrAddress = try CIDRAddress(container.networks[0].address)
+            let cidrAddress = container.networks[0].ipv4Address
             let url = "http://\(cidrAddress.address):\(port)"
             var request = HTTPClientRequest(url: url)
             request.method = .GET

--- a/Tests/CLITests/TestCLINoParallelCases.swift
+++ b/Tests/CLITests/TestCLINoParallelCases.swift
@@ -124,4 +124,170 @@ class TestCLINoParallelCases: CLITest {
         let alpineStillPresent = try isImagePresent(targetImage: alpine)
         #expect(alpineStillPresent, "expected image \(alpine) to remain")
     }
+
+    @available(macOS 26, *)
+    @Test func testNetworkPruneNoNetworks() throws {
+        // Ensure the testnetworkcreateanduse network is deleted
+        // Clean up is necessary for testing prune with no networks
+        doNetworkDeleteIfExists(name: "testnetworkcreateanduse")
+
+        // Prune with no networks should succeed
+        let (_, _, _, statusBefore) = try run(arguments: ["network", "list", "--quiet"])
+        #expect(statusBefore == 0)
+        let (_, output, error, status) = try run(arguments: ["network", "prune"])
+        if status != 0 {
+            throw CLIError.executionFailed("network prune failed: \(error)")
+        }
+
+        #expect(output.isEmpty, "should show no networks pruned")
+    }
+
+    @available(macOS 26, *)
+    @Test func testNetworkPruneUnusedNetworks() throws {
+        let name = getTestName()
+        let network1 = "\(name)_1"
+        let network2 = "\(name)_2"
+
+        // Clean up any existing resources from previous runs
+        doNetworkDeleteIfExists(name: network1)
+        doNetworkDeleteIfExists(name: network2)
+
+        defer {
+            doNetworkDeleteIfExists(name: network1)
+            doNetworkDeleteIfExists(name: network2)
+        }
+
+        try doNetworkCreate(name: network1)
+        try doNetworkCreate(name: network2)
+
+        // Verify networks are created
+        let (_, listBefore, _, statusBefore) = try run(arguments: ["network", "list", "--quiet"])
+        #expect(statusBefore == 0)
+        #expect(listBefore.contains(network1))
+        #expect(listBefore.contains(network2))
+
+        // Prune should remove both
+        let (_, output, error, status) = try run(arguments: ["network", "prune"])
+        if status != 0 {
+            throw CLIError.executionFailed("network prune failed: \(error)")
+        }
+
+        #expect(output.contains(network1), "should prune network1")
+        #expect(output.contains(network2), "should prune network2")
+
+        // Verify networks are gone
+        let (_, listAfter, _, statusAfter) = try run(arguments: ["network", "list", "--quiet"])
+        #expect(statusAfter == 0)
+        #expect(!listAfter.contains(network1), "network1 should be pruned")
+        #expect(!listAfter.contains(network2), "network2 should be pruned")
+    }
+
+    @available(macOS 26, *)
+    @Test(.disabled("https://github.com/apple/container/issues/953"))
+    func testNetworkPruneSkipsNetworksInUse() throws {
+        let name = getTestName()
+        let containerName = "\(name)_c1"
+        let networkInUse = "\(name)_inuse"
+        let networkUnused = "\(name)_unused"
+
+        // Clean up any existing resources from previous runs
+        try? doStop(name: containerName)
+        try? doRemove(name: containerName)
+        doNetworkDeleteIfExists(name: networkInUse)
+        doNetworkDeleteIfExists(name: networkUnused)
+
+        defer {
+            try? doStop(name: containerName)
+            try? doRemove(name: containerName)
+            doNetworkDeleteIfExists(name: networkInUse)
+            doNetworkDeleteIfExists(name: networkUnused)
+        }
+
+        try doNetworkCreate(name: networkInUse)
+        try doNetworkCreate(name: networkUnused)
+
+        // Verify networks are created
+        let (_, listBefore, _, statusBefore) = try run(arguments: ["network", "list", "--quiet"])
+        #expect(statusBefore == 0)
+        #expect(listBefore.contains(networkInUse))
+        #expect(listBefore.contains(networkUnused))
+
+        // Creation of container with network connection
+        let port = UInt16.random(in: 50000..<60000)
+        try doLongRun(
+            name: containerName,
+            image: "docker.io/library/python:alpine",
+            args: ["--network", networkInUse],
+            containerArgs: ["python3", "-m", "http.server", "--bind", "0.0.0.0", "\(port)"]
+        )
+        try waitForContainerRunning(containerName)
+        let container = try inspectContainer(containerName)
+        #expect(container.networks.count > 0)
+
+        // Prune should only remove the unused network
+        let (_, _, error, status) = try run(arguments: ["network", "prune"])
+        if status != 0 {
+            throw CLIError.executionFailed("network prune failed: \(error)")
+        }
+
+        // Verify in-use network still exists
+        let (_, listAfter, _, statusAfter) = try run(arguments: ["network", "list", "--quiet"])
+        #expect(statusAfter == 0)
+        #expect(listAfter.contains(networkInUse), "network in use should NOT be pruned")
+        #expect(!listAfter.contains(networkUnused), "unused network should be pruned")
+    }
+
+    @available(macOS 26, *)
+    @Test(.disabled("https://github.com/apple/container/issues/953"))
+    func testNetworkPruneSkipsNetworkAttachedToStoppedContainer() async throws {
+        let name = getTestName()
+        let containerName = "\(name)_c1"
+        let networkName = "\(name)"
+
+        // Clean up any existing resources from previous runs
+        try? doStop(name: containerName)
+        try? doRemove(name: containerName)
+        doNetworkDeleteIfExists(name: networkName)
+
+        defer {
+            try? doStop(name: containerName)
+            try? doRemove(name: containerName)
+            doNetworkDeleteIfExists(name: networkName)
+        }
+
+        try doNetworkCreate(name: networkName)
+
+        // Creation of container with network connection
+        let port = UInt16.random(in: 50000..<60000)
+        try doLongRun(
+            name: containerName,
+            image: "docker.io/library/python:alpine",
+            args: ["--network", networkName],
+            containerArgs: ["python3", "-m", "http.server", "--bind", "0.0.0.0", "\(port)"]
+        )
+        try await Task.sleep(for: .seconds(1))
+
+        // Prune should NOT remove the network (container exists, even if stopped)
+        let (_, _, error, status) = try run(arguments: ["network", "prune"])
+        if status != 0 {
+            throw CLIError.executionFailed("network prune failed: \(error)")
+        }
+
+        let (_, listAfter, _, statusAfter) = try run(arguments: ["network", "list", "--quiet"])
+        #expect(statusAfter == 0)
+        #expect(listAfter.contains(networkName), "network attached to stopped container should NOT be pruned")
+
+        try? doStop(name: containerName)
+        try? doRemove(name: containerName)
+
+        let (_, _, error2, status2) = try run(arguments: ["network", "prune"])
+        if status2 != 0 {
+            throw CLIError.executionFailed("network prune failed: \(error2)")
+        }
+
+        // Verify network is gone
+        let (_, listFinal, _, statusFinal) = try run(arguments: ["network", "list", "--quiet"])
+        #expect(statusFinal == 0)
+        #expect(!listFinal.contains(networkName), "network should be pruned after container is deleted")
+    }
 }

--- a/Tests/CLITests/Utilities/CLITest.swift
+++ b/Tests/CLITests/Utilities/CLITest.swift
@@ -545,4 +545,15 @@ class CLITest {
             throw CLIError.executionFailed("command failed: \(error)")
         }
     }
+
+    func doNetworkCreate(name: String) throws {
+        let (_, _, error, status) = try run(arguments: ["network", "create", name])
+        if status != 0 {
+            throw CLIError.executionFailed("network create failed: \(error)")
+        }
+    }
+
+    func doNetworkDeleteIfExists(name: String) {
+        let (_, _, _, _) = (try? run(arguments: ["network", "rm", name])) ?? (nil, "", "", 1)
+    }
 }

--- a/Tests/ContainerNetworkServiceTests/NetworkConfigurationTest.swift
+++ b/Tests/ContainerNetworkServiceTests/NetworkConfigurationTest.swift
@@ -33,12 +33,12 @@ struct NetworkConfigurationTest {
             "0-_.1",
         ]
         for id in ids {
-            let subnet = "192.168.64.1/24"
+            let ipv4Subnet = try CIDRv4("192.168.64.1/24")
             let labels = [
                 "foo": "bar",
                 "baz": String(repeating: "0", count: 4096 - "baz".count - "=".count),
             ]
-            _ = try NetworkConfiguration(id: id, mode: .nat, subnet: subnet, labels: labels)
+            _ = try NetworkConfiguration(id: id, mode: .nat, ipv4Subnet: ipv4Subnet, labels: labels)
         }
     }
 
@@ -50,35 +50,19 @@ struct NetworkConfigurationTest {
             "Foo",
         ]
         for id in ids {
-            let subnet = "192.168.64.1/24"
+            let ipv4Subnet = try CIDRv4("192.168.64.1/24")
             let labels = [
                 "foo": "bar",
                 "baz": String(repeating: "0", count: 4096 - "baz".count - "=".count),
             ]
             #expect {
-                _ = try NetworkConfiguration(id: id, mode: .nat, subnet: subnet, labels: labels)
+                _ = try NetworkConfiguration(id: id, mode: .nat, ipv4Subnet: ipv4Subnet, labels: labels)
             } throws: { error in
                 guard let err = error as? ContainerizationError else { return false }
                 #expect(err.code == .invalidArgument)
                 #expect(err.message.starts(with: "invalid network ID"))
                 return true
             }
-        }
-    }
-
-    @Test func testValidationBadSubnet() throws {
-        let id = "foo"
-        let subnet = "192.168.64.1"
-        let labels = [
-            "foo": "bar",
-            "baz": String(repeating: "0", count: 4096 - "baz".count - "=".count),
-        ]
-        #expect {
-            _ = try NetworkConfiguration(id: id, mode: .nat, subnet: subnet, labels: labels)
-        } throws: { error in
-            guard let err = error as? NetworkAddressError else { return false }
-            #expect(err.description.starts(with: "invalid CIDR block"))
-            return true
         }
     }
 
@@ -91,8 +75,8 @@ struct NetworkConfigurationTest {
         ]
         for labels in allLabels {
             let id = "foo"
-            let subnet = "192.168.64.1/24"
-            _ = try NetworkConfiguration(id: id, mode: .nat, subnet: subnet, labels: labels)
+            let ipv4Subnet = try CIDRv4("192.168.64.1/24")
+            _ = try NetworkConfiguration(id: id, mode: .nat, ipv4Subnet: ipv4Subnet, labels: labels)
         }
     }
 
@@ -106,9 +90,9 @@ struct NetworkConfigurationTest {
         ]
         for labels in allLabels {
             let id = "foo"
-            let subnet = "192.168.64.1/24"
+            let ipv4Subnet = try CIDRv4("192.168.64.1/24")
             #expect {
-                _ = try NetworkConfiguration(id: id, mode: .nat, subnet: subnet, labels: labels)
+                _ = try NetworkConfiguration(id: id, mode: .nat, ipv4Subnet: ipv4Subnet, labels: labels)
             } throws: { error in
                 guard let err = error as? ContainerizationError else { return false }
                 #expect(err.code == .invalidArgument)

--- a/Tests/SocketForwarderTests/ConnectHandlerRaceTest.swift
+++ b/Tests/SocketForwarderTests/ConnectHandlerRaceTest.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import NIO
+import Testing
+
+@testable import SocketForwarder
+
+struct ConnectHandlerRaceTest {
+    let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+
+    @Test
+    func testRapidConnectDisconnect() async throws {
+        let requestCount = 500
+
+        let serverAddress = try SocketAddress(ipAddress: "127.0.0.1", port: 0)
+        let server = TCPEchoServer(serverAddress: serverAddress, eventLoopGroup: eventLoopGroup)
+        let serverChannel = try await server.run().get()
+        let actualServerAddress = try #require(serverChannel.localAddress)
+
+        let proxyAddress = try SocketAddress(ipAddress: "127.0.0.1", port: 0)
+        let forwarder = try TCPForwarder(
+            proxyAddress: proxyAddress,
+            serverAddress: actualServerAddress,
+            eventLoopGroup: eventLoopGroup
+        )
+        let forwarderResult = try await forwarder.run().get()
+        let actualProxyAddress = try #require(forwarderResult.proxyAddress)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for _ in 0..<requestCount {
+                group.addTask {
+                    do {
+                        let channel = try await ClientBootstrap(group: self.eventLoopGroup)
+                            .connect(to: actualProxyAddress)
+                            .get()
+
+                        try await channel.close()
+                    } catch {
+                        // Going to ignore connection errors as we are intentionally stressing it
+                    }
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        serverChannel.eventLoop.execute { _ = serverChannel.close() }
+        try await serverChannel.closeFuture.get()
+
+        forwarderResult.close()
+        try await forwarderResult.wait()
+    }
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -682,6 +682,20 @@ container network delete [--all] [--debug] [<network-names> ...]
 
 *   `-a, --all`: Delete all networks
 
+### `container network prune`
+
+Removes networks not connected to any containers. However, default and system networks are preserved.
+
+**Usage**
+
+```bash
+container network prune [--debug]
+```
+
+**Options**
+
+No options.
+
 ### `container network list (ls)`
 
 Lists user-defined networks.


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
This is a fix for [issue#956](https://github.com/apple/container/issues/956)

`FileManager.default.contents(atPath:)` returns `nil` for named pipes (FIFOs) 
and process substitutions like `/dev/fd/XX` because:
1. It expects regular files with a known size
2. Named pipes are stream-based and block until data arrives

## Solution
Use `FileHandle(forReadingFrom:)` instead, which:
- Properly handles blocking I/O
- Works with named pipes, process substitutions, and regular files (mentioned in the [doc](https://developer.apple.com/documentation/foundation/filehandle))

## References
- https://stackoverflow.com/questions/60747062/ios-named-pipes-works-in-objc-does-not-work-in-swift-same-code

## Testing
- [X] Tested locally
- [X] Added/updated tests
- [ ] Added/updated docs

## Result
```bash
-> % ./bin/container run -it --rm --env-file <(printf "VAR1=value1\nVAR2=value2\n") ubuntu:latest
Warning! Running debug build. Performance may be degraded.
root@725da974-da43-47cd-b86e-745265317ed9:/# echo $VAR2
value2
```