### PR TITLE
Support using multiple different network plugins

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -310,7 +310,6 @@ let package = Package(
                 .product(name: "ContainerizationOS", package: "containerization"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 "ContainerAPIClient",
-                "ContainerNetworkServiceClient",
                 "ContainerPersistence",
                 "ContainerResource",
                 "ContainerSandboxServiceClient",
@@ -322,6 +321,7 @@ let package = Package(
         .target(
             name: "ContainerSandboxServiceClient",
             dependencies: [
+                "ContainerAPIClient",
                 "ContainerResource",
                 "ContainerXPC",
             ],
@@ -330,7 +330,10 @@ let package = Package(
         .target(
             name: "ContainerResource",
             dependencies: [
-                .product(name: "Containerization", package: "containerization")
+                .product(name: "Containerization", package: "containerization"),
+                "ContainerXPC",
+                "CAuditToken",
+                "CVersion",
             ]
         ),
         .testTarget(

--- a/Sources/ContainerCommands/Network/NetworkCreate.swift
+++ b/Sources/ContainerCommands/Network/NetworkCreate.swift
@@ -48,6 +48,12 @@ extension Application {
             })
         var ipv6Subnet: CIDRv6? = nil
 
+        @Option(name: .long, help: "Set the plugin to use to create this network.")
+        var plugin: String = "container-network-vmnet"
+
+        @Option(name: .long, help: "Set the variant of the network plugin to use.")
+        var pluginVariant: String?
+
         @OptionGroup
         public var logOptions: Flags.Logging
 
@@ -64,7 +70,8 @@ extension Application {
                 mode: mode,
                 ipv4Subnet: ipv4Subnet,
                 ipv6Subnet: ipv6Subnet,
-                labels: parsedLabels
+                labels: parsedLabels,
+                pluginInfo: NetworkPluginInfo(plugin: self.plugin, variant: self.pluginVariant)
             )
             let state = try await ClientNetwork.create(configuration: config)
             print(state.id)

--- a/Sources/ContainerResource/Network/AllocatedAttachment.swift
+++ b/Sources/ContainerResource/Network/AllocatedAttachment.swift
@@ -16,10 +16,10 @@
 
 import ContainerXPC
 
-/// AllocatedNetwork represents an allocated network attachment and additional
-/// relevant data needed for a sandbox to properly configure a network interface
-/// on bootstrap.
-public struct AllocatedNetwork: Sendable {
+/// AllocatedAttachment represents a network attachment that has been allocated for use
+/// by a container and any additional relevant data needed for a sandbox to properly
+/// configure networking on container bootstrap.
+public struct AllocatedAttachment: Sendable {
     public let attachment: Attachment
     public let additionalData: XPCMessage?
     public let pluginInfo: NetworkPluginInfo

--- a/Sources/ContainerResource/Network/AllocatedNetwork.swift
+++ b/Sources/ContainerResource/Network/AllocatedNetwork.swift
@@ -14,38 +14,19 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-public enum SandboxKeys: String {
-    /// ID key.
-    case id
-    /// Vsock port number key.
-    case port
-    /// Exit code for a process
-    case exitCode
-    /// Exit timestamp for a process
-    case exitedAt
-    /// FD to a container resource key.
-    case fd
-    /// Options for stopping a container key.
-    case stopOptions
-    /// An endpoint to talk to a sandbox service.
-    case sandboxServiceEndpoint
+import ContainerXPC
 
-    /// Process request keys.
-    case signal
-    case snapshot
-    case stdin
-    case stdout
-    case stderr
-    case width
-    case height
-    case processConfig
+/// AllocatedNetwork represents an allocated network attachment and additional
+/// relevant data needed for a sandbox to properly configure a network interface
+/// on bootstrap.
+public struct AllocatedNetwork: Sendable {
+    public let attachment: Attachment
+    public let additionalData: XPCMessage?
+    public let pluginInfo: NetworkPluginInfo
 
-    /// Container statistics
-    case statistics
-
-    /// Network resource keys.
-    case networkAllocated
-    case networkAdditionalData
-    case networkAttachment
-    case networkPluginInfo
+    public init(attachment: Attachment, additionalData: XPCMessage?, pluginInfo: NetworkPluginInfo) {
+        self.attachment = attachment
+        self.additionalData = additionalData
+        self.pluginInfo = pluginInfo
+    }
 }

--- a/Sources/ContainerResource/Network/Attachment.swift
+++ b/Sources/ContainerResource/Network/Attachment.swift
@@ -16,7 +16,7 @@
 
 import ContainerizationExtras
 
-/// A snapshot of a network interface allocated to a sandbox.
+/// A snapshot of a network interface for a sandbox.
 public struct Attachment: Codable, Sendable {
     /// The network ID associated with the attachment.
     public let network: String

--- a/Sources/ContainerResource/Network/NetworkConfiguration.swift
+++ b/Sources/ContainerResource/Network/NetworkConfiguration.swift
@@ -49,7 +49,9 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
     public var labels: [String: String] = [:]
 
     /// Details about the network plugin that manages this network.
-    public var pluginInfo: NetworkPluginInfo
+    /// FIXME: This field only needs to be optional while we wait for the field
+    /// to be proliferated to most users when they update container.
+    public var pluginInfo: NetworkPluginInfo?
 
     /// Creates a network configuration
     public init(
@@ -97,7 +99,7 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
         ipv6Subnet = try container.decodeIfPresent(String.self, forKey: .ipv6Subnet)
             .map { try CIDRv6($0) }
         labels = try container.decodeIfPresent([String: String].self, forKey: .labels) ?? [:]
-        pluginInfo = try container.decode(NetworkPluginInfo.self, forKey: .pluginInfo)
+        pluginInfo = try container.decodeIfPresent(NetworkPluginInfo.self, forKey: .pluginInfo)
         try validate()
     }
 
@@ -111,7 +113,7 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
         try container.encodeIfPresent(ipv4Subnet, forKey: .ipv4Subnet)
         try container.encodeIfPresent(ipv6Subnet, forKey: .ipv6Subnet)
         try container.encode(labels, forKey: .labels)
-        try container.encode(pluginInfo, forKey: .pluginInfo)
+        try container.encodeIfPresent(pluginInfo, forKey: .pluginInfo)
     }
 
     private func validate() throws {

--- a/Sources/ContainerResource/Network/NetworkConfiguration.swift
+++ b/Sources/ContainerResource/Network/NetworkConfiguration.swift
@@ -18,6 +18,16 @@ import ContainerizationError
 import ContainerizationExtras
 import Foundation
 
+public struct NetworkPluginInfo: Codable, Sendable, Hashable {
+    public let plugin: String
+    public let variant: String?
+
+    public init(plugin: String, variant: String? = nil) {
+        self.plugin = plugin
+        self.variant = variant
+    }
+}
+
 /// Configuration parameters for network creation.
 public struct NetworkConfiguration: Codable, Sendable, Identifiable {
     /// A unique identifier for the network
@@ -38,13 +48,17 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
     /// Key-value labels for the network.
     public var labels: [String: String] = [:]
 
+    /// Details about the network plugin that manages this network.
+    public var pluginInfo: NetworkPluginInfo
+
     /// Creates a network configuration
     public init(
         id: String,
         mode: NetworkMode,
         ipv4Subnet: CIDRv4? = nil,
         ipv6Subnet: CIDRv6? = nil,
-        labels: [String: String] = [:]
+        labels: [String: String] = [:],
+        pluginInfo: NetworkPluginInfo,
     ) throws {
         self.id = id
         self.creationDate = Date()
@@ -52,6 +66,7 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
         self.ipv4Subnet = ipv4Subnet
         self.ipv6Subnet = ipv6Subnet
         self.labels = labels
+        self.pluginInfo = pluginInfo
         try validate()
     }
 
@@ -62,6 +77,7 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
         case ipv4Subnet
         case ipv6Subnet
         case labels
+        case pluginInfo
         // TODO: retain for deserialization compatability for now, remove later
         case subnet
     }
@@ -81,6 +97,7 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
         ipv6Subnet = try container.decodeIfPresent(String.self, forKey: .ipv6Subnet)
             .map { try CIDRv6($0) }
         labels = try container.decodeIfPresent([String: String].self, forKey: .labels) ?? [:]
+        pluginInfo = try container.decode(NetworkPluginInfo.self, forKey: .pluginInfo)
         try validate()
     }
 
@@ -94,6 +111,7 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
         try container.encodeIfPresent(ipv4Subnet, forKey: .ipv4Subnet)
         try container.encodeIfPresent(ipv6Subnet, forKey: .ipv6Subnet)
         try container.encode(labels, forKey: .labels)
+        try container.encode(pluginInfo, forKey: .pluginInfo)
     }
 
     private func validate() throws {

--- a/Sources/ContainerResource/Network/NetworkState.swift
+++ b/Sources/ContainerResource/Network/NetworkState.swift
@@ -73,7 +73,7 @@ public enum NetworkState: Codable, Sendable {
         }
     }
 
-    public var pluginInfo: NetworkPluginInfo {
+    public var pluginInfo: NetworkPluginInfo? {
         switch self {
         case .created(let configuration), .running(let configuration, _): configuration.pluginInfo
         }

--- a/Sources/ContainerResource/Network/NetworkState.swift
+++ b/Sources/ContainerResource/Network/NetworkState.swift
@@ -72,4 +72,10 @@ public enum NetworkState: Codable, Sendable {
         case .created(let config), .running(let config, _): config.labels.isBuiltin
         }
     }
+
+    public var pluginInfo: NetworkPluginInfo {
+        switch self {
+        case .created(let configuration), .running(let configuration, _): configuration.pluginInfo
+        }
+    }
 }

--- a/Sources/ContainerXPC/XPCMessage.swift
+++ b/Sources/ContainerXPC/XPCMessage.swift
@@ -269,6 +269,12 @@ extension XPCMessage {
         }
     }
 
+    public func set(key: String, xpcDictionary: xpc_object_t) {
+        lock.withLock {
+            xpc_dictionary_set_value(self.object, key, xpcDictionary)
+        }
+    }
+
     public func endpoint(key: String) -> xpc_endpoint_t? {
         lock.withLock {
             xpc_dictionary_get_value(self.object, key)

--- a/Sources/Helpers/APIServer/APIServer+Start.swift
+++ b/Sources/Helpers/APIServer/APIServer+Start.swift
@@ -67,6 +67,7 @@ extension APIServer {
                     log: log,
                     routes: &routes
                 )
+                await containersService.setNetworksService(networkService)
                 initializeHealthCheckService(log: log, routes: &routes)
                 try initializeKernelService(log: log, routes: &routes)
                 let volumesService = try initializeVolumeService(containersService: containersService, log: log, routes: &routes)
@@ -269,10 +270,12 @@ extension APIServer {
                 .filter { $0.isBuiltin }
                 .first
             if defaultNetwork == nil {
+                // FIXME: default network should be configurable elsewhere
                 let config = try NetworkConfiguration(
                     id: ClientNetwork.defaultNetworkName,
                     mode: .nat,
-                    labels: [ResourceLabelKeys.role: ResourceRoleValues.builtin]
+                    labels: [ResourceLabelKeys.role: ResourceRoleValues.builtin],
+                    pluginInfo: NetworkPluginInfo(plugin: "container-network-vmnet")
                 )
                 _ = try await service.create(configuration: config)
             }

--- a/Sources/Helpers/NetworkVmnet/NetworkVmnetHelper+Start.swift
+++ b/Sources/Helpers/NetworkVmnet/NetworkVmnetHelper+Start.swift
@@ -76,11 +76,17 @@ extension NetworkVmnetHelper {
                 log.info("configuring XPC server")
                 let ipv4Subnet = try self.ipv4Subnet.map { try CIDRv4($0) }
                 let ipv6Subnet = try self.ipv6Subnet.map { try CIDRv6($0) }
+                let pluginInfo = NetworkPluginInfo(
+                    plugin: NetworkVmnetHelper._commandName,
+                    variant: self.variant.rawValue
+                )
+
                 let configuration = try NetworkConfiguration(
                     id: id,
                     mode: mode,
                     ipv4Subnet: ipv4Subnet,
                     ipv6Subnet: ipv6Subnet,
+                    pluginInfo: pluginInfo
                 )
                 let network = try Self.createNetwork(
                     configuration: configuration,

--- a/Sources/Services/ContainerAPIService/Client/ClientNetwork.swift
+++ b/Sources/Services/ContainerAPIService/Client/ClientNetwork.swift
@@ -17,6 +17,7 @@
 import ContainerResource
 import ContainerXPC
 import ContainerizationError
+import ContainerizationExtras
 import ContainerizationOS
 import Foundation
 
@@ -81,10 +82,10 @@ extension ClientNetwork {
 
     /// Delete the network with the given id.
     public static func delete(id: String) async throws {
-        let client = XPCClient(service: Self.serviceIdentifier)
+        let client = Self.newClient()
         let request = XPCMessage(route: .networkDelete)
         request.set(key: .networkId, value: id)
-        try await client.send(request)
+        let _ = try await xpcSend(client: client, message: request)
     }
 
     /// Retrieve the builtin network.

--- a/Sources/Services/ContainerAPIService/Server/Networks/NetworksService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Networks/NetworksService.swift
@@ -19,6 +19,7 @@ import ContainerNetworkServiceClient
 import ContainerPersistence
 import ContainerPlugin
 import ContainerResource
+import ContainerXPC
 import Containerization
 import ContainerizationError
 import ContainerizationExtras
@@ -27,15 +28,22 @@ import Foundation
 import Logging
 
 public actor NetworksService {
+    struct NetworkServiceState {
+        var networkState: NetworkState
+        var client: NetworkClient
+    }
+
     private let pluginLoader: PluginLoader
     private let resourceRoot: URL
     private let containersService: ContainersService
     private let log: Logger
 
     private let store: FilesystemEntityStore<NetworkConfiguration>
-    private let networkPlugin: Plugin
-    private var networkStates = [String: NetworkState]()
+    private let networkPlugins: [Plugin]
     private var busyNetworks = Set<String>()
+
+    private let stateLock = AsyncLock()
+    private var serviceStates = [String: NetworkServiceState]()
 
     public init(
         pluginLoader: PluginLoader,
@@ -55,15 +63,14 @@ public actor NetworksService {
             log: log
         )
 
-        let networkPlugin =
+        let networkPlugins =
             pluginLoader
             .findPlugins()
             .filter { $0.hasType(.network) }
-            .first
-        guard let networkPlugin else {
-            throw ContainerizationError(.internalError, message: "cannot find network plugin")
+        guard !networkPlugins.isEmpty else {
+            throw ContainerizationError(.internalError, message: "cannot find any plugins with type network")
         }
-        self.networkPlugin = networkPlugin
+        self.networkPlugins = networkPlugins
 
         let configurations = try await store.list()
         for var configuration in configurations {
@@ -81,29 +88,41 @@ public actor NetworksService {
                 try await registerService(configuration: configuration)
             } catch {
                 log.error(
-                    "failed to start network",
+                    "failed to start network: \(error)",
                     metadata: [
                         "id": "\(configuration.id)"
                     ])
             }
 
-            let client = NetworkClient(id: configuration.id)
-            let networkState = try await client.state()
+            let client = Self.getClient(configuration: configuration)
+            var networkState = try await client.state()
 
             // FIXME: Temporary workaround for persisted configuration being overwritten
             // by what comes back from the network helper, which messes up creationDate.
+            // FIXME: Temporarily need to override the plugin information with the info from
+            // the helper, so we can ensure that older networks get a variant value.
+            var finalConfig = configuration
             switch networkState {
-            case .created(_):
-                networkStates[configuration.id] = NetworkState.created(configuration)
-            case .running(_, let status):
-                networkStates[configuration.id] = NetworkState.running(configuration, status)
+            case .created(let helperConfig):
+                finalConfig.pluginInfo = helperConfig.pluginInfo
+                networkState = NetworkState.created(finalConfig)
+            case .running(let helperConfig, let status):
+                finalConfig.pluginInfo = helperConfig.pluginInfo
+                networkState = NetworkState.running(finalConfig, status)
             }
+
+            let state = NetworkServiceState(
+                networkState: networkState,
+                client: client
+            )
+
+            serviceStates[finalConfig.id] = state
 
             guard case .running = networkState else {
                 log.error(
                     "network failed to start",
                     metadata: [
-                        "id": "\(configuration.id)",
+                        "id": "\(finalConfig.id)",
                         "state": "\(networkState.state)",
                     ])
                 return
@@ -114,8 +133,8 @@ public actor NetworksService {
     /// List all networks registered with the service.
     public func list() async throws -> [NetworkState] {
         log.info("network service: list")
-        return networkStates.reduce(into: [NetworkState]()) {
-            $0.append($1.value)
+        return serviceStates.reduce(into: [NetworkState]()) {
+            $0.append($1.value.networkState)
         }
     }
 
@@ -141,41 +160,45 @@ public actor NetworksService {
         defer { busyNetworks.remove(configuration.id) }
 
         // Ensure the network doesn't already exist.
-        guard networkStates[configuration.id] == nil else {
-            throw ContainerizationError(.exists, message: "network \(configuration.id) already exists")
-        }
-
-        // Create and start the network.
-        try await registerService(configuration: configuration)
-        let client = NetworkClient(id: configuration.id)
-
-        // Ensure the network is running, and set up the persistent network state
-        // using our configuration data, as the one from the helper doesn't include
-        // metadata.
-        guard case .running(_, let status) = try await client.state() else {
-            throw ContainerizationError(.invalidState, message: "network \(configuration.id) failed to start")
-        }
-        let networkState: NetworkState = .running(configuration, status)
-        networkStates[configuration.id] = networkState
-
-        // Persist the configuration data.
-        do {
-            try await store.create(configuration)
-            return networkState
-        } catch {
-            networkStates.removeValue(forKey: configuration.id)
-            do {
-                try pluginLoader.deregisterWithLaunchd(plugin: networkPlugin, instanceId: configuration.id)
-            } catch {
-                log.error(
-                    "failed to deregister network service after failed creation",
-                    metadata: [
-                        "id": "\(configuration.id)",
-                        "error": "\(error.localizedDescription)",
-                    ])
+        return try await self.stateLock.withLock { _ in
+            guard await self.serviceStates[configuration.id] == nil else {
+                throw ContainerizationError(.exists, message: "network \(configuration.id) already exists")
             }
 
-            throw error
+            // Create and start the network.
+            try await self.registerService(configuration: configuration)
+            let client = Self.getClient(configuration: configuration)
+
+            // Ensure the network is running, and set up the persistent network state
+            // using our configuration data
+            guard case .running(let helperConfig, let status) = try await client.state() else {
+                throw ContainerizationError(.invalidState, message: "network \(configuration.id) failed to start")
+            }
+            var finalConfig = configuration
+            finalConfig.pluginInfo = helperConfig.pluginInfo
+
+            let networkState: NetworkState = .running(finalConfig, status)
+            let serviceState = NetworkServiceState(networkState: networkState, client: client)
+            await self.setServiceState(key: finalConfig.id, value: serviceState)
+
+            // Persist the configuration data.
+            do {
+                try await self.store.create(finalConfig)
+                return networkState
+            } catch {
+                await self.removeServiceState(key: finalConfig.id)
+                do {
+                    try await self.deregisterService(configuration: finalConfig)
+                } catch {
+                    self.log.error(
+                        "failed to deregister network service after failed creation",
+                        metadata: [
+                            "id": "\(finalConfig.id)",
+                            "error": "\(error.localizedDescription)",
+                        ])
+                }
+                throw error
+            }
         }
     }
 
@@ -196,91 +219,123 @@ public actor NetworksService {
                 "id": "\(id)"
             ])
 
-        guard let networkState = networkStates[id] else {
-            throw ContainerizationError(.notFound, message: "no network for id \(id)")
-        }
+        try await stateLock.withLock { _ in
+            guard let serviceState = await self.serviceStates[id] else {
+                throw ContainerizationError(.notFound, message: "no network for id \(id)")
+            }
 
-        // basic sanity checks on network itself
-        if networkState.isBuiltin {
-            throw ContainerizationError(.invalidArgument, message: "cannot delete builtin network: \(id)")
-        }
+            guard case .running(let netConfig, _) = serviceState.networkState else {
+                throw ContainerizationError(.invalidState, message: "cannot delete network \(id) in state \(serviceState.networkState.state)")
+            }
 
-        guard case .running = networkState else {
-            throw ContainerizationError(.invalidState, message: "cannot delete network \(id) in state \(networkState.state)")
-        }
+            // basic sanity checks on network itself
+            if serviceState.networkState.isBuiltin {
+                throw ContainerizationError(.invalidArgument, message: "cannot delete builtin network: \(id)")
+            }
 
-        // prevent container operations while we atomically check and delete
-        try await containersService.withContainerList { containers in
-            // find all containers that refer to the network
-            var referringContainers = Set<String>()
-            for container in containers {
-                for attachmentConfiguration in container.configuration.networks {
-                    if attachmentConfiguration.network == id {
-                        referringContainers.insert(container.configuration.id)
-                        break
+            // prevent container operations while we atomically check and delete
+            try await self.containersService.withContainerList { containers in
+                // find all containers that refer to the network
+                var referringContainers = Set<String>()
+                for container in containers {
+                    for attachmentConfiguration in container.configuration.networks {
+                        if attachmentConfiguration.network == id {
+                            referringContainers.insert(container.configuration.id)
+                            break
+                        }
                     }
+                }
+
+                // bail if any referring containers
+                guard referringContainers.isEmpty else {
+                    throw ContainerizationError(
+                        .invalidState,
+                        message: "cannot delete subnet \(id) with referring containers: \(referringContainers.joined(separator: ", "))"
+                    )
+                }
+
+                // disable the allocator so nothing else can attach
+                // TODO: remove this from the network helper later, not necesssary now that withContainerList is here
+                guard try await serviceState.client.disableAllocator() else {
+                    throw ContainerizationError(.invalidState, message: "cannot delete subnet \(id) because the IP allocator cannot be disabled with active containers")
+                }
+
+                // start network deletion, this is the last place we'll want to throw
+                do {
+                    try await self.deregisterService(configuration: netConfig)
+                } catch {
+                    self.log.error(
+                        "failed to deregister network service",
+                        metadata: [
+                            "id": "\(id)",
+                            "error": "\(error.localizedDescription)",
+                        ])
+                }
+
+                // deletion is underway, do not throw anything now
+                do {
+                    try await self.store.delete(id)
+                } catch {
+                    self.log.error(
+                        "failed to delete network from configuration store",
+                        metadata: [
+                            "id": "\(id)",
+                            "error": "\(error.localizedDescription)",
+                        ])
                 }
             }
 
-            // bail if any referring containers
-            guard referringContainers.isEmpty else {
-                throw ContainerizationError(
-                    .invalidState,
-                    message: "cannot delete subnet \(id) with referring containers: \(referringContainers.joined(separator: ", "))"
-                )
-            }
-
-            // disable the allocator so nothing else can attach
-            // TODO: remove this from the network helper later, not necesssary now that withContainerList is here
-            let client = NetworkClient(id: id)
-            guard try await client.disableAllocator() else {
-                throw ContainerizationError(.invalidState, message: "cannot delete subnet \(id) because the IP allocator cannot be disabled with active containers")
-            }
-
-            // start network deletion, this is the last place we'll want to throw
-            do {
-                try self.pluginLoader.deregisterWithLaunchd(plugin: self.networkPlugin, instanceId: id)
-            } catch {
-                self.log.error(
-                    "failed to deregister network service",
-                    metadata: [
-                        "id": "\(id)",
-                        "error": "\(error.localizedDescription)",
-                    ])
-            }
-
-            // deletion is underway, do not throw anything now
-            do {
-                try await self.store.delete(id)
-            } catch {
-                self.log.error(
-                    "failed to delete network from configuration store",
-                    metadata: [
-                        "id": "\(id)",
-                        "error": "\(error.localizedDescription)",
-                    ])
-            }
+            // having deleted successfully, remove the runtime state
+            await self.removeServiceState(key: id)
         }
-
-        // having deleted successfully, remove the runtime state
-        self.networkStates.removeValue(forKey: id)
     }
 
     /// Perform a hostname lookup on all networks.
     public func lookup(hostname: String) async throws -> Attachment? {
-        for id in networkStates.keys {
-            let client = NetworkClient(id: id)
-            guard let allocation = try await client.lookup(hostname: hostname) else {
-                continue
+        try await self.stateLock.withLock { _ in
+            for state in await self.serviceStates.values {
+                guard let allocation = try await state.client.lookup(hostname: hostname) else {
+                    continue
+                }
+                return allocation
             }
-            return allocation
+            return nil
         }
-        return nil
+    }
+
+    public func allocate(id: String, hostname: String, macAddress: MACAddress?) async throws -> AllocatedNetwork {
+        guard let serviceState = serviceStates[id] else {
+            throw ContainerizationError(.notFound, message: "no network for id \(id)")
+        }
+        let (attach, additionalData) = try await serviceState.client.allocate(hostname: hostname, macAddress: macAddress?.description)
+        return AllocatedNetwork(
+            attachment: attach,
+            additionalData: additionalData,
+            pluginInfo: serviceState.networkState.pluginInfo
+        )
+    }
+
+    public func deallocate(attachment: Attachment) async throws {
+        guard let serviceState = serviceStates[attachment.network] else {
+            throw ContainerizationError(.notFound, message: "no network for id \(attachment.network)")
+        }
+        return try await serviceState.client.deallocate(hostname: attachment.hostname)
+    }
+
+    private static func getClient(configuration: NetworkConfiguration) -> NetworkClient {
+        NetworkClient(id: configuration.id, plugin: configuration.pluginInfo.plugin)
     }
 
     private func registerService(configuration: NetworkConfiguration) async throws {
         guard configuration.mode == .nat || configuration.mode == .hostOnly else {
             throw ContainerizationError(.invalidArgument, message: "unsupported network mode \(configuration.mode.rawValue)")
+        }
+
+        guard let networkPlugin = self.networkPlugins.first(where: { $0.name == configuration.pluginInfo.plugin }) else {
+            throw ContainerizationError(
+                .notFound,
+                message: "unable to locate network plugin \(configuration.pluginInfo.plugin)"
+            )
         }
 
         guard let serviceIdentifier = networkPlugin.getMachService(instanceId: configuration.id, type: .network) else {
@@ -298,8 +353,8 @@ public actor NetworksService {
 
         if let ipv4Subnet = configuration.ipv4Subnet {
             var existingCidrs: [CIDRv4] = []
-            for networkState in networkStates.values {
-                if case .running(_, let status) = networkState {
+            for serviceState in serviceStates.values {
+                if case .running(_, let status) = serviceState.networkState {
                     existingCidrs.append(status.ipv4Subnet)
                 }
             }
@@ -318,8 +373,8 @@ public actor NetworksService {
 
         if let ipv6Subnet = configuration.ipv6Subnet {
             var existingCidrs: [CIDRv6] = []
-            for networkState in networkStates.values {
-                if case .running(_, let status) = networkState, let otherIPv6Subnet = status.ipv6Subnet {
+            for serviceState in serviceStates.values {
+                if case .running(_, let status) = serviceState.networkState, let otherIPv6Subnet = status.ipv6Subnet {
                     existingCidrs.append(otherIPv6Subnet)
                 }
             }
@@ -336,11 +391,35 @@ public actor NetworksService {
             args += ["--subnet-v6", ipv6Subnet.description]
         }
 
+        if let variant = configuration.pluginInfo.variant {
+            args += ["--variant", variant]
+        }
+
         try await pluginLoader.registerWithLaunchd(
             plugin: networkPlugin,
             pluginStateRoot: store.entityUrl(configuration.id),
             args: args,
             instanceId: configuration.id
         )
+    }
+
+    private func deregisterService(configuration: NetworkConfiguration) async throws {
+        guard let networkPlugin = self.networkPlugins.first(where: { $0.name == configuration.pluginInfo.plugin }) else {
+            throw ContainerizationError(
+                .notFound,
+                message: "unable to locate network plugin \(configuration.pluginInfo.plugin)"
+            )
+        }
+        try self.pluginLoader.deregisterWithLaunchd(plugin: networkPlugin, instanceId: configuration.id)
+    }
+}
+
+extension NetworksService {
+    private func removeServiceState(key: String) {
+        self.serviceStates.removeValue(forKey: key)
+    }
+
+    private func setServiceState(key: String, value: NetworkServiceState) {
+        self.serviceStates[key] = value
     }
 }

--- a/Sources/Services/ContainerNetworkService/Client/NetworkClient.swift
+++ b/Sources/Services/ContainerNetworkService/Client/NetworkClient.swift
@@ -55,12 +55,12 @@ extension NetworkClient {
 
     public func allocate(
         hostname: String,
-        macAddress: String? = nil
+        macAddress: MACAddress? = nil
     ) async throws -> (attachment: Attachment, additionalData: XPCMessage?) {
         let request = XPCMessage(route: NetworkRoutes.allocate.rawValue)
         request.set(key: NetworkKeys.hostname.rawValue, value: hostname)
         if let macAddress = macAddress {
-            request.set(key: NetworkKeys.macAddress.rawValue, value: macAddress)
+            request.set(key: NetworkKeys.macAddress.rawValue, value: macAddress.description)
         }
 
         let client = createClient()

--- a/Sources/Services/ContainerNetworkService/Client/NetworkClient.swift
+++ b/Sources/Services/ContainerNetworkService/Client/NetworkClient.swift
@@ -22,18 +22,23 @@ import Foundation
 
 /// A client for interacting with a single network.
 public struct NetworkClient: Sendable {
-    // FIXME: need more flexibility than a hard-coded constant?
-    static let label = "com.apple.container.network.container-network-vmnet"
+    static let label = "com.apple.container.network"
+
+    public static func machServiceLabel(id: String, plugin: String) -> String {
+        "\(Self.label).\(plugin).\(id)"
+    }
 
     private var machServiceLabel: String {
-        "\(Self.label).\(id)"
+        Self.machServiceLabel(id: id, plugin: plugin)
     }
 
     let id: String
+    let plugin: String
 
     /// Create a client for a network.
-    public init(id: String) {
+    public init(id: String, plugin: String) {
         self.id = id
+        self.plugin = plugin
     }
 }
 
@@ -50,12 +55,12 @@ extension NetworkClient {
 
     public func allocate(
         hostname: String,
-        macAddress: MACAddress? = nil
+        macAddress: String? = nil
     ) async throws -> (attachment: Attachment, additionalData: XPCMessage?) {
         let request = XPCMessage(route: NetworkRoutes.allocate.rawValue)
         request.set(key: NetworkKeys.hostname.rawValue, value: hostname)
         if let macAddress = macAddress {
-            request.set(key: NetworkKeys.macAddress.rawValue, value: macAddress.description)
+            request.set(key: NetworkKeys.macAddress.rawValue, value: macAddress)
         }
 
         let client = createClient()

--- a/Sources/Services/ContainerSandboxService/Client/SandboxClient.swift
+++ b/Sources/Services/ContainerSandboxService/Client/SandboxClient.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerAPIClient
 import ContainerResource
 import ContainerXPC
 import Containerization
@@ -76,7 +77,7 @@ public struct SandboxClient: Sendable {
 
 // Runtime Methods
 extension SandboxClient {
-    public func bootstrap(stdio: [FileHandle?]) async throws {
+    public func bootstrap(stdio: [FileHandle?], allocatedNetworks: [AllocatedNetwork]) async throws {
         let request = XPCMessage(route: SandboxRoutes.bootstrap.rawValue)
 
         for (i, h) in stdio.enumerated() {
@@ -96,6 +97,7 @@ extension SandboxClient {
         }
 
         do {
+            try request.setAllocatedNetworks(allocatedNetworks)
             try await self.client.send(request)
         } catch {
             throw ContainerizationError(
@@ -321,5 +323,25 @@ extension XPCMessage {
             )
         }
         return try JSONDecoder().decode(SandboxSnapshot.self, from: data)
+    }
+
+    func setAllocatedNetworks(_ networks: [AllocatedNetwork]) throws {
+        let encoder = JSONEncoder()
+        for net in networks {
+            let xpcObject: xpc_object_t = xpc_dictionary_create_empty()
+            let networkXPC = XPCMessage(object: xpcObject)
+
+            let attachmentEncoded = try encoder.encode(net.attachment)
+            networkXPC.set(key: SandboxKeys.networkAttachment.rawValue, value: attachmentEncoded)
+
+            let pluginInfoEncoded = try encoder.encode(net.pluginInfo)
+            networkXPC.set(key: SandboxKeys.networkPluginInfo.rawValue, value: pluginInfoEncoded)
+
+            if let additionalData = net.additionalData {
+                xpc_dictionary_set_value(networkXPC.underlying, SandboxKeys.networkAdditionalData.rawValue, additionalData.underlying)
+            }
+
+            self.set(key: "\(SandboxKeys.networkAllocated.rawValue)_\(net.attachment.network)", value: networkXPC.underlying)
+        }
     }
 }

--- a/Sources/Services/ContainerSandboxService/Client/SandboxKeys.swift
+++ b/Sources/Services/ContainerSandboxService/Client/SandboxKeys.swift
@@ -44,7 +44,7 @@ public enum SandboxKeys: String {
     case statistics
 
     /// Network resource keys.
-    case networkAllocated
+    case allocatedAttachments
     case networkAdditionalData
     case networkAttachment
     case networkPluginInfo

--- a/Tests/ContainerResourceTests/NetworkConfigurationTest.swift
+++ b/Tests/ContainerResourceTests/NetworkConfigurationTest.swift
@@ -21,9 +21,15 @@ import Testing
 @testable import ContainerResource
 
 struct NetworkConfigurationTest {
+    let defaultNetworkPluginInfo = NetworkPluginInfo(plugin: "container-network-vmnet")
+
     @Test func testValidationOkDefaults() throws {
         let id = "foo"
-        _ = try NetworkConfiguration(id: id, mode: .nat)
+        _ = try NetworkConfiguration(
+            id: id,
+            mode: .nat,
+            pluginInfo: defaultNetworkPluginInfo
+        )
     }
 
     @Test func testValidationGoodId() throws {
@@ -38,7 +44,13 @@ struct NetworkConfigurationTest {
                 "foo": "bar",
                 "baz": String(repeating: "0", count: 4096 - "baz".count - "=".count),
             ]
-            _ = try NetworkConfiguration(id: id, mode: .nat, ipv4Subnet: ipv4Subnet, labels: labels)
+            _ = try NetworkConfiguration(
+                id: id,
+                mode: .nat,
+                ipv4Subnet: ipv4Subnet,
+                labels: labels,
+                pluginInfo: defaultNetworkPluginInfo
+            )
         }
     }
 
@@ -56,7 +68,13 @@ struct NetworkConfigurationTest {
                 "baz": String(repeating: "0", count: 4096 - "baz".count - "=".count),
             ]
             #expect {
-                _ = try NetworkConfiguration(id: id, mode: .nat, ipv4Subnet: ipv4Subnet, labels: labels)
+                _ = try NetworkConfiguration(
+                    id: id,
+                    mode: .nat,
+                    ipv4Subnet: ipv4Subnet,
+                    labels: labels,
+                    pluginInfo: defaultNetworkPluginInfo
+                )
             } throws: { error in
                 guard let err = error as? ContainerizationError else { return false }
                 #expect(err.code == .invalidArgument)
@@ -76,7 +94,13 @@ struct NetworkConfigurationTest {
         for labels in allLabels {
             let id = "foo"
             let ipv4Subnet = try CIDRv4("192.168.64.1/24")
-            _ = try NetworkConfiguration(id: id, mode: .nat, ipv4Subnet: ipv4Subnet, labels: labels)
+            _ = try NetworkConfiguration(
+                id: id,
+                mode: .nat,
+                ipv4Subnet: ipv4Subnet,
+                labels: labels,
+                pluginInfo: defaultNetworkPluginInfo
+            )
         }
     }
 
@@ -92,7 +116,13 @@ struct NetworkConfigurationTest {
             let id = "foo"
             let ipv4Subnet = try CIDRv4("192.168.64.1/24")
             #expect {
-                _ = try NetworkConfiguration(id: id, mode: .nat, ipv4Subnet: ipv4Subnet, labels: labels)
+                _ = try NetworkConfiguration(
+                    id: id,
+                    mode: .nat,
+                    ipv4Subnet: ipv4Subnet,
+                    labels: labels,
+                    pluginInfo: defaultNetworkPluginInfo
+                )
             } throws: { error in
                 guard let err = error as? ContainerizationError else { return false }
                 #expect(err.code == .invalidArgument)


### PR DESCRIPTION
## Type of Change
- [x] New feature  
- [x] Breaking change

## Motivation and Context
We want to be able to support using multiple network plugins during `container`'s lifetime. This additionally means needing to pick an interface strategy to interpret a network attachment based on what network plugin was used to create that attachment. This PR will potentially replace https://github.com/apple/container/pull/1081. 

Followups:
- doc updates to include the ability to specify plugin in the network creation cli 

## Testing
- [x] Tested locally
- [x] Added/updated tests