### PR TITLE
Clarify uninstall script location in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,16 @@ container system start
 
 ### Uninstall
 
-Use the `uninstall-container.sh` script to remove `container` from your system. To remove your user data along with the tool, run:
+Use the `uninstall-container.sh` script (installed to `/usr/local/bin`) to remove `container` from your system. To remove your user data along with the tool, run:
 
 ```bash
-uninstall-container.sh -d
+/usr/local/bin/uninstall-container.sh -d
 ```
 
 To retain your user data so that it is available should you reinstall later, run:
 
 ```bash
-uninstall-container.sh -k
+/usr/local/bin/uninstall-container.sh -k
 ```
 
 ## Next steps


### PR DESCRIPTION
## Summary
- Clarifies where the `uninstall-container.sh` script is located after installation
- Updates example commands to use the full path

## Details
The README mentioned running `uninstall-container.sh` but didn't specify where users should find this script. Users might be confused whether it's in the repository, their PATH, or a specific location.

This PR:
1. Adds a note that the script is installed to `/usr/local/bin`
2. Updates the example commands to use the full path `/usr/local/bin/uninstall-container.sh`

## Test plan
- [x] Verified the Makefile installs the script to `/usr/local/bin` (line 103)
- [x] Checked that using the full path matches standard practice for installed tools