### PR TITLE
fix(build): sign debug binaries with required entitlements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,9 @@ build:
 	@echo Building container binaries...
 	@$(SWIFT) --version
 	@$(SWIFT) build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION)
+	@echo Signing binaries with required entitlements...
+	@codesign $(CODESIGN_OPTS) --entitlements=signing/container-runtime-linux.entitlements "$(BUILD_BIN_DIR)/container-runtime-linux"
+	@codesign $(CODESIGN_OPTS) --entitlements=signing/container-network-vmnet.entitlements "$(BUILD_BIN_DIR)/container-network-vmnet"
 
 .PHONY: container
 # Install binaries under project directory


### PR DESCRIPTION
The vmnet plugin requires com.apple.security.virtualization entitlement. Without it, vmnet_network_create() fails with VMNET_MEM_FAILURE (1002).

Previously only installer-pkg signed binaries with entitlements. Debug builds were adhoc-signed without entitlements, causing vmnet failures.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

We can't create vmnet without these entitlements. Needed for nat, shared networking, and dhcp client. Startup of `container` could also just hang forever without this.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
