### PR TITLE
fix: performance warning should not output ANSI codes if stderr redirected

### DIFF
--- a/Sources/ContainerCommands/Application.swift
+++ b/Sources/ContainerCommands/Application.swift
@@ -91,7 +91,12 @@ public struct Application: AsyncParsableCommand {
 
         #if DEBUG
         let warning = "Running debug build. Performance may be degraded."
-        let formattedWarning = "\u{001B}[33mWarning!\u{001B}[0m \(warning)\n"
+        let formattedWarning: String
+        if isatty(FileHandle.standardError.fileDescriptor) == 1 {
+            formattedWarning = "\u{001B}[33mWarning!\u{001B}[0m \(warning)\n"
+        } else {
+            formattedWarning = "Warning! \(warning)\n"
+        }
         let warningData = Data(formattedWarning.utf8)
         FileHandle.standardError.write(warningData)
         #endif


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Fixes #1045
When stderr is redirected to a file, the debug warning includes raw ANSI escape codes.
I added a code that detects if the stderr is redirected to a file and then write plain text.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
