### PR TITLE
CLI: Forego logging errors on multi-container operations

### DIFF
--- a/Sources/ContainerCommands/AggregateError.swift
+++ b/Sources/ContainerCommands/AggregateError.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// An error type that aggregates multiple errors into one.
+///
+/// When displayed, each underlying error is printed on its own line.
+public struct AggregateError: Swift.Error, Sendable {
+    public let errors: [any Error]
+
+    public init(_ errors: [any Error]) {
+        self.errors = errors
+    }
+}
+
+extension AggregateError: CustomStringConvertible {
+    public var description: String {
+        errors.map { String(describing: $0) }.joined(separator: "\n")
+    }
+}

--- a/Sources/ContainerCommands/Container/ContainerKill.swift
+++ b/Sources/ContainerCommands/Container/ContainerKill.swift
@@ -64,18 +64,17 @@ extension Application {
 
             let signalNumber = try Signals.parseSignal(signal)
 
-            var failed: [String] = []
+            var errors: [any Error] = []
             for container in containers {
                 do {
                     try await client.kill(id: container.id, signal: signalNumber)
                     print(container.id)
                 } catch {
-                    log.error("failed to kill container \(container.id): \(error)")
-                    failed.append(container.id)
+                    errors.append(error)
                 }
             }
-            if failed.count > 0 {
-                throw ContainerizationError(.internalError, message: "kill failed for one or more containers \(failed.joined(separator: ","))")
+            if !errors.isEmpty {
+                throw AggregateError(errors)
             }
         }
     }

--- a/Sources/ContainerCommands/System/SystemStop.swift
+++ b/Sources/ContainerCommands/System/SystemStop.swift
@@ -67,10 +67,11 @@ extension Application {
                     let containers = try await client.list()
                     let signal = try Signals.parseSignal("SIGTERM")
                     let opts = ContainerStopOptions(timeoutInSeconds: Self.stopTimeoutSeconds, signal: signal)
-                    let failed = try await ContainerStop.stopContainers(client: client, containers: containers, stopOptions: opts, log: log)
-                    if !failed.isEmpty {
-                        log.warning("some containers could not be stopped gracefully", metadata: ["ids": "\(failed)"])
-                    }
+                    try await ContainerStop.stopContainers(
+                        client: client,
+                        containers: containers,
+                        stopOptions: opts,
+                    )
                 } catch {
                     log.warning("failed to stop all containers", metadata: ["error": "\(error)"])
                 }


### PR DESCRIPTION
Instead of logging errors, and then additionally throwing an error stating what containers couldn't be stopped/killed/deleted, let's just concatenate the errors and throw the single error.