### PR TITLE
ProgressBar: Various fixes

### DIFF
--- a/Sources/TerminalProgress/ProgressBar+State.swift
+++ b/Sources/TerminalProgress/ProgressBar+State.swift
@@ -17,10 +17,10 @@
 import Foundation
 
 extension ProgressBar {
-    /// A configuration struct for the progress bar.
-    public struct State {
+    /// State for the progress bar.
+    struct State {
         /// A flag indicating whether the progress bar is finished.
-        public var finished = false
+        var finished = false
         var iteration = 0
         private let speedInterval: DispatchTimeInterval = .seconds(1)
 
@@ -41,6 +41,7 @@ extension ProgressBar {
                 calculateSizeSpeed()
             }
         }
+
         var totalSize: Int64?
         private var sizeUpdateSpeed: String?
         var sizeSpeed: String? {
@@ -66,6 +67,7 @@ extension ProgressBar {
 
         var startTime: DispatchTime
         var output = ""
+        var renderTask: Task<Void, Never>?
 
         init(
             description: String = "", subDescription: String = "", itemsName: String = "", tasks: Int = 0, totalTasks: Int? = nil, items: Int = 0, totalItems: Int? = nil,


### PR DESCRIPTION
There's a couple things I don't think are intuitive about this.

1. Because of the internal task, render() can still be called even after
finish() completes. Ideally async defers are supported and we could just
await the final render completing after cancelling the task and setting
.finished, but alas. To fix this we can just lock across the methods for
now.
2. We always clear the screen in the destructor, even if we don't use the
progress bar. I don't think we should honestly do anything in the destructor.
Feels a programmer error not to defer { bar.finish() } or call it somewhere.
3. Our spaces based line clearing. Use the ansi escape sequence for clearing line;
I think our calculations were slightly off and it would leave trailing output ( "s]" )
in some cases.
4. Shrinking the window until the output is smaller than the terminal window (and vice
versa) is wonky on various term emulators. Truthfully, this is just a hard problem,
but we can truncate our output and still provide some useful info.

This fixes some single line output (cat /etc/hostname etc.) getting cleared in our atexit handler, as well as the need for the usleep.