### PR TITLE
Fix MAC address option typo in how-to documentation

### DIFF
--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -216,7 +216,7 @@ container run --network default,mac=02:42:ac:11:00:02 ubuntu:latest
 To verify the MAC address is set correctly, run `ip addr show` inside the container:
 
 ```console
-% container run --rm --mac-address 02:42:ac:11:00:02 ubuntu:latest ip addr show eth0
+% container run --rm --network default,mac=02:42:ac:11:00:02 ubuntu:latest ip addr show eth0
 2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
     link/ether 02:42:ac:11:00:02 brd ff:ff:ff:ff:ff:ff
     inet 192.168.64.2/24 brd 192.168.64.255 scope global eth0


### PR DESCRIPTION
## Summary
- Corrects the MAC address example command in the how-to guide to use the correct `--network` flag syntax instead of the incorrect `--mac-address` flag

## Details
The example on line 219 of `docs/how-to.md` was using `--mac-address 02:42:ac:11:00:02` which is incorrect. The correct syntax, as shown earlier in the same section (line 213), is `--network default,mac=02:42:ac:11:00:02`.

This was a documentation inconsistency where the example didn't match the documented syntax.

## Test plan
- [x] Verified the correct syntax is used earlier in the same section
- [x] Confirmed this matches the actual CLI implementation