### PR TITLE
Support using multiple different network plugins

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -309,7 +309,6 @@ let package = Package(
                 .product(name: "ContainerizationOS", package: "containerization"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 "ContainerAPIClient",
-                "ContainerNetworkServiceClient",
                 "ContainerPersistence",
                 "ContainerResource",
                 "ContainerSandboxServiceClient",

--- a/Sources/ContainerCommands/Network/NetworkCreate.swift
+++ b/Sources/ContainerCommands/Network/NetworkCreate.swift
@@ -45,6 +45,12 @@ extension Application {
             })
         var ipv6Subnet: CIDRv6? = nil
 
+        @Option(name: .long, help: "Set the plugin to use to create this network.")
+        var plugin: String = "container-network-vmnet"
+
+        @Option(name: .long, help: "Set the variant of the network plugin to use.")
+        var pluginVariant: String?
+
         @OptionGroup
         var global: Flags.Global
 
@@ -60,7 +66,8 @@ extension Application {
                 mode: .nat,
                 ipv4Subnet: ipv4Subnet,
                 ipv6Subnet: ipv6Subnet,
-                labels: parsedLabels
+                labels: parsedLabels,
+                pluginInfo: NetworkPluginInfo(plugin: self.plugin, variant: self.pluginVariant)
             )
             let state = try await ClientNetwork.create(configuration: config)
             print(state.id)

--- a/Sources/ContainerResource/Network/NetworkConfiguration.swift
+++ b/Sources/ContainerResource/Network/NetworkConfiguration.swift
@@ -18,6 +18,16 @@ import ContainerizationError
 import ContainerizationExtras
 import Foundation
 
+public struct NetworkPluginInfo: Codable, Sendable {
+    public let plugin: String
+    public let variant: String?
+
+    public init(plugin: String, variant: String? = nil) {
+        self.plugin = plugin
+        self.variant = variant
+    }
+}
+
 /// Configuration parameters for network creation.
 public struct NetworkConfiguration: Codable, Sendable, Identifiable {
     /// A unique identifier for the network
@@ -38,13 +48,17 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
     /// Key-value labels for the network.
     public var labels: [String: String] = [:]
 
+    /// Details about the network plugin that manages this network.
+    public var pluginInfo: NetworkPluginInfo
+
     /// Creates a network configuration
     public init(
         id: String,
         mode: NetworkMode,
         ipv4Subnet: CIDRv4? = nil,
         ipv6Subnet: CIDRv6? = nil,
-        labels: [String: String] = [:]
+        labels: [String: String] = [:],
+        pluginInfo: NetworkPluginInfo,
     ) throws {
         self.id = id
         self.creationDate = Date()
@@ -52,6 +66,7 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
         self.ipv4Subnet = ipv4Subnet
         self.ipv6Subnet = ipv6Subnet
         self.labels = labels
+        self.pluginInfo = pluginInfo
         try validate()
     }
 
@@ -62,6 +77,7 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
         case ipv4Subnet
         case ipv6Subnet
         case labels
+        case pluginInfo
         // TODO: retain for deserialization compatability for now, remove later
         case subnet
     }
@@ -81,6 +97,7 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
         ipv6Subnet = try container.decodeIfPresent(String.self, forKey: .ipv6Subnet)
             .map { try CIDRv6($0) }
         labels = try container.decodeIfPresent([String: String].self, forKey: .labels) ?? [:]
+        pluginInfo = try container.decode(NetworkPluginInfo.self, forKey: .pluginInfo)
         try validate()
     }
 
@@ -94,6 +111,7 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
         try container.encodeIfPresent(ipv4Subnet, forKey: .ipv4Subnet)
         try container.encodeIfPresent(ipv6Subnet, forKey: .ipv6Subnet)
         try container.encode(labels, forKey: .labels)
