### PR TITLE
[Docs] Fix typo in BUILDING.md: launchd -> launchctl

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -137,7 +137,7 @@ Attach debugger to the XPC helpers using their launchd service labels:
    % container system start
    % container run -d --name test debian:bookworm sleep infinity
    test
-   % launchd list | grep container
+   % launchctl list | grep container
    27068   0       com.apple.container.container-network-vmnet.default
    27072   0       com.apple.container.container-core-images
    26980   0       com.apple.container.apiserver


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context
The debug instructions in `BUILDING.md` incorrectly reference launchd list instead of `launchctl` list. `launchd` is the daemon itself and cannot be invoked directly.

## Testing
- [ ] Tested locally
- [ ] Added/updated tests
- [x] Added/updated docs
