### PR TITLE
Add debugging to the PR labeler CI flow

### DIFF
--- a/.github/workflows/pr-label-apply.yml
+++ b/.github/workflows/pr-label-apply.yml
@@ -29,8 +29,12 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           pattern: pr-metadata-*
           merge-multiple: false
-        continue-on-error: true
         id: download-artifact
+
+      - name: Debug workspace contents 
+        run: |
+          echo "Workspace contents:"
+          ls -R 
       
       - name: Read PR number
         id: pr-number


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context
The PR labeler workflow has been failing for a while but it's difficult to know how to fix it since the PR labeler workflow is run from main (aka NOT the current PR branch) for security reasons. Example at https://github.com/apple/container/actions/runs/21690229300/workflow