### PR TITLE
Fix pfctl executable path in PacketFilter DNS reload

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/PacketFilter.swift
+++ b/Sources/Services/ContainerAPIService/Client/PacketFilter.swift
@@ -183,7 +183,7 @@ public struct PacketFilter {
         let reloadProcess = Foundation.Process()
         var reloadStatus: Int32
 
-        reloadProcess.executableURL = URL(fileURLWithPath: "/sbin/reloadProcess")
+        reloadProcess.executableURL = URL(fileURLWithPath: "/sbin/pfctl")
         reloadProcess.arguments = ["-f", configURL.path]
         reloadProcess.standardOutput = null
         reloadProcess.standardError = null


### PR DESCRIPTION
## Summary

The `reload()` method in `PacketFilter.swift` references `/sbin/reloadProcess` (the local variable name) instead of `/sbin/pfctl`. This causes all DNS create and delete operations to fail:

```
Error: internalError: "pfctl reload exec failed: "Error Domain=NSCocoaErrorDomain Code=4 "The file "reloadProcess" doesn't exist.""
```

## Fix

One-line change: `/sbin/reloadProcess` → `/sbin/pfctl`

## Testing

Verified on macOS 26 (Tahoe) with Apple Silicon:
- `sudo container system dns create test.sdc.internal --localhost 203.0.113.1` succeeds without error
- Container can resolve and reach host services through the DNS redirect