### PR TITLE
Removes ArgumentParser import from NetworkMode.

### DIFF
--- a/Sources/ContainerResource/Network/NetworkMode.swift
+++ b/Sources/ContainerResource/Network/NetworkMode.swift
@@ -14,10 +14,8 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import ArgumentParser
-
 /// Networking mode that applies to client containers.
-public enum NetworkMode: String, Codable, Sendable, ExpressibleByArgument {
+public enum NetworkMode: String, Codable, Sendable {
     /// NAT networking mode.
     /// Containers do not have routable IPs, and the host performs network
     /// address translation to allow containers to reach external services.

--- a/Sources/Helpers/NetworkVmnet/NetworkVmnetHelper+Start.swift
+++ b/Sources/Helpers/NetworkVmnet/NetworkVmnetHelper+Start.swift
@@ -29,6 +29,8 @@ enum Variant: String, ExpressibleByArgument {
     case allocationOnly
 }
 
+extension NetworkMode: ExpressibleByArgument {}
+
 extension NetworkVmnetHelper {
     struct Start: AsyncParsableCommand {
         static let configuration = CommandConfiguration(


### PR DESCRIPTION
- ContainerResources shouldn't need to know anything about CLI stuff.
- Move ExpressibleByArgument protocol conformance to an extension in the package where it's needed.