### PR TITLE
CLI: Small fixups for implicit envvars

### DIFF
--- a/Sources/ContainerClient/Flags.swift
+++ b/Sources/ContainerClient/Flags.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025 Apple Inc. and the container project authors.
+// Copyright © 2025-2026 Apple Inc. and the container project authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ public struct Flags {
     public struct Process: ParsableArguments {
         public init() {}
 
-        @Option(name: .shortAndLong, help: "Set environment variables (format: key=value)")
+        @Option(name: .shortAndLong, help: "Set environment variables (key=value, or just key to inherit from host)")
         public var env: [String] = []
 
         @Option(

--- a/Sources/ContainerClient/Parser.swift
+++ b/Sources/ContainerClient/Parser.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025 Apple Inc. and the container project authors.
+// Copyright © 2025-2026 Apple Inc. and the container project authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -192,8 +192,9 @@ public struct Parser {
         var envVar: [String] = []
         for env in envList {
             var env = env
-            let parts = env.split(separator: "=", maxSplits: 2)
-            if parts.count == 1 {
+            // Only inherit from host if no "=" is present (e.g., "--env VAR")
+            // "VAR=" should set an explicit empty value, not inherit.
+            if !env.contains("=") {
                 guard let val = ProcessInfo.processInfo.environment[env] else {
                     continue
                 }


### PR DESCRIPTION
We should only inherit from the host if there's no =. Additionally document the flag a little more to show that we can inherit from the host.