### PR TITLE
Set mtu to old Containerization default

### DIFF
--- a/Sources/Helpers/RuntimeLinux/IsolatedInterfaceStrategy.swift
+++ b/Sources/Helpers/RuntimeLinux/IsolatedInterfaceStrategy.swift
@@ -25,6 +25,12 @@ import Containerization
 struct IsolatedInterfaceStrategy: InterfaceStrategy {
     public func toInterface(attachment: Attachment, interfaceIndex: Int, additionalData: XPCMessage?) -> Interface {
         let ipv4Gateway = interfaceIndex == 0 ? attachment.ipv4Gateway : nil
-        return NATInterface(ipv4Address: attachment.ipv4Address, ipv4Gateway: ipv4Gateway, macAddress: attachment.macAddress)
+        return NATInterface(
+            ipv4Address: attachment.ipv4Address,
+            ipv4Gateway: ipv4Gateway,
+            macAddress: attachment.macAddress,
+            // https://github.com/apple/containerization/pull/38
+            mtu: 1280
+        )
     }
 }

--- a/Sources/Helpers/RuntimeLinux/NonisolatedInterfaceStrategy.swift
+++ b/Sources/Helpers/RuntimeLinux/NonisolatedInterfaceStrategy.swift
@@ -44,6 +44,13 @@ struct NonisolatedInterfaceStrategy: InterfaceStrategy {
 
         log.info("creating NATNetworkInterface with network reference")
         let ipv4Gateway = interfaceIndex == 0 ? attachment.ipv4Gateway : nil
-        return NATNetworkInterface(ipv4Address: attachment.ipv4Address, ipv4Gateway: ipv4Gateway, reference: networkRef, macAddress: attachment.macAddress)
+        return NATNetworkInterface(
+            ipv4Address: attachment.ipv4Address,
+            ipv4Gateway: ipv4Gateway,
+            reference: networkRef,
+            macAddress: attachment.macAddress,
+            // https://github.com/apple/containerization/pull/38
+            mtu: 1280
+        )
     }
 }


### PR DESCRIPTION
The old mtu default in containerization was 1280 to account for some alpine/musl images that have issues with
1500. This changed in the last couple tags to be modifiable, but the new default is the standard 1500. Ideally we eventually allow supplying the mtu to be used when you create a network (or possibly a container creation setting), but for now just default in here back to what CZ used to use.