### PR TITLE
Upgrade kernel to Kata 3.26.0.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b5e7886cffebc763ebcce883e1b62740a6d38a8166d53a28fe1635148c5e4c12",
+  "originHash" : "77f4cb7cb202f3e17c1555bf456b949cdbe8ca07e268d02d39f02ec01a37042c",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "92b02fc497953d2d59d29af425d29a1d8a783f1c",
-        "version" : "0.24.0"
+        "revision" : "c3fe889a2f739ee4a9b0faccedd9f36f3862dc29",
+        "version" : "0.24.5"
       }
     },
     {
@@ -242,6 +242,15 @@
       "state" : {
         "revision" : "890830fff1a577dc83134890c7984020c5f6b43b",
         "version" : "1.6.2"
+      }
+    },
+    {
+      "identity" : "zstd",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/facebook/zstd.git",
+      "state" : {
+        "revision" : "f8745da6ff1ad1e7bab384bd1f9d742439278e99",
+        "version" : "1.5.7"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ import PackageDescription
 let releaseVersion = ProcessInfo.processInfo.environment["RELEASE_VERSION"] ?? "0.0.0"
 let gitCommit = ProcessInfo.processInfo.environment["GIT_COMMIT"] ?? "unspecified"
 let builderShimVersion = "0.7.0"
-let scVersion = "0.24.0"
+let scVersion = "0.24.5"
 
 let package = Package(
     name: "container",

--- a/Sources/ContainerPersistence/DefaultsStore.swift
+++ b/Sources/ContainerPersistence/DefaultsStore.swift
@@ -181,9 +181,9 @@ extension DefaultsStore.Keys {
             }
             return "ghcr.io/apple/containerization/vminit:\(tag)"
         case .defaultKernelBinaryPath:
-            return "opt/kata/share/kata-containers/vmlinux-6.12.42-162"
+            return "opt/kata/share/kata-containers/vmlinux-6.18.5-177"
         case .defaultKernelURL:
-            return "https://github.com/kata-containers/kata-containers/releases/download/3.20.0/kata-static-3.20.0-arm64.tar.xz"
+            return "https://github.com/kata-containers/kata-containers/releases/download/3.26.0/kata-static-3.26.0-arm64.tar.zst"
         case .defaultSubnet:
             return "192.168.64.1/24"
         case .defaultIPv6Subnet:

--- a/Sources/ContainerResource/Common/ManagedResource.swift
+++ b/Sources/ContainerResource/Common/ManagedResource.swift
@@ -44,7 +44,7 @@ public protocol ManagedResource: Identifiable, Sendable, Codable {
 
 extension ManagedResource {
     /// Generate a random identifier that has the format of an ASCII SHA-256 hash.
-    public static func randomId() -> String {
+    public static func generateId() -> String {
         (0..<2)
             .map { _ in UInt128.random(in: 0...UInt128.max) }
             .map { String($0, radix: 16).padding(toLength: 32, withPad: "0", startingAt: 0) }

--- a/Tests/ContainerResourceTests/ManagedResourceTests.swift
+++ b/Tests/ContainerResourceTests/ManagedResourceTests.swift
@@ -28,10 +28,6 @@ struct ManagedResourceTests {
         var creationDate: Date
         var labels: [String: String]
 
-        static func generateId() -> String {
-            randomId()
-        }
-
         static func nameValid(_ name: String) -> Bool {
             true
         }
@@ -39,7 +35,7 @@ struct ManagedResourceTests {
 
     @Test("randomId generates valid hex string SHA256 hash format")
     func testRandomIdFormat() {
-        let id = MockManagedResource.randomId()
+        let id = MockManagedResource.generateId()
 
         // SHA256 hash is 64 hex characters (256 bits / 4 bits per hex char)
         #expect(id.count == 64, "randomId should generate 64 character string")
@@ -55,7 +51,7 @@ struct ManagedResourceTests {
     @Test("randomId generates unique values")
     func testRandomIdUniqueness() {
         // Generate multiple IDs and verify they're all different
-        let ids = (0..<100).map { _ in MockManagedResource.randomId() }
+        let ids = (0..<100).map { _ in MockManagedResource.generateId() }
         let uniqueIds = Set(ids)
 
         #expect(uniqueIds.count == 100, "All generated IDs should be unique")
@@ -63,7 +59,7 @@ struct ManagedResourceTests {
 
     @Test("randomId uses lowercase hexadecimal")
     func testRandomIdLowercase() {
-        let id = MockManagedResource.randomId()
+        let id = MockManagedResource.generateId()
 
         // Should not contain uppercase letters
         let uppercaseLetters = CharacterSet.uppercaseLetters


### PR DESCRIPTION
- Upgrade to containerization 0.24.5 to pick up zstd decompression enhancement.
- Closes #767.
- Closes #988.
- Closes #1132.
- Requires apple/containerization#508.
