### PR TITLE
Fix: prevent delete default network

### DIFF
--- a/Sources/ContainerCommands/Network/NetworkDelete.swift
+++ b/Sources/ContainerCommands/Network/NetworkDelete.swift
@@ -54,8 +54,16 @@ extension Application {
             let uniqueNetworkNames = Set<String>(networkNames)
             let networks: [NetworkState]
 
+            if uniqueNetworkNames.contains(ClientNetwork.defaultNetworkName) {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "cannot delete the default network"
+                )
+            }
+
             if all {
                 networks = try await ClientNetwork.list()
+                    .filter { $0.id != ClientNetwork.defaultNetworkName }
             } else {
                 networks = try await ClientNetwork.list()
                     .filter { c in
@@ -76,13 +84,6 @@ extension Application {
                         message: "failed to delete one or more networks: \(missing)"
                     )
                 }
-            }
-
-            if uniqueNetworkNames.contains(ClientNetwork.defaultNetworkName) {
-                throw ContainerizationError(
-                    .invalidArgument,
-                    message: "cannot delete the default network"
-                )
             }
 
             var failed = [String]()


### PR DESCRIPTION
## Type of Change

- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Fixed #1073

Move the conditional check to the front; there's no need to check for a default network after filtering.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
