### PR TITLE
Fix grammar in tutorial.md

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -284,7 +284,7 @@ Push your image to a container registry, publishing it so that you and others ca
 
 ### Publish the web server image
 
-To publish your image, you need push images to a registry service that stores the image for future use. Typically, you need to authenticate with a registry to push an image. This example assumes that you have an account at a hypothetical registry named `some-registry.example.com` with username `fido` and a password or token `my-secret`, and that your personal repository name is the same as your username.
+To publish your image, you need to push images to a registry service that stores the image for future use. Typically, you need to authenticate with a registry to push an image. This example assumes that you have an account at a hypothetical registry named `some-registry.example.com` with username `fido` and a password or token `my-secret`, and that your personal repository name is the same as your username.
 
 To sign into a secure registry with your login credentials, enter your username and password at the prompts after running:
 


### PR DESCRIPTION
## Summary
- Fixes a grammar error in the tutorial's publish section

## Details
Line 287 of `docs/tutorial.md` had "you need push images" which should be "you need to push images".

This is a simple grammar fix to improve readability.

## Test plan
- [x] Verified the sentence now reads correctly