### PR TITLE
Add support for aarch64 architecture alias

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/Arch.swift
+++ b/Sources/Services/ContainerAPIService/Client/Arch.swift
@@ -19,7 +19,7 @@ public enum Arch: String {
 
     public init?(rawValue: String) {
         switch rawValue.lowercased() {
-        case "arm64":
+        case "arm64", "aarch64":
             self = .arm64
         case "amd64", "x86_64", "x86-64":
             self = .amd64

--- a/Tests/ContainerAPIClientTests/ArchTests.swift
+++ b/Tests/ContainerAPIClientTests/ArchTests.swift
@@ -44,10 +44,17 @@ struct ArchTests {
         #expect(arch == .arm64)
     }
 
+    @Test func testAarch64Alias() throws {
+        let arch = Arch(rawValue: "aarch64")
+        #expect(arch != nil)
+        #expect(arch == .arm64)
+    }
+
     @Test func testCaseInsensitive() throws {
         #expect(Arch(rawValue: "AMD64") == .amd64)
         #expect(Arch(rawValue: "X86_64") == .amd64)
         #expect(Arch(rawValue: "ARM64") == .arm64)
+        #expect(Arch(rawValue: "AARCH64") == .arm64)
         #expect(Arch(rawValue: "Amd64") == .amd64)
     }
 


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Adds `aarch64` as an alias for `arm64` in the `Arch` enum. This addresses the maintainer's request to support this common architecture name, ensuring consistency with `x86_64` normalization and preventing failures for users expecting `aarch64` support.

## Testing
- [ ] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs
