### PR TITLE
Remove @Suite(.serialized) workaround by fixing network cleanup with retries

### DIFF
--- a/Tests/CLITests/Subcommands/Networks/TestCLINetwork.swift
+++ b/Tests/CLITests/Subcommands/Networks/TestCLINetwork.swift
@@ -58,7 +58,7 @@ class TestCLINetwork: CLITest {
                 } catch {
                     print("Container stop threw error for '\(name)': \(error)")
                 }
-                
+
                 do {
                     let deleteResult = try run(arguments: ["network", "rm", name])
                     if deleteResult.status != 0 {
@@ -231,7 +231,7 @@ class TestCLINetwork: CLITest {
         if result.status != 0 {
             throw CLIError.executionFailed("command failed: \(result.error)")
         }
-        
+
         defer {
             // Proper cleanup order: stop container first, then delete network
             do {
@@ -245,7 +245,7 @@ class TestCLINetwork: CLITest {
             } catch {
                 print("Container stop threw error for '\(name)': \(error)")
             }
-            
+
             do {
                 let deleteResult = try run(arguments: ["network", "rm", name])
                 if deleteResult.status != 0 {
@@ -258,7 +258,7 @@ class TestCLINetwork: CLITest {
                 print("Network cleanup threw error for '\(name)': \(error)")
             }
         }
-        
+
         let port = UInt16.random(in: 50000..<60000)
         try doLongRun(
             name: name,


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Fixes #1124

`TestCLINetwork` was failing intermittently in CI when tests ran in parallel, requiring the `@Suite(.serialized)` workaround to force sequential execution.

**Root Cause:** Tests used `defer { try? ... }` which silently swallowed cleanup errors. When network deletion failed (e.g., container still attached), resources leaked and caused conflicts in parallel tests.

**The fix:** 
- Added `doNetworkDeleteWithRetry()` and `doStopWithRetry()` with exponential backoff (500ms, 1s, 2s)
- Fixed cleanup order: stop containers *before* deleting networks
- Replaced silent `try?` with proper error handling that logs failures to CI
- Removed unsafe force unwraps (`throw error!` → `throw error ?? fallback`)

```swift
// Before: Silent failures, wrong order
defer { _ = try? run(arguments: networkDeleteArgs) }  // Runs second
defer { try? doStop(name: name) }  // Runs first (LIFO)
```
```swift
// After: Proper order, visible errors
defer {
    do {
        try doStopWithRetry(name: name)
        try doNetworkDeleteWithRetry(name: name)
    } catch {
        print("Test cleanup failed for '\(name)': \(error)")
    }
}
```

## Testing
- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
