### PR TITLE
feat: add cluster cli tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,11 +62,11 @@ cli:
 	@echo Building container CLI...
 	@$(SWIFT) --version
 	@$(SWIFT) build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --product container
-	@$(SWIFT) build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --product kubernetes
+	@$(SWIFT) build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --product cluster
 	@echo Installing container CLI to bin/...
 	@mkdir -p bin
 	@install "$(BUILD_BIN_DIR)/container" "bin/container"
-	@install "$(BUILD_BIN_DIR)/kubernetes" "bin/kubernetes"
+	@install "$(BUILD_BIN_DIR)/cluster" "bin/cluster"
 
 .PHONY: container
 # Install binaries under project directory
@@ -102,7 +102,7 @@ $(STAGING_DIR):
 	@mkdir -p "$(join $(STAGING_DIR), libexec/container/plugins/container-core-images/bin)"
 
 	@install "$(BUILD_BIN_DIR)/container" "$(join $(STAGING_DIR), bin/container)"
-	@install "$(BUILD_BIN_DIR)/kubernetes" "$(join $(STAGING_DIR), bin/kubernetes)"
+	@install "$(BUILD_BIN_DIR)/cluster" "$(join $(STAGING_DIR), bin/cluster)"
 	@install "$(BUILD_BIN_DIR)/container-apiserver" "$(join $(STAGING_DIR), bin/container-apiserver)"
 	@install "$(BUILD_BIN_DIR)/container-runtime-linux" "$(join $(STAGING_DIR), libexec/container/plugins/container-runtime-linux/bin/container-runtime-linux)"
 	@install config/container-runtime-linux-config.json "$(join $(STAGING_DIR), libexec/container/plugins/container-runtime-linux/config.json)"
@@ -118,7 +118,7 @@ $(STAGING_DIR):
 installer-pkg: $(STAGING_DIR)
 	@echo Signing container binaries...
 	@codesign $(CODESIGN_OPTS) --identifier com.apple.container.cli "$(join $(STAGING_DIR), bin/container)"
-	@codesign $(CODESIGN_OPTS) --identifier com.apple.kubernetes.cli "$(join $(STAGING_DIR), bin/kubernetes)"
+	@codesign $(CODESIGN_OPTS) --identifier com.apple.cluster.cli "$(join $(STAGING_DIR), bin/cluster)"
 	@codesign $(CODESIGN_OPTS) --identifier com.apple.container.apiserver "$(join $(STAGING_DIR), bin/container-apiserver)"
 	@codesign $(CODESIGN_OPTS) --prefix=com.apple.container. "$(join $(STAGING_DIR), libexec/container/plugins/container-core-images/bin/container-core-images)"
 	@codesign $(CODESIGN_OPTS) --prefix=com.apple.container. --entitlements=signing/container-runtime-linux.entitlements "$(join $(STAGING_DIR), libexec/container/plugins/container-runtime-linux/bin/container-runtime-linux)"
@@ -138,7 +138,7 @@ dsym:
 	@cp -a "$(BUILD_BIN_DIR)/container-core-images.dSYM" "$(DSYM_DIR)"
 	@cp -a "$(BUILD_BIN_DIR)/container-apiserver.dSYM" "$(DSYM_DIR)"
 	@cp -a "$(BUILD_BIN_DIR)/container.dSYM" "$(DSYM_DIR)"
-	@cp -a "$(BUILD_BIN_DIR)/kubernetes.dSYM" "$(DSYM_DIR)"
+	@cp -a "$(BUILD_BIN_DIR)/cluster.dSYM" "$(DSYM_DIR)"
 
 	@echo Packaging the debug symbols...
 	@(cd "$(dir $(DSYM_DIR))" ; zip -r $(notdir $(DSYM_PATH)) $(notdir $(DSYM_DIR)))

--- a/Package.swift
+++ b/Package.swift
@@ -42,6 +42,7 @@ let package = Package(
         .library(name: "ContainerPlugin", targets: ["ContainerPlugin"]),
         .library(name: "ContainerVersion", targets: ["ContainerVersion"]),
         .library(name: "ContainerXPC", targets: ["ContainerXPC"]),
+        .library(name: "ClusterCommands", targets: ["ClusterCommands"]),
         .library(name: "SocketForwarder", targets: ["SocketForwarder"]),
         .library(name: "TerminalProgress", targets: ["TerminalProgress"]),
     ],
@@ -67,6 +68,14 @@ let package = Package(
                 "ContainerCommands",
             ],
             path: "Sources/CLI"
