### PR TITLE
Fix bash completion source path in documentation

### DIFF
--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -571,7 +571,7 @@ Without bash-completion, you’ll need to source the completion script directly.
 ```bash
 mkdir -p ~/.bash_completions
 container --generate-completion-script bash >  ~/.bash_completions/container
-source /opt/homebrew/etc/bash_completion.d/container
+source ~/.bash_completions/container
 ```
 
 Furthermore, you can add the following line to `~/.bash_profile` or `~/.bashrc`, in order for every new bash session to have autocompletion ready.


### PR DESCRIPTION
## Summary
- Corrects the source path for bash completion script when not using bash-completion package

## Details
In the section about installing bash completions without the bash-completion package, line 574 of `docs/how-to.md` incorrectly instructs users to source from `/opt/homebrew/etc/bash_completion.d/container`, but the script was just created in `~/.bash_completions/container` on line 573.

The homebrew path is only relevant when using bash-completion (covered earlier in the same section). This fix ensures the example is internally consistent.

## Test plan
- [x] Verified the script is created in `~/.bash_completions/container` on line 573
- [x] Confirmed the corrected source command matches the same path
- [x] Checked that line 580 already uses the correct path