### PR TITLE
Fix usage of "clean up" as verb

### DIFF
--- a/Sources/ContainerCommands/Image/ImageDelete.swift
+++ b/Sources/ContainerCommands/Image/ImageDelete.swift
@@ -69,7 +69,7 @@ extension Application {
                     failures.append(image.reference)
                 }
             }
-            let (_, size) = try await ClientImage.cleanupOrphanedBlobs()
+            let (_, size) = try await ClientImage.cleanUpOrphanedBlobs()
             let formatter = ByteCountFormatter()
             let freed = formatter.string(fromByteCount: Int64(size))
 

--- a/Sources/ContainerCommands/Image/ImagePrune.swift
+++ b/Sources/ContainerCommands/Image/ImagePrune.swift
@@ -64,7 +64,7 @@ extension Application {
                 }
             }
 
-            let (deletedDigests, size) = try await ClientImage.cleanupOrphanedBlobs()
+            let (deletedDigests, size) = try await ClientImage.cleanUpOrphanedBlobs()
 
             for image in imagesToPrune {
                 print("untagged \(image.reference)")

--- a/Sources/Helpers/Images/ImagesHelper.swift
+++ b/Sources/Helpers/Images/ImagesHelper.swift
@@ -96,7 +96,7 @@ extension ImagesHelper {
             routes[ImagesServiceXPCRoute.imageSave.rawValue] = harness.save
             routes[ImagesServiceXPCRoute.imageLoad.rawValue] = harness.load
             routes[ImagesServiceXPCRoute.imageUnpack.rawValue] = harness.unpack
-            routes[ImagesServiceXPCRoute.imageCleanupOrphanedBlobs.rawValue] = harness.cleanupOrphanedBlobs
+            routes[ImagesServiceXPCRoute.imageCleanupOrphanedBlobs.rawValue] = harness.cleanUpOrphanedBlobs
             routes[ImagesServiceXPCRoute.imageDiskUsage.rawValue] = harness.calculateDiskUsage
             routes[ImagesServiceXPCRoute.snapshotDelete.rawValue] = harness.deleteSnapshot
             routes[ImagesServiceXPCRoute.snapshotGet.rawValue] = harness.getSnapshot

--- a/Sources/Services/ContainerAPIService/Client/ClientImage.swift
+++ b/Sources/Services/ContainerAPIService/Client/ClientImage.swift
@@ -321,7 +321,7 @@ extension ClientImage {
         return ImageLoadResult(images: images, rejectedMembers: rejectedMembers)
     }
 
-    public static func cleanupOrphanedBlobs() async throws -> ([String], UInt64) {
+    public static func cleanUpOrphanedBlobs() async throws -> ([String], UInt64) {
         let client = newXPCClient()
         let request = newRequest(.imageCleanupOrphanedBlobs)
         let response = try await client.send(request)

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -490,7 +490,7 @@ public actor ContainersService {
             let client = try state.getClient()
             try await client.stop(options: opts)
             try await self.lock.withLock { context in
-                try await self.cleanup(id: id, context: context)
+                try await self.cleanUp(id: id, context: context)
             }
         case .stopping:
             throw ContainerizationError(
@@ -499,7 +499,7 @@ public actor ContainersService {
             )
         default:
             try await self.lock.withLock { context in
-                try await self.cleanup(id: id, context: context)
+                try await self.cleanUp(id: id, context: context)
             }
         }
     }
@@ -575,7 +575,7 @@ public actor ContainersService {
 
         let options = try getContainerCreationOptions(id: id)
         if options.autoRemove {
-            try await self.cleanup(id: id, context: context)
+            try await self.cleanUp(id: id, context: context)
         }
     }
 
@@ -583,7 +583,7 @@ public actor ContainersService {
         "\(Self.launchdDomainString)/\(Self.machServicePrefix).\(runtimeName).\(instanceId)"
     }
 
-    private func _cleanup(id: String) async throws {
+    private func _cleanUp(id: String) async throws {
         self.log.debug("\(#function)")
 
         // Did the exit container handler win?
@@ -608,8 +608,8 @@ public actor ContainersService {
         self.containers.removeValue(forKey: id)
     }
 
-    private func cleanup(id: String, context: AsyncLock.Context) async throws {
-        try await self._cleanup(id: id)
+    private func cleanUp(id: String, context: AsyncLock.Context) async throws {
+        try await self._cleanUp(id: id)
     }
 
     private func getContainerCreationOptions(id: String) throws -> ContainerCreateOptions {

--- a/Sources/Services/ContainerImagesService/Server/ImageService.swift
+++ b/Sources/Services/ContainerImagesService/Server/ImageService.swift
@@ -128,10 +128,10 @@ public actor ImagesService {
         return (images, rejectedMembers)
     }
 
-    public func cleanupOrphanedBlobs() async throws -> ([String], UInt64) {
+    public func cleanUpOrphanedBlobs() async throws -> ([String], UInt64) {
         let images = try await self._list()
         let freedSnapshotBytes = try await self.snapshotStore.clean(keepingSnapshotsFor: images)
-        let (deleted, freedContentBytes) = try await self.imageStore.cleanupOrphanedBlobs()
+        let (deleted, freedContentBytes) = try await self.imageStore.cleanUpOrphanedBlobs()
         return (deleted, freedContentBytes + freedSnapshotBytes)
     }
 

--- a/Sources/Services/ContainerImagesService/Server/ImagesServiceHarness.swift
+++ b/Sources/Services/ContainerImagesService/Server/ImagesServiceHarness.swift
@@ -182,8 +182,8 @@ public struct ImagesServiceHarness: Sendable {
     }
 
     @Sendable
-    public func cleanupOrphanedBlobs(_ message: XPCMessage) async throws -> XPCMessage {
-        let (deleted, size) = try await service.cleanupOrphanedBlobs()
+    public func cleanUpOrphanedBlobs(_ message: XPCMessage) async throws -> XPCMessage {
+        let (deleted, size) = try await service.cleanUpOrphanedBlobs()
         let reply = message.reply()
         let data = try JSONEncoder().encode(deleted)
         reply.set(key: .digests, value: data)

--- a/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
+++ b/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
@@ -223,10 +223,10 @@ public actor SandboxService {
                 await self.setState(.booted)
             } catch {
                 do {
-                    try await self.cleanupContainer(containerInfo: ctrInfo)
+                    try await self.cleanUpContainer(containerInfo: ctrInfo)
                     await self.setState(.created)
                 } catch {
-                    self.log.error("failed to cleanup container: \(error)")
+                    self.log.error("Failed to clean up container: \(error)")
                 }
                 throw error
             }
@@ -443,9 +443,9 @@ public actor SandboxService {
                     if case .stopped(_) = await self.state {
                         return message.reply()
                     }
-                    try await self.cleanupContainer(containerInfo: ctr, exitStatus: exitStatus)
+                    try await self.cleanUpContainer(containerInfo: ctr, exitStatus: exitStatus)
                 } catch {
-                    self.log.error("failed to cleanup container: \(error)")
+                    self.log.error("Failed to clean up container: \(error)")
                 }
                 await self.setState(.stopped(exitStatus.exitCode))
             default:
@@ -668,7 +668,7 @@ public actor SandboxService {
             }
             try await self.monitor.track(id: id, waitingOn: waitFunc)
         } catch {
-            try? await self.cleanupContainer(containerInfo: info)
+            try? await self.cleanUpContainer(containerInfo: info)
             self.setState(.created)
             throw error
         }
@@ -796,9 +796,9 @@ public actor SandboxService {
             }
 
             do {
-                try await cleanupContainer(containerInfo: ctrInfo, exitStatus: exitStatus)
+                try await cleanUpContainer(containerInfo: ctrInfo, exitStatus: exitStatus)
             } catch {
-                self.log.error("failed to cleanup container: \(error)")
+                self.log.error("Failed to clean up container: \(error)")
             }
             await setState(.stopped(exitStatus.exitCode))
         }
@@ -1025,7 +1025,7 @@ public actor SandboxService {
         return code
     }
 
-    private func cleanupContainer(containerInfo: ContainerInfo, exitStatus: ExitStatus? = nil) async throws {
+    private func cleanUpContainer(containerInfo: ContainerInfo, exitStatus: ExitStatus? = nil) async throws {
         let container = containerInfo.container
         let id = container.id
 

--- a/Tests/CLITests/Subcommands/Volumes/TestCLIAnonymousVolumes.swift
+++ b/Tests/CLITests/Subcommands/Volumes/TestCLIAnonymousVolumes.swift
@@ -24,10 +24,10 @@ class TestCLIAnonymousVolumes: CLITest {
     override init() throws {
         try super.init()
         // Clean up any leftover resources from previous test runs
-        cleanupAllTestResources()
+        cleanUpAllTestResources()
     }
 
-    private func cleanupAllTestResources() {
+    private func cleanUpAllTestResources() {
         // Clean up test containers (force remove)
         if let (_, output, _, status) = try? run(arguments: ["ls", "-a"]), status == 0 {
             let containers = output.components(separatedBy: .newlines)
@@ -185,7 +185,7 @@ class TestCLIAnonymousVolumes: CLITest {
         output = output.trimmingCharacters(in: .whitespacesAndNewlines)
         #expect(output == testData, "data should persist in anonymous volume")
 
-        // Cleanup
+        // Clean up
         try doStop(name: containerName2)
         doRemoveIfExists(name: containerName2, force: true)
         doVolumeDeleteIfExists(name: volumeID)

--- a/Tests/CLITests/Subcommands/Volumes/TestCLIVolumes.swift
+++ b/Tests/CLITests/Subcommands/Volumes/TestCLIVolumes.swift
@@ -71,7 +71,7 @@ class TestCLIVolumes: CLITest {
         doRemoveIfExists(name: container2Name, force: true)
 
         defer {
-            // Cleanup containers and volume
+            // Clean up containers and volume
             try? doStop(name: container1Name)
             doRemoveIfExists(name: container1Name, force: true)
             try? doStop(name: container2Name)
@@ -118,7 +118,7 @@ class TestCLIVolumes: CLITest {
         doRemoveIfExists(name: container2Name, force: true)
 
         defer {
-            // Cleanup containers and volume
+            // Clean up containers and volume
             try? doStop(name: container1Name)
             doRemoveIfExists(name: container1Name, force: true)
             try? doStop(name: container2Name)
@@ -138,7 +138,7 @@ class TestCLIVolumes: CLITest {
 
         #expect(status != 0, "second container should fail when trying to use volume already in use")
 
-        // Cleanup
+        // Clean up
         try doStop(name: container1Name)
         doRemoveIfExists(name: container1Name, force: true)
         doVolumeDeleteIfExists(name: volumeName)
@@ -154,7 +154,7 @@ class TestCLIVolumes: CLITest {
         doRemoveIfExists(name: containerName, force: true)
 
         defer {
-            // Cleanup container and volume
+            // Clean up container and volume
             try? doStop(name: containerName)
             doRemoveIfExists(name: containerName, force: true)
             doVolumeDeleteIfExists(name: volumeName)
@@ -189,7 +189,7 @@ class TestCLIVolumes: CLITest {
         doRemoveIfExists(name: containerName, force: true)
 
         defer {
-            // Cleanup container and volume
+            // Clean up container and volume
             try? doStop(name: containerName)
             doRemoveIfExists(name: containerName, force: true)
             doVolumeDeleteIfExists(name: volumeName)


### PR DESCRIPTION
"clean up" is a verb, and "cleanup" is a noun. I've fixed function names and comments accordingly. I didn't mark the incorrect function name as deprecated, since deprecation notices are not desired in [this related PR](https://github.com/apple/containerization/pull/507#pullrequestreview-3741684153).

CI tests will fail until https://github.com/apple/containerization/pull/507 is merged.