### PR TITLE
fix(xpc): prevent startup hangs with proper timeout handling (#561)

### DIFF
--- a/Sources/ContainerXPC/XPCServer.swift
+++ b/Sources/ContainerXPC/XPCServer.swift
@@ -52,7 +52,7 @@ public struct XPCServer: Sendable {
 
     public func listen() async throws {
         let connections = AsyncStream<xpc_connection_t> { cont in
-            lock.withLock {
+            self.lock.withLock {
                 xpc_connection_set_event_handler(self.connection) { object in
                     switch xpc_get_type(object) {
                     case XPC_TYPE_CONNECTION:

--- a/Sources/Helpers/APIServer/APIServer+Start.swift
+++ b/Sources/Helpers/APIServer/APIServer+Start.swift
@@ -240,12 +240,13 @@ extension APIServer {
                 log: log
             )
 
+            // Check for default network - don't block on creation during startup
+            // to avoid blocking if vmnet plugin fails. Users can create networks on-demand.
             let defaultNetwork = try await service.list()
                 .filter { $0.id == ClientNetwork.defaultNetworkName }
                 .first
             if defaultNetwork == nil {
-                let config = try NetworkConfiguration(id: ClientNetwork.defaultNetworkName, mode: .nat)
-                _ = try await service.create(configuration: config)
+                log.info("default network not present, can be created with 'container network create'")
             }
 
             let harness = NetworksHarness(service: service, log: log)

--- a/Sources/Services/ContainerAPIService/Networks/NetworksService.swift
+++ b/Sources/Services/ContainerAPIService/Networks/NetworksService.swift
@@ -95,7 +95,7 @@ public actor NetworksService {
                         "id": "\(configuration.id)",
                         "state": "\(networkState.state)",
                     ])
-                return
+                continue
             }
         }
     }

--- a/Sources/Services/ContainerNetworkService/NetworkClient.swift
+++ b/Sources/Services/ContainerNetworkService/NetworkClient.swift
@@ -37,11 +37,14 @@ public struct NetworkClient: Sendable {
 
 // Runtime Methods
 extension NetworkClient {
+    /// Default timeout for network XPC calls.
+    private static let xpcTimeout: Duration = .seconds(5)
+
     public func state() async throws -> NetworkState {
         let request = XPCMessage(route: NetworkRoutes.state.rawValue)
         let client = createClient()
 
-        let response = try await client.send(request)
+        let response = try await client.send(request, responseTimeout: Self.xpcTimeout)
         let state = try response.state()
         return state
     }
@@ -55,7 +58,7 @@ extension NetworkClient {
 
         let client = createClient()
 
-        let response = try await client.send(request)
+        let response = try await client.send(request, responseTimeout: Self.xpcTimeout)
         let attachment = try response.attachment()
         let additionalData = response.additionalData()
         return (attachment, additionalData)
@@ -66,7 +69,7 @@ extension NetworkClient {
         request.set(key: NetworkKeys.hostname.rawValue, value: hostname)
 
         let client = createClient()
-        try await client.send(request)
+        try await client.send(request, responseTimeout: Self.xpcTimeout)
     }
 
     public func lookup(hostname: String) async throws -> Attachment? {
@@ -75,7 +78,7 @@ extension NetworkClient {
 
         let client = createClient()
 
-        let response = try await client.send(request)
+        let response = try await client.send(request, responseTimeout: Self.xpcTimeout)
         return try response.dataNoCopy(key: NetworkKeys.attachment.rawValue).map {
             try JSONDecoder().decode(Attachment.self, from: $0)
         }
@@ -86,7 +89,7 @@ extension NetworkClient {
 
         let client = createClient()
 
-        let response = try await client.send(request)
+        let response = try await client.send(request, responseTimeout: Self.xpcTimeout)
         return try response.allocatorDisabled()
     }
 


### PR DESCRIPTION
- Add timeout to XPCClient.send() that cancels connection on expiry
- Use .timeout error code with helpful message suggesting system start
- Skip blocking default network creation during apiserver startup
- Add 5-second timeouts to all NetworkClient XPC calls
- Fix NetworksService init to continue on network failure, not return

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

The apiserver could hang indefinitely during startup if the vmnet plugin failed or was unresponsive. XPC calls now have proper timeout handling that cancels the connection on expiry and returns a helpful error message. The apiserver no longer blocks on default network creation during startup, and NetworkClient XPC calls have 5-second timeouts. Additionally, NetworksService initialization now continues processing remaining networks when one fails instead of returning early.

`container system start` would hang on startup waiting for the apiserver.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
