### PR TITLE
Update to containerization 0.20.0.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cdb00eae6b7604ecbcae4d6486a6e5e0f5f89e93c1e645b50a7c4758b8ef38ca",
+  "originHash" : "538f97f4c9123825536afb15abcaa4d9d865563e402bcb7fd26be69f55461c1d",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "2f55d75fec39474212170439b73274006200e2e2",
-        "version" : "0.19.0"
+        "revision" : "452f354bac52ecbfe4a40b729880435a070c5a29",
+        "version" : "0.20.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ import PackageDescription
 let releaseVersion = ProcessInfo.processInfo.environment["RELEASE_VERSION"] ?? "0.0.0"
 let gitCommit = ProcessInfo.processInfo.environment["GIT_COMMIT"] ?? "unspecified"
 let builderShimVersion = "0.7.0"
-let scVersion = "0.19.0"
+let scVersion = "0.20.0"
 
 let package = Package(
     name: "container",

--- a/Sources/ContainerResource/Network/Attachment.swift
+++ b/Sources/ContainerResource/Network/Attachment.swift
@@ -27,9 +27,9 @@ public struct Attachment: Codable, Sendable {
     /// The IPv4 gateway address.
     public let ipv4Gateway: IPv4Address
     /// The MAC address associated with the attachment (optional).
-    public let macAddress: String?
+    public let macAddress: MACAddress?
 
-    public init(network: String, hostname: String, ipv4Address: CIDRv4, ipv4Gateway: IPv4Address, macAddress: String? = nil) {
+    public init(network: String, hostname: String, ipv4Address: CIDRv4, ipv4Gateway: IPv4Address, macAddress: MACAddress? = nil) {
         self.network = network
         self.hostname = hostname
         self.ipv4Address = ipv4Address
@@ -43,29 +43,5 @@ public struct Attachment: Codable, Sendable {
         case ipv4Address
         case ipv4Gateway
         case macAddress
-    }
-
-    /// Create an attachment from the supplied Decoder.
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        network = try container.decode(String.self, forKey: .network)
-        hostname = try container.decode(String.self, forKey: .hostname)
-        let addressText = try container.decode(String.self, forKey: .ipv4Address)
-        ipv4Address = try CIDRv4(addressText)
-        let gatewayText = try container.decode(String.self, forKey: .ipv4Gateway)
-        ipv4Gateway = try IPv4Address(gatewayText)
-        macAddress = try container.decodeIfPresent(String.self, forKey: .macAddress)
-    }
-
-    /// Encode the attachment to the supplied Encoder.
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-
-        try container.encode(network, forKey: .network)
-        try container.encode(hostname, forKey: .hostname)
-        try container.encode(ipv4Address.description, forKey: .ipv4Address)
-        try container.encode(ipv4Gateway.description, forKey: .ipv4Gateway)
-        try container.encodeIfPresent(macAddress, forKey: .macAddress)
     }
 }

--- a/Sources/Services/ContainerNetworkService/Server/NetworkService.swift
+++ b/Sources/Services/ContainerNetworkService/Server/NetworkService.swift
@@ -61,7 +61,8 @@ public actor NetworkService: Sendable {
         }
 
         let hostname = try message.hostname()
-        let macAddress = message.string(key: NetworkKeys.macAddress.rawValue)
+        let macAddress = try message.string(key: NetworkKeys.macAddress.rawValue)
+            .map { try MACAddress($0) }
         let index = try await allocator.allocate(hostname: hostname)
         let subnet = status.ipv4Subnet
         let ip = IPv4Address(index)
@@ -78,7 +79,7 @@ public actor NetworkService: Sendable {
                 "hostname": "\(hostname)",
                 "ipv4Address": "\(attachment.ipv4Address)",
                 "ipv4Gateway": "\(attachment.ipv4Gateway)",
-                "macAddress": "\(macAddress ?? "auto")",
+                "macAddress": "\(macAddress?.description ?? "unspecified")",
             ])
         let reply = message.reply()
         try reply.setAttachment(attachment)

--- a/Tests/CLITests/Subcommands/Containers/TestCLICreate.swift
+++ b/Tests/CLITests/Subcommands/Containers/TestCLICreate.swift
@@ -43,7 +43,10 @@ class TestCLICreateCommand: CLITest {
             try waitForContainerRunning(name)
             let inspectResp = try inspectContainer(name)
             #expect(inspectResp.networks.count > 0, "expected at least one network attachment")
-            #expect(inspectResp.networks[0].macAddress == expectedMAC, "expected MAC address \(expectedMAC), got \(inspectResp.networks[0].macAddress ?? "nil")")
+            #expect(
+                inspectResp.networks[0].macAddress?.description == expectedMAC,
+                "expected MAC address \(expectedMAC), got \(inspectResp.networks[0].macAddress?.description ?? "nil")"
+            )
         }
     }
 


### PR DESCRIPTION
- Use MACAddress for Attachment and CZ interfaces.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Move data validation closer to API surface.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
