### PR TITLE
CLI: Rework ClientContainer

### DIFF
--- a/Sources/ContainerCommands/BuildCommand.swift
+++ b/Sources/ContainerCommands/BuildCommand.swift
@@ -153,10 +153,10 @@ extension Application {
                     }
 
                     group.addTask { [vsockPort, cpus, memory, log, dnsNameservers] in
+                        let client = ContainerClient()
                         while true {
                             do {
-                                let container = try await ClientContainer.get(id: "buildkit")
-                                let fh = try await container.dial(vsockPort)
+                                let fh = try await client.dial(id: "buildkit", port: vsockPort)
 
                                 let threadGroup: MultiThreadedEventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
                                 let b = try Builder(socket: fh, group: threadGroup)

--- a/Sources/ContainerCommands/Builder/BuilderDelete.swift
+++ b/Sources/ContainerCommands/Builder/BuilderDelete.swift
@@ -39,14 +39,15 @@ extension Application {
 
         public func run() async throws {
             do {
-                let container = try await ClientContainer.get(id: "buildkit")
+                let client = ContainerClient()
+                let container = try await client.get(id: "buildkit")
                 if container.status != .stopped {
                     guard force else {
                         throw ContainerizationError(.invalidState, message: "BuildKit container is not stopped, use --force to override")
                     }
-                    try await container.stop()
+                    try await client.stop(id: container.id)
                 }
-                try await container.delete()
+                try await client.delete(id: container.id)
             } catch {
                 if error is ContainerizationError {
                     if (error as? ContainerizationError)?.code == .notFound {

--- a/Sources/ContainerCommands/Builder/BuilderStart.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStart.swift
@@ -119,7 +119,8 @@ extension Application {
             }
             targetEnvVars.sort()
 
-            let existingContainer = try? await ClientContainer.get(id: "buildkit")
+            let client = ContainerClient()
+            let existingContainer = try? await client.get(id: "buildkit")
             if let existingContainer {
                 let existingImage = existingContainer.configuration.image.reference
                 let existingResources = existingContainer.configuration.resources
@@ -174,16 +175,16 @@ extension Application {
                         return
                     }
                     // If they changed, stop and delete the existing builder
-                    try await existingContainer.stop()
-                    try await existingContainer.delete()
+                    try await client.stop(id: existingContainer.id)
+                    try await client.delete(id: existingContainer.id)
                 case .stopped:
                     // If the builder is stopped and matches our requirements, start it
                     // Otherwise, delete it and create a new one
                     guard imageChanged || cpuChanged || memChanged || envChanged || dnsChanged else {
-                        try await existingContainer.startBuildKit(progressUpdate, nil)
+                        try await startBuildKit(client: client, id: existingContainer.id, progressUpdate, nil)
                         return
                     }
-                    try await existingContainer.delete()
+                    try await client.delete(id: existingContainer.id)
                 case .stopping:
                     throw ContainerizationError(
                         .invalidState,
@@ -296,43 +297,46 @@ extension Application {
                 .setDescription("Starting BuildKit container")
             ])
 
-            let container = try await ClientContainer.create(
+            try await client.create(
                 configuration: config,
                 options: .default,
                 kernel: kernel
             )
 
-            try await container.startBuildKit(progressUpdate, taskManager)
+            try await startBuildKit(client: client, id: Builder.builderContainerId, progressUpdate, taskManager)
             log.debug("starting BuildKit and BuildKit-shim")
         }
     }
 }
 
-// MARK: - ClientContainer Extension for BuildKit
+// MARK: - BuildKit Start Helper
 
-extension ClientContainer {
-    /// Starts the BuildKit process within the container
-    /// This method handles bootstrapping the container and starting the BuildKit process
-    fileprivate func startBuildKit(_ progress: @escaping ProgressUpdateHandler, _ taskManager: ProgressTaskCoordinator? = nil) async throws {
-        do {
-            let io = try ProcessIO.create(
-                tty: false,
-                interactive: false,
-                detach: true
-            )
-            defer { try? io.close() }
+/// Starts the BuildKit process within the container
+/// This function handles bootstrapping the container and starting the BuildKit process
+private func startBuildKit(
+    client: ContainerClient,
+    id: String,
+    _ progress: @escaping ProgressUpdateHandler,
+    _ taskManager: ProgressTaskCoordinator? = nil
+) async throws {
+    do {
+        let io = try ProcessIO.create(
+            tty: false,
+            interactive: false,
+            detach: true
+        )
+        defer { try? io.close() }
 
-            let process = try await bootstrap(stdio: io.stdio)
-            try await process.start()
-            await taskManager?.finish()
-            try io.closeAfterStart()
-        } catch {
-            try? await stop()
-            try? await delete()
-            if error is ContainerizationError {
-                throw error
-            }
-            throw ContainerizationError(.internalError, message: "failed to start BuildKit: \(error)")
+        let process = try await client.bootstrap(id: id, stdio: io.stdio)
+        try await process.start()
+        await taskManager?.finish()
+        try io.closeAfterStart()
+    } catch {
+        try? await client.stop(id: id)
+        try? await client.delete(id: id)
+        if error is ContainerizationError {
+            throw error
         }
+        throw ContainerizationError(.internalError, message: "failed to start BuildKit: \(error)")
     }
 }

--- a/Sources/ContainerCommands/Builder/BuilderStatus.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStatus.swift
@@ -16,6 +16,7 @@
 
 import ArgumentParser
 import ContainerAPIClient
+import ContainerResource
 import ContainerizationError
 import ContainerizationExtras
 import Foundation
@@ -42,7 +43,8 @@ extension Application {
 
         public func run() async throws {
             do {
-                let container = try await ClientContainer.get(id: "buildkit")
+                let client = ContainerClient()
+                let container = try await client.get(id: "buildkit")
                 try printContainers(containers: [container], format: format)
             } catch {
                 if error is ContainerizationError {
@@ -59,7 +61,7 @@ extension Application {
             [["ID", "IMAGE", "STATE", "ADDR", "CPUS", "MEMORY"]]
         }
 
-        private func printContainers(containers: [ClientContainer], format: ListFormat) throws {
+        private func printContainers(containers: [ContainerSnapshot], format: ListFormat) throws {
             if format == .json {
                 let printables = containers.map {
                     PrintableContainer($0)
@@ -88,7 +90,7 @@ extension Application {
     }
 }
 
-extension ClientContainer {
+extension ContainerSnapshot {
     fileprivate var asRow: [String] {
         [
             self.id,

--- a/Sources/ContainerCommands/Builder/BuilderStop.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStop.swift
@@ -35,8 +35,8 @@ extension Application {
 
         public func run() async throws {
             do {
-                let container = try await ClientContainer.get(id: "buildkit")
-                try await container.stop()
+                let client = ContainerClient()
+                try await client.stop(id: "buildkit")
             } catch {
                 if error is ContainerizationError {
                     if (error as? ContainerizationError)?.code == .notFound {

--- a/Sources/ContainerCommands/Container/ContainerCreate.swift
+++ b/Sources/ContainerCommands/Container/ContainerCreate.swift
@@ -82,11 +82,12 @@ extension Application {
             )
 
             let options = ContainerCreateOptions(autoRemove: managementFlags.remove)
-            let container = try await ClientContainer.create(configuration: ck.0, options: options, kernel: ck.1)
+            let client = ContainerClient()
+            try await client.create(configuration: ck.0, options: options, kernel: ck.1)
 
             if !self.managementFlags.cidfile.isEmpty {
                 let path = self.managementFlags.cidfile
-                let data = container.id.data(using: .utf8)
+                let data = id.data(using: .utf8)
                 var attributes = [FileAttributeKey: Any]()
                 attributes[.posixPermissions] = 0o644
                 let success = FileManager.default.createFile(
@@ -101,7 +102,7 @@ extension Application {
             }
             progress.finish()
 
-            print(container.id)
+            print(id)
         }
     }
 }

--- a/Sources/ContainerCommands/Container/ContainerDelete.swift
+++ b/Sources/ContainerCommands/Container/ContainerDelete.swift
@@ -16,6 +16,7 @@
 
 import ArgumentParser
 import ContainerAPIClient
+import ContainerResource
 import ContainerizationError
 import Foundation
 
@@ -54,12 +55,13 @@ extension Application {
 
         public mutating func run() async throws {
             let set = Set<String>(containerIds)
-            var containers = [ClientContainer]()
+            let client = ContainerClient()
+            var containers = [ContainerSnapshot]()
 
             if all {
-                containers = try await ClientContainer.list()
+                containers = try await client.list()
             } else {
-                let ctrs = try await ClientContainer.list()
+                let ctrs = try await client.list()
                 containers = ctrs.filter { c in
                     set.contains(c.id)
                 }
@@ -94,7 +96,7 @@ extension Application {
                                 return nil  // Skip running container when using --all
                             }
 
-                            try await container.delete(force: force)
+                            try await client.delete(id: container.id, force: force)
                             print(container.id)
                             return nil
                         } catch {

--- a/Sources/ContainerCommands/Container/ContainerExec.swift
+++ b/Sources/ContainerCommands/Container/ContainerExec.swift
@@ -45,7 +45,8 @@ extension Application {
 
         public func run() async throws {
             var exitCode: Int32 = 127
-            let container = try await ClientContainer.get(id: containerId)
+            let client = ContainerClient()
+            let container = try await client.get(id: containerId)
             try ensureRunning(container: container)
 
             let stdin = self.processFlags.interactive
@@ -79,8 +80,9 @@ extension Application {
                     try? io.close()
                 }
 
-                let process = try await container.createProcess(
-                    id: UUID().uuidString.lowercased(),
+                let process = try await client.createProcess(
+                    containerId: container.id,
+                    processId: UUID().uuidString.lowercased(),
                     configuration: config,
                     stdio: io.stdio
                 )

--- a/Sources/ContainerCommands/Container/ContainerInspect.swift
+++ b/Sources/ContainerCommands/Container/ContainerInspect.swift
@@ -16,6 +16,7 @@
 
 import ArgumentParser
 import ContainerAPIClient
+import ContainerResource
 import Foundation
 import SwiftProtobuf
 
@@ -34,7 +35,8 @@ extension Application {
         var containerIds: [String]
 
         public func run() async throws {
-            let objects: [any Codable] = try await ClientContainer.list().filter {
+            let client = ContainerClient()
+            let objects: [any Codable] = try await client.list().filter {
                 containerIds.contains($0.id)
             }.map {
                 PrintableContainer($0)

--- a/Sources/ContainerCommands/Container/ContainerKill.swift
+++ b/Sources/ContainerCommands/Container/ContainerKill.swift
@@ -51,8 +51,9 @@ extension Application {
 
         public mutating func run() async throws {
             let set = Set<String>(containerIds)
+            let client = ContainerClient()
 
-            var containers = try await ClientContainer.list().filter { c in
+            var containers = try await client.list().filter { c in
                 c.status == .running
             }
             if !self.all {
@@ -66,7 +67,7 @@ extension Application {
             var failed: [String] = []
             for container in containers {
                 do {
-                    try await container.kill(signalNumber)
+                    try await client.kill(id: container.id, signal: signalNumber)
                     print(container.id)
                 } catch {
                     log.error("failed to kill container \(container.id): \(error)")

--- a/Sources/ContainerCommands/Container/ContainerList.swift
+++ b/Sources/ContainerCommands/Container/ContainerList.swift
@@ -43,7 +43,8 @@ extension Application {
         public init() {}
 
         public func run() async throws {
-            let containers = try await ClientContainer.list()
+            let client = ContainerClient()
+            let containers = try await client.list()
             try printContainers(containers: containers, format: format)
         }
 
@@ -51,7 +52,7 @@ extension Application {
             [["ID", "IMAGE", "OS", "ARCH", "STATE", "ADDR", "CPUS", "MEMORY", "STARTED"]]
         }
 
-        private func printContainers(containers: [ClientContainer], format: ListFormat) throws {
+        private func printContainers(containers: [ContainerSnapshot], format: ListFormat) throws {
             if format == .json {
                 let printables = containers.map {
                     PrintableContainer($0)
@@ -86,13 +87,13 @@ extension Application {
     }
 }
 
-extension ClientContainer {
+extension ContainerSnapshot {
     fileprivate var asRow: [String] {
         [
             self.id,
             self.configuration.image.reference,
-            self.configuration.platform.os,
-            self.configuration.platform.architecture,
+            self.platform.os,
+            self.platform.architecture,
             self.status.rawValue,
             self.networks.compactMap { $0.ipv4Address.description }.joined(separator: ","),
             "\(self.configuration.resources.cpus)",
@@ -108,7 +109,7 @@ struct PrintableContainer: Codable {
     let networks: [Attachment]
     let startedDate: Date?
 
-    init(_ container: ClientContainer) {
+    init(_ container: ContainerSnapshot) {
         self.status = container.status
         self.configuration = container.configuration
         self.networks = container.networks

--- a/Sources/ContainerCommands/Container/ContainerLogs.swift
+++ b/Sources/ContainerCommands/Container/ContainerLogs.swift
@@ -46,22 +46,15 @@ extension Application {
         var containerId: String
 
         public func run() async throws {
-            do {
-                let container = try await ClientContainer.get(id: containerId)
-                let fhs = try await container.logs()
-                let fileHandle = boot ? fhs[1] : fhs[0]
+            let client = ContainerClient()
+            let fhs = try await client.logs(id: containerId)
+            let fileHandle = boot ? fhs[1] : fhs[0]
 
-                try await Self.tail(
-                    fh: fileHandle,
-                    n: numLines,
-                    follow: follow
-                )
-            } catch {
-                throw ContainerizationError(
-                    .invalidArgument,
-                    message: "failed to fetch container logs for \(containerId): \(error)"
-                )
-            }
+            try await Self.tail(
+                fh: fileHandle,
+                n: numLines,
+                follow: follow
+            )
         }
 
         private static func tail(

--- a/Sources/ContainerCommands/Container/ContainerPrune.swift
+++ b/Sources/ContainerCommands/Container/ContainerPrune.swift
@@ -32,16 +32,17 @@ extension Application {
         public var logOptions: Flags.Logging
 
         public func run() async throws {
-            let containersToPrune = try await ClientContainer.list().filter { $0.status == .stopped }
+            let client = ContainerClient()
+            let containersToPrune = try await client.list().filter { $0.status == .stopped }
 
             var prunedContainerIds = [String]()
             var totalSize: UInt64 = 0
 
             for container in containersToPrune {
                 do {
-                    let actualSize = try await ClientContainer.containerDiskUsage(id: container.id)
+                    let actualSize = try await client.diskUsage(id: container.id)
                     totalSize += actualSize
-                    try await container.delete()
+                    try await client.delete(id: container.id)
                     prunedContainerIds.append(container.id)
                 } catch {
                     log.error("Failed to prune container \(container.id): \(error)")

--- a/Sources/ContainerCommands/Container/ContainerStats.swift
+++ b/Sources/ContainerCommands/Container/ContainerStats.swift
@@ -62,15 +62,16 @@ extension Application {
         }
 
         private func runStatic() async throws {
-            let allContainers = try await ClientContainer.list()
+            let client = ContainerClient()
+            let allContainers = try await client.list()
 
-            let containersToShow: [ClientContainer]
+            let containersToShow: [ContainerSnapshot]
             if containers.isEmpty {
                 // No containers specified - show all running containers
                 containersToShow = allContainers.filter { $0.status == .running }
             } else {
                 // Validate all specified containers exist before proceeding
-                var found: [ClientContainer] = []
+                var found: [ContainerSnapshot] = []
                 for containerId in containers {
                     guard let container = allContainers.first(where: { $0.id == containerId || $0.id.starts(with: containerId) }) else {
                         throw ContainerizationError(
@@ -83,7 +84,7 @@ extension Application {
                 containersToShow = found
             }
 
-            let statsData = try await collectStats(for: containersToShow)
+            let statsData = try await collectStats(client: client, for: containersToShow)
 
             if format == .json {
                 let jsonStats = statsData.map { $0.stats2 }
@@ -96,9 +97,11 @@ extension Application {
         }
 
         private func runStreaming() async throws {
+            let client = ContainerClient()
+
             // If containers were specified, validate they all exist upfront
             if !containers.isEmpty {
-                let allContainers = try await ClientContainer.list()
+                let allContainers = try await client.list()
                 for containerId in containers {
                     guard allContainers.first(where: { $0.id == containerId || $0.id.starts(with: containerId) }) != nil else {
                         throw ContainerizationError(
@@ -115,13 +118,13 @@ extension Application {
 
             while true {
                 do {
-                    let allContainers = try await ClientContainer.list()
+                    let allContainers = try await client.list()
 
-                    let containersToShow: [ClientContainer]
+                    let containersToShow: [ContainerSnapshot]
                     if containers.isEmpty {
                         containersToShow = allContainers.filter { $0.status == .running }
                     } else {
-                        var found: [ClientContainer] = []
+                        var found: [ContainerSnapshot] = []
                         for containerId in containers {
                             if let container = allContainers.first(where: { $0.id == containerId || $0.id.starts(with: containerId) }) {
                                 found.append(container)
@@ -130,7 +133,7 @@ extension Application {
                         containersToShow = found
                     }
 
-                    let statsData = try await collectStats(for: containersToShow)
+                    let statsData = try await collectStats(client: client, for: containersToShow)
 
                     // Clear screen and reprint
                     clearScreen()
@@ -148,19 +151,19 @@ extension Application {
         }
 
         private struct StatsSnapshot {
-            let container: ClientContainer
+            let container: ContainerSnapshot
             let stats1: ContainerResource.ContainerStats
             let stats2: ContainerResource.ContainerStats
         }
 
-        private func collectStats(for containers: [ClientContainer]) async throws -> [StatsSnapshot] {
+        private func collectStats(client: ContainerClient, for containers: [ContainerSnapshot]) async throws -> [StatsSnapshot] {
             var snapshots: [StatsSnapshot] = []
 
             // First sample
             for container in containers {
                 guard container.status == .running else { continue }
                 do {
-                    let stats1 = try await container.stats()
+                    let stats1 = try await client.stats(id: container.id)
                     snapshots.append(StatsSnapshot(container: container, stats1: stats1, stats2: stats1))
                 } catch {
                     // Skip containers that error out
@@ -175,7 +178,7 @@ extension Application {
                 // Second sample
                 for i in 0..<snapshots.count {
                     do {
-                        let stats2 = try await snapshots[i].container.stats()
+                        let stats2 = try await client.stats(id: snapshots[i].container.id)
                         snapshots[i] = StatsSnapshot(
                             container: snapshots[i].container,
                             stats1: snapshots[i].stats1,

--- a/Sources/ContainerCommands/Container/ProcessUtils.swift
+++ b/Sources/ContainerCommands/Container/ProcessUtils.swift
@@ -15,13 +15,14 @@
 //===----------------------------------------------------------------------===//
 
 import ContainerAPIClient
+import ContainerResource
 import Containerization
 import ContainerizationError
 import ContainerizationOS
 import Foundation
 
 extension Application {
-    static func ensureRunning(container: ClientContainer) throws {
+    static func ensureRunning(container: ContainerSnapshot) throws {
         if container.status != .running {
             throw ContainerizationError(.invalidState, message: "container \(container.id) is not running")
         }

--- a/Sources/ContainerCommands/Image/ImagePrune.swift
+++ b/Sources/ContainerCommands/Image/ImagePrune.swift
@@ -38,7 +38,8 @@ extension Application {
             let imagesToPrune: [ClientImage]
             if all {
                 // Find all images not used by any container
-                let containers = try await ClientContainer.list()
+                let client = ContainerClient()
+                let containers = try await client.list()
                 var imagesInUse = Set<String>()
                 for container in containers {
                     imagesInUse.insert(container.configuration.image.reference)

--- a/Sources/ContainerCommands/Network/NetworkPrune.swift
+++ b/Sources/ContainerCommands/Network/NetworkPrune.swift
@@ -30,7 +30,8 @@ extension Application.NetworkCommand {
         public var logOptions: Flags.Logging
 
         public func run() async throws {
-            let allContainers = try await ClientContainer.list()
+            let client = ContainerClient()
+            let allContainers = try await client.list()
             let allNetworks = try await ClientNetwork.list()
 
             var networksInUse = Set<String>()

--- a/Sources/ContainerCommands/Volume/VolumePrune.swift
+++ b/Sources/ContainerCommands/Volume/VolumePrune.swift
@@ -32,7 +32,8 @@ extension Application.VolumeCommand {
             let allVolumes = try await ClientVolume.list()
 
             // Find all volumes not used by any container
-            let containers = try await ClientContainer.list()
+            let client = ContainerClient()
+            let containers = try await client.list()
             var volumesInUse = Set<String>()
             for container in containers {
                 for mount in container.configuration.mounts {

--- a/Sources/ContainerResource/Container/ContainerSnapshot.swift
+++ b/Sources/ContainerResource/Container/ContainerSnapshot.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerizationOCI
 import Foundation
 
 /// A snapshot of a container along with its configuration
@@ -21,6 +22,17 @@ import Foundation
 public struct ContainerSnapshot: Codable, Sendable {
     /// The configuration of the container.
     public var configuration: ContainerConfiguration
+
+    /// Identifier of the container.
+    public var id: String {
+        configuration.id
+    }
+
+    /// Configured platform for the container.
+    public var platform: ContainerizationOCI.Platform {
+        configuration.platform
+    }
+
     /// The runtime status of the container.
     public var status: RuntimeStatus
     /// Network interfaces attached to the sandbox that are provided to the container.

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -446,8 +446,11 @@ public actor ContainersService {
         self.log.debug("\(#function)")
 
         // Logs doesn't care if the container is running or not, just that
-        // the bundle is there, and that the files actually exist.
+        // the bundle is there, and that the files actually exist. We do
+        // first try and get the container state so we get a nicer error message
+        // (container foo not found) however.
         do {
+            _ = try _getContainerState(id: id)
             let path = self.containerRoot.appendingPathComponent(id)
             let bundle = ContainerResource.Bundle(path: path)
             return [


### PR DESCRIPTION
ClientContainer was honestly extremely awkward. It could only be created by passing either a ContainerConfiguration, or a Snapshot that had to be obtained from calling a static method on the type itself. The type also did not store a connection, so every single method got a new xpc connection to the APIServer. This change aims to rework this type to be just a generic client, that is *not* a client for one specific container, but for any.

- Rename to ContainerClient
- Have list() return [ContainerSnapshot]
- Create a connection in the constructor
- Change all the callsites to use the new API
- Small, somewhat related, change to logs API in the APIServer. Now that we don't need to call get() to grab a client anymore which was typically what did "does this container exist" logic and gave a nice error message, I added a small check in the APIServer to see if the container exists and return mostly the same error message.