### PR TITLE
docs: explain why uninstall script requires administrator password

### DIFF
--- a/scripts/uninstall-container.sh
+++ b/scripts/uninstall-container.sh
@@ -60,6 +60,15 @@ if [ -n "$CONTAINER_RUNNING" ]; then
     exit 1
 fi
 
+# Explain why administrator password is required
+echo "This script requires administrator privileges to:"
+echo "  - Remove application files from ${INSTALL_DIR}"
+echo "  - Unregister the installer package receipt"
+if [ "$DELETE_DATA" = true ]; then
+    echo "  - Delete user data from ~/Library/Application Support"
+fi
+echo ""
+
 FILES=$(pkgutil --only-files --files com.apple.container-installer)
 for i in ${FILES[@]}; do
     # this command can fail for some of the reported files from pkgutil such as 


### PR DESCRIPTION
## Summary
Addresses #1111

Adds an informative message before the sudo commands in `uninstall-container.sh` explaining why administrator privileges are required:

- Files are being removed from `/usr/local`
- Package receipt needs to be unregistered via `pkgutil --forget`
- User data deletion (if `-d` flag is used)

## Example Output
```
$ uninstall-container.sh -d
This script requires administrator privileges to:
  - Remove application files from /usr/local
  - Unregister the installer package receipt
  - Delete user data from ~/Library/Application Support

Password:
Removed `container` tool and helpers
Removing `container` user data
```

## Testing
Tested locally to verify message displays correctly before password prompt.