### PR TITLE
Use full path for uninstall script in upgrade instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you're upgrading, first stop and uninstall your existing `container` (the `-k
 
 ```bash
 container system stop
-uninstall-container.sh -k
+/usr/local/bin/uninstall-container.sh -k
 ```
 
 Download the latest signed installer package for `container` from the [GitHub release page](https://github.com/apple/container/releases).


### PR DESCRIPTION
## Summary
- Makes the upgrade section consistent with the uninstall section by using the full path to the uninstall script

## Details
The upgrade section (line 25) was using `uninstall-container.sh -k` without the full path, which is inconsistent with the uninstall section which correctly uses `/usr/local/bin/uninstall-container.sh`.

This PR updates the upgrade instructions to use the full path for consistency and clarity.

## Test plan
- [x] Verified the script is installed to `/usr/local/bin` by the Makefile
- [x] Checked consistency with the uninstall section in the same file