### PR TITLE
Turn on oops=panic kernel cmdline

### DIFF
--- a/Sources/Services/ContainerSandboxService/SandboxService.swift
+++ b/Sources/Services/ContainerSandboxService/SandboxService.swift
@@ -120,8 +120,10 @@ public actor SandboxService {
 
             var config = try bundle.configuration
 
+            var kernel = try bundle.kernel
+            kernel.commandLine.kernelArgs.append("oops=panic")
             let vmm = VZVirtualMachineManager(
-                kernel: try bundle.kernel,
+                kernel: kernel,
                 initialFilesystem: bundle.initialFilesystem.asMount,
                 rosetta: config.rosetta,
                 logger: self.log


### PR DESCRIPTION
We've had quite a few oops' from ext4 issues (that are likely self inflicted) and this is causing the guest to be in a pretty borked state after. I think upgrading these to panics will be useful for now.