### PR TITLE
Explain why uninstall script needs admin password

### DIFF
--- a/scripts/uninstall-container.sh
+++ b/scripts/uninstall-container.sh
@@ -60,6 +60,8 @@ if [ -n "$CONTAINER_RUNNING" ]; then
     exit 1
 fi
 
+echo "This script requires an administrator password to remove the application files from system directories."
+
 FILES=$(pkgutil --only-files --files com.apple.container-installer)
 for i in ${FILES[@]}; do
     # this command can fail for some of the reported files from pkgutil such as 


### PR DESCRIPTION
## Summary

Fixes #1111

Adds an informative message to the uninstall script explaining why an administrator password is required before prompting for it.

## Changes

Added a single line before the first `sudo` command:
```
This script requires an administrator password to remove the application files from system directories.
```

## Before

```console
% uninstall-container.sh -d
Password:
```

## After

```console
% uninstall-container.sh -d
This script requires an administrator password to remove the application files from system directories.
Password:
```