+        ),
+        .executableTarget(
+            name: "cluster",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                "ClusterCommands",
+            ],
+            path: "Sources/ClusterCLI"
         ),
         .testTarget(
             name: "CLITests",
@@ -101,6 +110,26 @@ let package = Package(
                 "TerminalProgress",
             ],
             path: "Sources/ContainerCommands"
+        ),
+        .target(
+            name: "ClusterCommands",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "Containerization", package: "containerization"),
+                "ContainerAPIClient",
+                "ContainerLog",
+                "ContainerResource",
+                "TerminalProgress",
+            ],
+            path: "Sources/ClusterCommands"
+        ),
+        .testTarget(
+            name: "ClusterTests",
+            dependencies: [
+                "ClusterCommands"
+            ],
+            path: "Tests/ClusterTests"
         ),
         .target(
             name: "ContainerBuild",

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # `container`
 
+> [!NOTE]
+> This fork also ships a `cluster` CLI for running a single-node Kubernetes cluster on Apple Containerization. The standard `container` installer package includes the `cluster` CLI. See `docs/cluster.md`.
+
 `container` is a tool that you can use to create and run Linux containers as lightweight virtual machines on your Mac. It's written in Swift, and optimized for Apple silicon.
 
 The tool consumes and produces [OCI-compatible container images](https://github.com/opencontainers/image-spec), so you can pull and run images from any standard container registry. You can push images that you build to those registries as well, and run the images in any other OCI-compatible application.
 
 `container` uses the [Containerization](https://github.com/apple/containerization) Swift package for low level container, image, and process management.
 
-This fork also ships a `kubernetes` CLI for running a single-node Kubernetes cluster on Apple Containerization. See `docs/kubernetes.md`.
 
 ![introductory movie showing some basic commands](./docs/assets/landing-movie.gif)
 

--- a/Sources/ClusterCLI/ClusterCLI.swift
+++ b/Sources/ClusterCLI/ClusterCLI.swift
@@ -15,23 +15,23 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
-import KubernetesCommands
+import ClusterCommands
 
 @main
-public struct KubernetesCLI: AsyncParsableCommand {
+public struct ClusterCLI: AsyncParsableCommand {
     public init() {}
 
     @Argument(parsing: .captureForPassthrough)
     var arguments: [String] = []
 
-    public static let configuration = KubernetesApplication.configuration
+    public static let configuration = ClusterApplication.configuration
 
     public static func main() async throws {
-        try await KubernetesApplication.main()
+        try await ClusterApplication.main()
     }
 
     public func run() async throws {
-        var application = try KubernetesApplication.parse(arguments)
+        var application = try ClusterApplication.parse(arguments)
         try application.run()
     }
 }

--- a/Sources/ClusterCommands/ClusterApplication.swift
+++ b/Sources/ClusterCommands/ClusterApplication.swift
@@ -17,22 +17,23 @@
 import ArgumentParser
 import ContainerVersion
 import ContainerizationError
+import Darwin
 import TerminalProgress
 
-public struct KubernetesApplication: AsyncParsableCommand {
+public struct ClusterApplication: AsyncParsableCommand {
     public init() {}
 
     public static let configuration = CommandConfiguration(
-        commandName: "kubernetes",
+        commandName: "cluster",
         abstract: "Kubernetes clusters on Apple Containerization",
-        version: ReleaseVersion.singleLine(appName: "kubernetes CLI"),
+        version: ReleaseVersion.singleLine(appName: "cluster CLI"),
         subcommands: [
-            KubernetesCreate.self,
-            KubernetesDelete.self,
-            KubernetesStart.self,
-            KubernetesStop.self,
-            KubernetesStatus.self,
-            KubernetesKubeconfig.self,
+            ClusterCreate.self,
+            ClusterDelete.self,
+            ClusterStart.self,
+            ClusterStop.self,
+            ClusterStatus.self,
+            ClusterKubeconfig.self,
         ]
     )
 
@@ -43,7 +44,7 @@ public struct KubernetesApplication: AsyncParsableCommand {
         let args = Array(fullArgs.dropFirst())
 
         do {
-            var command = try KubernetesApplication.parseAsRoot(args)
+            var command = try ClusterApplication.parseAsRoot(args)
             if var asyncCommand = command as? AsyncParsableCommand {
                 try await asyncCommand.run()
             } else {
@@ -56,9 +57,9 @@ public struct KubernetesApplication: AsyncParsableCommand {
                     .interrupted,
                     message: "\(error)\nEnsure container system service has been started with `container system start`."
                 )
-                KubernetesApplication.exit(withError: modifiedError)
+                ClusterApplication.exit(withError: modifiedError)
             } else {
-                KubernetesApplication.exit(withError: error)
+                ClusterApplication.exit(withError: error)
             }
         }
     }
@@ -66,7 +67,7 @@ public struct KubernetesApplication: AsyncParsableCommand {
     private static func restoreCursorAtExit() {
         let signalHandler: @convention(c) (Int32) -> Void = { signal in
             let exitCode = ExitCode(signal + 128)
-            KubernetesApplication.exit(withError: exitCode)
+            ClusterApplication.exit(withError: exitCode)
         }
         signal(SIGINT, signalHandler)
         signal(SIGTERM, signalHandler)

--- a/Sources/ClusterCommands/ClusterSupport.swift
+++ b/Sources/ClusterCommands/ClusterSupport.swift
@@ -19,7 +19,7 @@ import ContainerizationError
 import Foundation
 import Logging
 
-enum KubernetesDefaults {
+enum ClusterDefaults {
     static let clusterName = "kubernetes"
     static let image = "docker.io/kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a"
     static let memory = "16G"
@@ -71,7 +71,7 @@ enum KubeconfigManager {
         }
         let kubeDir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".kube")
-            .appendingPathComponent("kubernetes", isDirectory: true)
+            .appendingPathComponent("cluster", isDirectory: true)
         return kubeDir.appendingPathComponent("\(clusterName).config")
     }
 
@@ -121,7 +121,7 @@ struct ExecResult: Sendable {
     let exitCode: Int32
 }
 
-enum KubernetesExecutor {
+enum ClusterExecutor {
     static func run(
         container: ClientContainer,
         command: [String],
@@ -185,7 +185,7 @@ enum KubernetesExecutor {
     }
 }
 
-enum KubernetesContainer {
+enum ClusterContainer {
     static func ensureRunning(_ container: ClientContainer) throws {
         if container.status != .running {
             throw ContainerizationError(.invalidState, message: "container \(container.id) is not running")

--- a/Tests/ClusterTests/KubeconfigPatcherTests.swift
+++ b/Tests/ClusterTests/KubeconfigPatcherTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import KubernetesCommands
+@testable import ClusterCommands
 
 final class KubeconfigPatcherTests: XCTestCase {
     func testPatchRewritesServerAndNames() {

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -1,6 +1,6 @@
-# `kubernetes` CLI
+# `cluster` CLI
 
-`kubernetes` is a small companion CLI that creates a single-node Kubernetes
+`cluster` is a small companion CLI that creates a single-node Kubernetes
 cluster inside Apple Containerization, using `kubeadm` and `kindnet`.
 
 ## Requirements
@@ -14,20 +14,20 @@ cluster inside Apple Containerization, using `kubeadm` and `kindnet`.
 
 ```bash
 # Create a cluster named "kubernetes"
-kubernetes create
+cluster create
 
 # Use a custom kernel (recommended for certain CNI features)
-kubernetes create --kernel /path/to/vmlinux
+cluster create --kernel /path/to/vmlinux
 
 # Show status and endpoints
-kubernetes status
+cluster status
 
 # Stop/start the cluster
-kubernetes stop
-kubernetes start
+cluster stop
+cluster start
 
 # Delete the cluster
-kubernetes delete
+cluster delete
 ```
 
 ## Kubeconfig
@@ -35,19 +35,19 @@ kubernetes delete
 By default, kubeconfig is written to:
 
 ```
-~/.kube/kubernetes/<cluster-name>.config
+~/.kube/cluster/<cluster-name>.config
 ```
 
 You can override the path during creation:
 
 ```bash
-kubernetes create --kubeconfig ~/.kube/config
+cluster create --kubeconfig ~/.kube/config
 ```
 
 You can also print a fresh kubeconfig from a running cluster:
 
 ```bash
-kubernetes kubeconfig
+cluster kubeconfig
 ```
 
 ## Flags (create)


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
This updates the fork to ship a dedicated `cluster` CLI for single-node Kubernetes on Apple Containerization, with renamed modules/types and updated docs/README. It also tidies the `cluster create` output to show a curated summary in non-debug runs, and removes the localhost socat forwarding blurb. GitHub release workflows continue using the existing installer artifacts, which already include the `cluster` CLI.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [x] Added/updated docs
