### PR TITLE
Change behavior of the default arguments in the plugin config

### DIFF
--- a/Sources/ContainerPlugin/PluginConfig.swift
+++ b/Sources/ContainerPlugin/PluginConfig.swift
@@ -79,7 +79,6 @@ public struct PluginConfig: Sendable, Codable {
         public let services: [Service]
         /// An optional parameter that include any command line arguments
         /// that must be passed to the plugin binary when it is loaded.
-        /// This parameter is used only when `servicesConfig.loadAtBoot` is `true`
         public let defaultArguments: [String]
     }
 

--- a/Sources/ContainerPlugin/PluginLoader.swift
+++ b/Sources/ContainerPlugin/PluginLoader.swift
@@ -225,7 +225,7 @@ extension PluginLoader {
 
         let plist = LaunchPlist(
             label: id,
-            arguments: [plugin.binaryURL.path] + (args ?? serviceConfig.defaultArguments),
+            arguments: [plugin.binaryURL.path] + (args ?? ["start"]) + serviceConfig.defaultArguments,
             environment: env,
             limitLoadToSessionType: [.Aqua, .Background, .System],
             runAtLoad: serviceConfig.runAtLoad,

--- a/config/container-core-images-config.json
+++ b/config/container-core-images-config.json
@@ -11,6 +11,6 @@
                 "description": "Provide an XPC interface to interact with an image store."
             }
         ],
-        "defaultArguments": ["start"]
+        "defaultArguments": []
     }
 }


### PR DESCRIPTION
## Type of Change
- [x] New feature  
- [x] Breaking change

## Motivation and Context
This PR changes the behavior of the `defaultArguments` field in the service plugin config. Previously, `defaultArguments` was functioning as a way to indicate how to start a plugin in the event that the plugin is loaded at boot (such as for the `container-core-images plugin`). However, we now follow a convention where all plugins have a "start" command that is used when launching the plugin, so this `defaultArguments` field wasn't really providing much. Instead, there are use cases where we may want to set default values to pass to a plugin. This PR repurposes the `defaultArguments` field for those use cases. 

As an example use case, there are scenarios where someone may want to use the AllocationOnlyVmnetNetwork even when running on macOS 26+. This PR adds the ability to pass in a command line option to the vmnet network plugin to specify that request. Combined with the `defaultArguments` plugin config change, a user may choose to set that field to ["--variant", "allocationOnly"] in the `container-network-vmnet-config.json` to use AllocationOnlyVmnetNetwork by default for all networks.

## Testing
- [x] Tested locally
