### PR TITLE
Fix file path for the PR number in the PR labeler workflow

### DIFF
--- a/.github/workflows/pr-label-apply.yml
+++ b/.github/workflows/pr-label-apply.yml
@@ -30,23 +30,11 @@ jobs:
           pattern: pr-metadata-*
           merge-multiple: false
         id: download-artifact
-
-      - name: Debug workspace contents 
-        run: |
-          echo "Workspace contents:"
-          ls -R 
       
       - name: Read PR number
         id: pr-number
         run: |
-          METADATA_DIR=$(find . -type d -name "pr-metadata-*" 2>/dev/null | head -n 1)
-          
-          if [ -z "$METADATA_DIR" ]; then
-            echo "No metadata found"
-            exit 1
-          fi
-          
-          PR_NUMBER=$(cat "${METADATA_DIR}/pr-number.txt")
+          PR_NUMBER=$(cat "pr-number.txt")
           echo "number=${PR_NUMBER}" >> $GITHUB_OUTPUT
           echo "PR Number: ${PR_NUMBER}"
       


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context
The PR label applier GitHub workflow has been failing for a while. This PR fixes that by correcting the file path we look for when trying to read the PR number. See example failure here https://github.com/apple/container/actions/runs/21691766538/job/62552959972#step:4:23