### PR TITLE
fix: use pax instead of tar for pkg payload extraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ install: installer-pkg
 	@if [ -z "$(SUDO)" ] ; then \
 		temp_dir=$$(mktemp -d) ; \
 		xar -xf $(PKG_PATH) -C $${temp_dir} ; \
-		(cd $${temp_dir} && tar -xf Payload -C "$(DEST_DIR)") ; \
+		(cd "$(DEST_DIR)" && pax -rz -f $${temp_dir}/Payload) ; \
 		rm -rf $${temp_dir} ; \
 	else \
 		$(SUDO) installer -pkg $(PKG_PATH) -target / ; \


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
It is common to have `gnu-tar` alongside other GNU tools installed and aliased for compatibility reasons.
However, this breaks the current make build. The following error happened when GNU tar tried to extract the pkg Payload (which is cpio+gzip, not tar) during `make all` > `install` target, extracting pkg Payload to `bin/` and `libexec/`:

```
gtar: This does not look like a tar archive
gtar: Skipping to next header
gtar: Exiting with failure status due to previous errors
```
The build succeeded, the pkg was created, but the extraction silently failed, leaving `bin/container` missing.

The proposed fix uses BSD-only binaries (no GNU equivalents that are commonly aliased), making the Makefile more portable.

Why `gunzip | cpio` instead of `tar`:
- macOS pkg Payloads are gzip-compressed cpio archives, not tar
- BSD tar (macOS default) can read them because libarchive auto-detects formats
- GNU tar (`gtar`) cannot
## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
