### PR TITLE
Reorder global args to start of list.

### DIFF
--- a/Sources/CLI/ContainerCLI.swift
+++ b/Sources/CLI/ContainerCLI.swift
@@ -30,10 +30,4 @@ public struct ContainerCLI: AsyncParsableCommand {
     public static func main() async throws {
         try await Application.main()
     }
-
-    public func run() async throws {
-        var application = try Application.parse(arguments)
-        try application.validate()
-        try application.run()
-    }
 }

--- a/Tests/CLITests/Subcommands/Run/TestCLIRunCommand.swift
+++ b/Tests/CLITests/Subcommands/Run/TestCLIRunCommand.swift
@@ -52,6 +52,22 @@ class TestCLIRunCommand1: CLITest {
         }
     }
 
+    @Test func testRunDebugCommand() throws {
+        // Test argument reordering when --debug is after the subcommand.
+        do {
+            let name = getTestName()
+            try doLongRun(name: name, args: ["--debug"])
+            defer {
+                try? doStop(name: name)
+            }
+            let _ = try doExec(name: name, cmd: ["date"])
+            try doStop(name: name)
+        } catch {
+            Issue.record("failed to run container \(error)")
+            return
+        }
+    }
+
     @Test func testRunCommandCWD() throws {
         do {
             let name = getTestName()


### PR DESCRIPTION
Co-author: Chris Naples <cnaples79@gmail.com> (@cnaples79)

- Fixes #360.
- Adapts #730 to new dispatch mechanism.
- Gets rid of wonky error message when `--debug` is placed after the subcommand and before `--`.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
That error message is really vexing.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs
