### PR TITLE
Fix relative path resolution in entrypoint

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "538f97f4c9123825536afb15abcaa4d9d865563e402bcb7fd26be69f55461c1d",
+  "originHash" : "b11a80bed0b568e35f4b538956344d483125e344c4931c362a2a31a2f7a8565b",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -16,7 +16,7 @@
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
         "revision" : "452f354bac52ecbfe4a40b729880435a070c5a29",
-        "version" : "0.20.0"
+        "version" : "0.20.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ import PackageDescription
 let releaseVersion = ProcessInfo.processInfo.environment["RELEASE_VERSION"] ?? "0.0.0"
 let gitCommit = ProcessInfo.processInfo.environment["GIT_COMMIT"] ?? "unspecified"
 let builderShimVersion = "0.7.0"
-let scVersion = "0.20.0"
+let scVersion = "0.20.1"
 
 let package = Package(
     name: "container",

--- a/Tests/ContainerAPIClientTests/ParserTest.swift
+++ b/Tests/ContainerAPIClientTests/ParserTest.swift
@@ -845,4 +845,22 @@ struct ParserTest {
             return error.description.contains("invalid property format")
         }
     }
+
+    // MARK: - Relative Path Passthrough Tests
+
+    @Test
+    func testProcessEntrypointRelativePathPassthrough() throws {
+        let processFlags = try Flags.Process.parse(["--cwd", "/bin"])
+        let managementFlags = try Flags.Management.parse(["--entrypoint", "./uname"])
+
+        let result = try Parser.process(
+            arguments: [],
+            processFlags: processFlags,
+            managementFlags: managementFlags,
+            config: nil
+        )
+
+        #expect(result.executable == "./uname")
+        #expect(result.workingDirectory == "/bin")
+    }
 }


### PR DESCRIPTION
- Fixes #962 

## Type of Change
- [x] Bug fix (Coordinated with engine-side fix)
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Initially, this PR aimed to resolve relative paths within the CLI parser. However, following maintainer feedback (@jglogan), we've adopted a **"Cleaner Approach"** by moving the path resolution logic directly into the executor (`vmexec`) within the `apple/containerization` repository.

By handling the resolution at the engine level, we ensure that the OCI bundle configuration remains clean and consistent with industry standards (Docker/Podman), where the executor handles binary lookups relative to the `WORKDIR`.

**Changes in this PR:**
- **Reverted CLI-side resolution**: Keeps the `Parser.swift` logic simple, passing the raw entrypoint/cmd strings to the engine.
- **Added Passthrough Test**: Introduced `testProcessEntrypointRelativePathPassthrough` in `ParserTest.swift` to ensure that relative paths (e.g., `./uname`) are handed off to the executor without any unintended modifications by the CLI.

## Testing
- [x] **Unit Tests**: Ran `swift test --filter Passthrough` to confirm the CLI correctly passes relative paths untouched.
- [x] **Integration Tests**: Verified on **macOS 26.0** using a local build of `containerization` (via `swift package edit`).
  - **Scenario**: `container run --rm --workdir /bin --entrypoint ./uname alpine`
  - **Result**: Successfully executed and returned `Linux`. This confirms the end-to-end flow where the CLI passes `./uname` and the engine resolves it to `/bin/uname`.

### Coordination
The actual root-cause fix is submitted here: https://github.com/apple/containerization/pull/473
