### PR TITLE
Fix testExecOnExitingContainer

### DIFF
--- a/Tests/CLITests/Subcommands/Containers/TestCLIExec.swift
+++ b/Tests/CLITests/Subcommands/Containers/TestCLIExec.swift
@@ -125,6 +125,9 @@ class TestCLIExecCommand: CLITest {
                 // There's no nice way to check fail reason here
                 #expect(message.contains("is not running"), "expected container is not running if exec failed")
             }
+
+            // Give time for the exec (or start) error handling settles down
+            sleep(1)
             #expect(throws: Never.self, "expected the container remains") {
                 try getContainerStatus(name)
             }


### PR DESCRIPTION
Check the container remains only, not its status as the status might not have been updated at the time checking.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
[Why is this change needed?]

## Testing
- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