+        try container.encode(pluginInfo, forKey: .pluginInfo)
     }
 
     private func validate() throws {

--- a/Sources/Helpers/APIServer/APIServer+Start.swift
+++ b/Sources/Helpers/APIServer/APIServer+Start.swift
@@ -245,7 +245,11 @@ extension APIServer {
                 .filter { $0.id == ClientNetwork.defaultNetworkName }
                 .first
             if defaultNetwork == nil {
-                let config = try NetworkConfiguration(id: ClientNetwork.defaultNetworkName, mode: .nat)
+                let config = try NetworkConfiguration(
+                    id: ClientNetwork.defaultNetworkName,
+                    mode: .nat,
+                    pluginInfo: NetworkPluginInfo(plugin: "container-network-vmnet")
+                )
                 _ = try await service.create(configuration: config)
             }
 
@@ -254,6 +258,10 @@ extension APIServer {
             routes[XPCRoute.networkCreate] = harness.create
             routes[XPCRoute.networkDelete] = harness.delete
             routes[XPCRoute.networkList] = harness.list
+            routes[XPCRoute.networkAllocate] = harness.allocate
+            routes[XPCRoute.networkDeallocate] = harness.deallocate
+            routes[XPCRoute.networkLookup] = harness.lookup
+            routes[XPCRoute.networkDisableAllocator] = harness.disableAllocator
             return service
         }
 

--- a/Sources/Helpers/NetworkVmnet/NetworkVmnetHelper+Start.swift
+++ b/Sources/Helpers/NetworkVmnet/NetworkVmnetHelper+Start.swift
@@ -71,11 +71,17 @@ extension NetworkVmnetHelper {
                 log.info("configuring XPC server")
                 let ipv4Subnet = try self.ipv4Subnet.map { try CIDRv4($0) }
                 let ipv6Subnet = try self.ipv6Subnet.map { try CIDRv6($0) }
+                let pluginInfo = NetworkPluginInfo(
+                    plugin: NetworkVmnetHelper._commandName,
+                    variant: self.variant.rawValue
+                )
+
                 let configuration = try NetworkConfiguration(
                     id: id,
                     mode: .nat,
                     ipv4Subnet: ipv4Subnet,
                     ipv6Subnet: ipv6Subnet,
+                    pluginInfo: pluginInfo
                 )
                 let network = try Self.createNetwork(
                     configuration: configuration,

--- a/Sources/Services/ContainerAPIService/Client/XPC+.swift
+++ b/Sources/Services/ContainerAPIService/Client/XPC+.swift
@@ -98,6 +98,11 @@ public enum XPCKeys: String {
     case networkConfig
     case networkState
     case networkStates
+    case networkHostname
+    case networkMACAddress
+    case networkAdditionalData
+    case networkDisableAllocator
+    case networkAttachment
 
     /// Kernel
     case kernel
@@ -150,6 +155,11 @@ public enum XPCRoute: String {
     case networkCreate
     case networkDelete
     case networkList
+    case networkState
+    case networkAllocate
+    case networkDeallocate
+    case networkLookup
+    case networkDisableAllocator
 
     case volumeCreate
     case volumeDelete

--- a/Sources/Services/ContainerAPIService/Server/Networks/NetworksService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Networks/NetworksService.swift
@@ -19,6 +19,7 @@ import ContainerNetworkServiceClient
 import ContainerPersistence
 import ContainerPlugin
 import ContainerResource
+import ContainerXPC
 import Containerization
 import ContainerizationError
 import ContainerizationExtras
@@ -27,15 +28,22 @@ import Foundation
 import Logging
 
 public actor NetworksService {
+    struct NetworkServiceState {
+        var networkState: NetworkState
+        var client: NetworkClient
+    }
+
     private let pluginLoader: PluginLoader
     private let resourceRoot: URL
     private let containersService: ContainersService
     private let log: Logger
 
     private let store: FilesystemEntityStore<NetworkConfiguration>
-    private let networkPlugin: Plugin
-    private var networkStates = [String: NetworkState]()
+    private let networkPlugins: [Plugin]
     private var busyNetworks = Set<String>()
+
+    private let stateLock = AsyncLock()
+    private var serviceStates = [String: NetworkServiceState]()
 
     public init(
         pluginLoader: PluginLoader,
@@ -55,15 +63,14 @@ public actor NetworksService {
             log: log
         )
 
-        let networkPlugin =
+        let networkPlugins =
             pluginLoader
             .findPlugins()
             .filter { $0.hasType(.network) }
-            .first
-        guard let networkPlugin else {
-            throw ContainerizationError(.internalError, message: "cannot find network plugin")
+        guard !networkPlugins.isEmpty else {
+            throw ContainerizationError(.internalError, message: "cannot find any plugins with type network")
         }
-        self.networkPlugin = networkPlugin
+        self.networkPlugins = networkPlugins
 
         let configurations = try await store.list()
         for configuration in configurations {
@@ -71,23 +78,30 @@ public actor NetworksService {
                 try await registerService(configuration: configuration)
             } catch {
                 log.error(
-                    "failed to start network",
+                    "failed to start network: \(error)",
                     metadata: [
                         "id": "\(configuration.id)"
                     ])
             }
 
-            let client = NetworkClient(id: configuration.id)
-            let networkState = try await client.state()
+            let client = Self.getClient(configuration: configuration)
+            var networkState = try await client.state()
 
             // FIXME: Temporary workaround for persisted configuration being overwritten
             // by what comes back from the network helper, which messes up creationDate.
             switch networkState {
             case .created(_):
-                networkStates[configuration.id] = NetworkState.created(configuration)
+                networkState = NetworkState.created(configuration)
             case .running(_, let status):
-                networkStates[configuration.id] = NetworkState.running(configuration, status)
+                networkState = NetworkState.running(configuration, status)
             }
+
+            let state = NetworkServiceState(
+                networkState: networkState,
+                client: client
+            )
+
+            serviceStates[configuration.id] = state
 
             guard case .running = networkState else {
                 log.error(
@@ -104,8 +118,8 @@ public actor NetworksService {
     /// List all networks registered with the service.
     public func list() async throws -> [NetworkState] {
         log.info("network service: list")
-        return networkStates.reduce(into: [NetworkState]()) {
-            $0.append($1.value)
+        return serviceStates.reduce(into: [NetworkState]()) {
+            $0.append($1.value.networkState)
         }
     }
 
@@ -131,41 +145,43 @@ public actor NetworksService {
         defer { busyNetworks.remove(configuration.id) }
 
         // Ensure the network doesn't already exist.
-        guard networkStates[configuration.id] == nil else {
-            throw ContainerizationError(.exists, message: "network \(configuration.id) already exists")
-        }
-
-        // Create and start the network.
-        try await registerService(configuration: configuration)
-        let client = NetworkClient(id: configuration.id)
-
-        // Ensure the network is running, and set up the persistent network state
-        // using our configuration data, as the one from the helper doesn't include
-        // metadata.
-        guard case .running(_, let status) = try await client.state() else {
-            throw ContainerizationError(.invalidState, message: "network \(configuration.id) failed to start")
-        }
-        let networkState: NetworkState = .running(configuration, status)
-        networkStates[configuration.id] = networkState
-
-        // Persist the configuration data.
-        do {
-            try await store.create(configuration)
-            return networkState
-        } catch {
-            networkStates.removeValue(forKey: configuration.id)
-            do {
-                try pluginLoader.deregisterWithLaunchd(plugin: networkPlugin, instanceId: configuration.id)
-            } catch {
-                log.error(
-                    "failed to deregister network service after failed creation",
-                    metadata: [
-                        "id": "\(configuration.id)",
-                        "error": "\(error.localizedDescription)",
-                    ])
+        return try await self.stateLock.withLock { _ in
+            guard await self.serviceStates[configuration.id] == nil else {
+                throw ContainerizationError(.exists, message: "network \(configuration.id) already exists")
             }
 
-            throw error
+            // Create and start the network.
+            try await self.registerService(configuration: configuration)
+            let client = Self.getClient(configuration: configuration)
+
+            // Ensure the network is running, and set up the persistent network state
+            // using our configuration data, as the one from the helper doesn't include
+            // metadata.
+            guard case .running(_, let status) = try await client.state() else {
+                throw ContainerizationError(.invalidState, message: "network \(configuration.id) failed to start")
+            }
+            let networkState: NetworkState = .running(configuration, status)
+            let serviceState = NetworkServiceState(networkState: networkState, client: client)
+            await self.setServiceState(key: configuration.id, value: serviceState)
+
+            // Persist the configuration data.
+            do {
+                try await self.store.create(configuration)
+                return networkState
+            } catch {
+                await self.removeServiceState(key: configuration.id)
+                do {
+                    try await self.deregisterService(configuration: configuration)
+                } catch {
+                    self.log.error(
+                        "failed to deregister network service after failed creation",
+                        metadata: [
+                            "id": "\(configuration.id)",
+                            "error": "\(error.localizedDescription)",
+                        ])
+                }
+                throw error
+            }
         }
     }
 
@@ -191,86 +207,127 @@ public actor NetworksService {
             throw ContainerizationError(.invalidArgument, message: "cannot delete system subnet \(ClientNetwork.defaultNetworkName)")
         }
 
-        guard let networkState = networkStates[id] else {
-            throw ContainerizationError(.notFound, message: "no network for id \(id)")
-        }
+        try await stateLock.withLock { _ in
+            guard let serviceState = await self.serviceStates[id] else {
+                throw ContainerizationError(.notFound, message: "no network for id \(id)")
+            }
 
-        guard case .running = networkState else {
-            throw ContainerizationError(.invalidState, message: "cannot delete subnet \(id) in state \(networkState.state)")
-        }
+            guard case .running(let netConfig, _) = serviceState.networkState else {
+                throw ContainerizationError(.invalidState, message: "cannot delete subnet \(id) in state \(serviceState.networkState.state)")
+            }
 
-        // prevent container operations while we atomically check and delete
-        try await containersService.withContainerList { containers in
-            // find all containers that refer to the network
-            var referringContainers = Set<String>()
-            for container in containers {
-                for attachmentConfiguration in container.configuration.networks {
-                    if attachmentConfiguration.network == id {
-                        referringContainers.insert(container.configuration.id)
-                        break
+            // prevent container operations while we atomically check and delete
+            try await self.containersService.withContainerList { containers in
+                // find all containers that refer to the network
+                var referringContainers = Set<String>()
+                for container in containers {
+                    for attachmentConfiguration in container.configuration.networks {
+                        if attachmentConfiguration.network == id {
+                            referringContainers.insert(container.configuration.id)
+                            break
+                        }
                     }
+                }
+
+                // bail if any referring containers
+                guard referringContainers.isEmpty else {
+                    throw ContainerizationError(
+                        .invalidState,
+                        message: "cannot delete subnet \(id) with referring containers: \(referringContainers.joined(separator: ", "))"
+                    )
+                }
+
+                // disable the allocator so nothing else can attach
+                // TODO: remove this from the network helper later, not necesssary now that withContainerList is here
+                guard try await serviceState.client.disableAllocator() else {
+                    throw ContainerizationError(.invalidState, message: "cannot delete subnet \(id) because the IP allocator cannot be disabled with active containers")
+                }
+
+                // start network deletion, this is the last place we'll want to throw
+                do {
+                    try await self.deregisterService(configuration: netConfig)
+                } catch {
+                    self.log.error(
+                        "failed to deregister network service",
+                        metadata: [
+                            "id": "\(id)",
+                            "error": "\(error.localizedDescription)",
+                        ])
+                }
+
+                // deletion is underway, do not throw anything now
+                do {
+                    try await self.store.delete(id)
+                } catch {
+                    self.log.error(
+                        "failed to delete network from configuration store",
+                        metadata: [
+                            "id": "\(id)",
+                            "error": "\(error.localizedDescription)",
+                        ])
                 }
             }
 
-            // bail if any referring containers
-            guard referringContainers.isEmpty else {
-                throw ContainerizationError(
-                    .invalidState,
-                    message: "cannot delete subnet \(id) with referring containers: \(referringContainers.joined(separator: ", "))"
-                )
-            }
-
-            // disable the allocator so nothing else can attach
-            // TODO: remove this from the network helper later, not necesssary now that withContainerList is here
-            let client = NetworkClient(id: id)
-            guard try await client.disableAllocator() else {
-                throw ContainerizationError(.invalidState, message: "cannot delete subnet \(id) because the IP allocator cannot be disabled with active containers")
-            }
-
-            // start network deletion, this is the last place we'll want to throw
-            do {
-                try self.pluginLoader.deregisterWithLaunchd(plugin: self.networkPlugin, instanceId: id)
-            } catch {
-                self.log.error(
-                    "failed to deregister network service",
-                    metadata: [
-                        "id": "\(id)",
-                        "error": "\(error.localizedDescription)",
-                    ])
-            }
-
-            // deletion is underway, do not throw anything now
-            do {
-                try await self.store.delete(id)
-            } catch {
-                self.log.error(
-                    "failed to delete network from configuration store",
-                    metadata: [
-                        "id": "\(id)",
-                        "error": "\(error.localizedDescription)",
-                    ])
-            }
+            // having deleted successfully, remove the runtime state
+            await self.removeServiceState(key: id)
         }
-
-        // having deleted successfully, remove the runtime state
-        self.networkStates.removeValue(forKey: id)
     }
 
     /// Perform a hostname lookup on all networks.
     public func lookup(hostname: String) async throws -> Attachment? {
-        for id in networkStates.keys {
-            let client = NetworkClient(id: id)
-            guard let allocation = try await client.lookup(hostname: hostname) else {
-                continue
+        try await self.stateLock.withLock { _ in
+            for state in await self.serviceStates.values {
+                guard let allocation = try await state.client.lookup(hostname: hostname) else {
+                    continue
+                }
+                return allocation
             }
-            return allocation
+            return nil
         }
-        return nil
+    }
+
+    public func allocate(id: String, hostname: String, macAddress: String?) async throws -> (attachment: Attachment, additionalData: XPCMessage?) {
+        guard let serviceState = serviceStates[id] else {
+            throw ContainerizationError(.notFound, message: "no network for id \(id)")
+        }
+        return try await serviceState.client.allocate(hostname: hostname, macAddress: macAddress)
+    }
+
+    public func deallocate(id: String, hostname: String) async throws {
+        guard let serviceState = serviceStates[id] else {
+            throw ContainerizationError(.notFound, message: "no network for id \(id)")
+        }
+        return try await serviceState.client.deallocate(hostname: hostname)
+    }
+
+    public func lookup(id: String, hostname: String) async throws -> Attachment? {
+        guard let serviceState = serviceStates[id] else {
+            throw ContainerizationError(.notFound, message: "no network for id \(id)")
+        }
+        return try await serviceState.client.lookup(hostname: hostname)
+    }
+
+    public func disableAllocator(id: String) async throws -> Bool {
+        guard let serviceState = serviceStates[id] else {
+            throw ContainerizationError(.notFound, message: "no network for id \(id)")
+        }
+        return try await serviceState.client.disableAllocator()
+    }
+
+    private static func getClient(configuration: NetworkConfiguration) -> NetworkClient {
+        NetworkClient(id: configuration.id, plugin: configuration.pluginInfo.plugin)
     }
 
     private func registerService(configuration: NetworkConfiguration) async throws {
         guard configuration.mode == .nat else {
             throw ContainerizationError(.invalidArgument, message: "unsupported network mode \(configuration.mode.rawValue)")
+        }
+
+        guard let networkPlugin = self.networkPlugins.first(where: { $0.name == configuration.pluginInfo.plugin }) else {
+            throw ContainerizationError(
+                .notFound,
+                message: "unable to locate network plugin \(configuration.pluginInfo.plugin)"
+            )
         }
 
         guard let serviceIdentifier = networkPlugin.getMachService(instanceId: configuration.id, type: .network) else {
@@ -286,8 +343,8 @@ public actor NetworksService {
 
         if let ipv4Subnet = configuration.ipv4Subnet {
             var existingCidrs: [CIDRv4] = []
-            for networkState in networkStates.values {
-                if case .running(_, let status) = networkState {
+            for serviceState in serviceStates.values {
+                if case .running(_, let status) = serviceState.networkState {
                     existingCidrs.append(status.ipv4Subnet)
                 }
             }
@@ -306,8 +363,8 @@ public actor NetworksService {
 
         if let ipv6Subnet = configuration.ipv6Subnet {
             var existingCidrs: [CIDRv6] = []
-            for networkState in networkStates.values {
-                if case .running(_, let status) = networkState, let otherIPv6Subnet = status.ipv6Subnet {
+            for serviceState in serviceStates.values {
+                if case .running(_, let status) = serviceState.networkState, let otherIPv6Subnet = status.ipv6Subnet {
                     existingCidrs.append(otherIPv6Subnet)
                 }
             }
@@ -324,11 +381,35 @@ public actor NetworksService {
             args += ["--subnet-v6", ipv6Subnet.description]
         }
 
+        if let variant = configuration.pluginInfo.variant {
+            args += ["--variant", variant]
+        }
+
         try await pluginLoader.registerWithLaunchd(
             plugin: networkPlugin,
             pluginStateRoot: store.entityUrl(configuration.id),
             args: args,
             instanceId: configuration.id
         )
+    }
+
+    private func deregisterService(configuration: NetworkConfiguration) async throws {
+        guard let networkPlugin = self.networkPlugins.first(where: { $0.name == configuration.pluginInfo.plugin }) else {
+            throw ContainerizationError(
+                .notFound,
+                message: "unable to locate network plugin \(configuration.pluginInfo.plugin)"
+            )
+        }
+        try self.pluginLoader.deregisterWithLaunchd(plugin: networkPlugin, instanceId: configuration.id)
+    }
+}
+
+extension NetworksService {
+    private func removeServiceState(key: String) {
+        self.serviceStates.removeValue(forKey: key)
+    }
+
+    private func setServiceState(key: String, value: NetworkServiceState) {
+        self.serviceStates[key] = value
     }
 }

--- a/Sources/Services/ContainerNetworkService/Client/NetworkClient.swift
+++ b/Sources/Services/ContainerNetworkService/Client/NetworkClient.swift
@@ -22,18 +22,23 @@ import Foundation
 
 /// A client for interacting with a single network.
 public struct NetworkClient: Sendable {
-    // FIXME: need more flexibility than a hard-coded constant?
-    static let label = "com.apple.container.network.container-network-vmnet"
+    static let label = "com.apple.container.network"
+
+    public static func machServiceLabel(id: String, plugin: String) -> String {
+        "\(Self.label).\(plugin).\(id)"
+    }
 
     private var machServiceLabel: String {
-        "\(Self.label).\(id)"
+        Self.machServiceLabel(id: id, plugin: plugin)
     }
 
     let id: String
+    let plugin: String
 
     /// Create a client for a network.
-    public init(id: String) {
+    public init(id: String, plugin: String) {
         self.id = id
+        self.plugin = plugin
     }
 }
 
@@ -50,12 +55,12 @@ extension NetworkClient {
 
     public func allocate(
         hostname: String,
-        macAddress: MACAddress? = nil
+        macAddress: String? = nil
     ) async throws -> (attachment: Attachment, additionalData: XPCMessage?) {
         let request = XPCMessage(route: NetworkRoutes.allocate.rawValue)
         request.set(key: NetworkKeys.hostname.rawValue, value: hostname)
         if let macAddress = macAddress {
-            request.set(key: NetworkKeys.macAddress.rawValue, value: macAddress.description)
+            request.set(key: NetworkKeys.macAddress.rawValue, value: macAddress)
         }
 
         let client = createClient()

--- a/Tests/ContainerResourceTests/NetworkConfigurationTest.swift
+++ b/Tests/ContainerResourceTests/NetworkConfigurationTest.swift
@@ -21,9 +21,15 @@ import Testing
 @testable import ContainerResource
 
 struct NetworkConfigurationTest {
+    let defaultNetworkPluginInfo = NetworkPluginInfo(plugin: "container-network-vmnet")
+
     @Test func testValidationOkDefaults() throws {
         let id = "foo"
-        _ = try NetworkConfiguration(id: id, mode: .nat)
+        _ = try NetworkConfiguration(
+            id: id,
+            mode: .nat,
+            pluginInfo: defaultNetworkPluginInfo
+        )
     }
 
     @Test func testValidationGoodId() throws {
@@ -38,7 +44,13 @@ struct NetworkConfigurationTest {
                 "foo": "bar",
                 "baz": String(repeating: "0", count: 4096 - "baz".count - "=".count),
             ]
-            _ = try NetworkConfiguration(id: id, mode: .nat, ipv4Subnet: ipv4Subnet, labels: labels)
+            _ = try NetworkConfiguration(
+                id: id,
+                mode: .nat,
+                ipv4Subnet: ipv4Subnet,
+                labels: labels,
+                pluginInfo: defaultNetworkPluginInfo
+            )
         }
     }
 
@@ -56,7 +68,13 @@ struct NetworkConfigurationTest {
                 "baz": String(repeating: "0", count: 4096 - "baz".count - "=".count),
             ]
             #expect {
-                _ = try NetworkConfiguration(id: id, mode: .nat, ipv4Subnet: ipv4Subnet, labels: labels)
+                _ = try NetworkConfiguration(
+                    id: id,
+                    mode: .nat,
+                    ipv4Subnet: ipv4Subnet,
+                    labels: labels,
+                    pluginInfo: defaultNetworkPluginInfo
+                )
             } throws: { error in
                 guard let err = error as? ContainerizationError else { return false }
                 #expect(err.code == .invalidArgument)
@@ -76,7 +94,13 @@ struct NetworkConfigurationTest {
         for labels in allLabels {
             let id = "foo"
             let ipv4Subnet = try CIDRv4("192.168.64.1/24")
-            _ = try NetworkConfiguration(id: id, mode: .nat, ipv4Subnet: ipv4Subnet, labels: labels)
+            _ = try NetworkConfiguration(
+                id: id,
+                mode: .nat,
+                ipv4Subnet: ipv4Subnet,
+                labels: labels,
+                pluginInfo: defaultNetworkPluginInfo
+            )
         }
     }
 
@@ -92,7 +116,13 @@ struct NetworkConfigurationTest {
             let id = "foo"
             let ipv4Subnet = try CIDRv4("192.168.64.1/24")
             #expect {
-                _ = try NetworkConfiguration(id: id, mode: .nat, ipv4Subnet: ipv4Subnet, labels: labels)
+                _ = try NetworkConfiguration(
+                    id: id,
+                    mode: .nat,
+                    ipv4Subnet: ipv4Subnet,
+                    labels: labels,
+                    pluginInfo: defaultNetworkPluginInfo
+                )
             } throws: { error in
                 guard let err = error as? ContainerizationError else { return false }
                 #expect(err.code == .invalidArgument)


### PR DESCRIPTION
## Type of Change
- [x] New feature  
- [x] Breaking change

## Motivation and Context
* To support this, we need to change the architecture of communicating with network service instances, which is a breaking change. Now to communicate with the network service instance, you must first communicate with the NetworksService via the APIServer so you can accurately determine which network plugin was used to manage that network instance.
* This follows a similar model to what the we do for the SandboxClient and SandboxService.

Closes https://github.com/apple/container/issues/1048

Future changes:
- Docs changes for the new fields on NetworkCreate 
- Better UX for determining the default network plugin and default network configurations 
- Additional network plugins and better testing 

## Testing
- [x] Tested locally
