### PR TITLE
chore: Replace force-unwrapped String(data:encoding:) with String(decoding:as:)

### DIFF
--- a/Sources/ContainerCommands/Builder/BuilderStatus.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStatus.swift
@@ -67,7 +67,7 @@ extension Application {
                     PrintableContainer($0)
                 }
                 let data = try JSONEncoder().encode(printables)
-                print(String(data: data, encoding: .utf8)!)
+                print(String(decoding: data, as: UTF8.self))
 
                 return
             }

--- a/Sources/ContainerCommands/Codable+JSON.swift
+++ b/Sources/ContainerCommands/Codable+JSON.swift
@@ -18,6 +18,6 @@ import Foundation
 
 extension [any Codable] {
     func jsonArray() throws -> String {
-        "[\(try self.map { String(data: try JSONEncoder().encode($0), encoding: .utf8)! }.joined(separator: ","))]"
+        "[\(try self.map { String(decoding: try JSONEncoder().encode($0), as: UTF8.self) }.joined(separator: ","))]"
     }
 }

--- a/Sources/ContainerCommands/Container/ContainerList.swift
+++ b/Sources/ContainerCommands/Container/ContainerList.swift
@@ -58,7 +58,7 @@ extension Application {
                     PrintableContainer($0)
                 }
                 let data = try JSONEncoder().encode(printables)
-                print(String(data: data, encoding: .utf8)!)
+                print(String(decoding: data, as: UTF8.self))
 
                 return
             }

--- a/Sources/ContainerCommands/Container/ContainerStats.swift
+++ b/Sources/ContainerCommands/Container/ContainerStats.swift
@@ -89,7 +89,7 @@ extension Application {
             if format == .json {
                 let jsonStats = statsData.map { $0.stats2 }
                 let data = try JSONEncoder().encode(jsonStats)
-                print(String(data: data, encoding: .utf8)!)
+                print(String(decoding: data, as: UTF8.self))
                 return
             }
 

--- a/Sources/ContainerCommands/Image/ImageList.swift
+++ b/Sources/ContainerCommands/Image/ImageList.swift
@@ -119,7 +119,7 @@ extension Application {
                     )
                 }
                 let data = try JSONEncoder().encode(printableImages)
-                print(String(data: data, encoding: .utf8)!)
+                print(String(decoding: data, as: UTF8.self))
                 return
             }
 

--- a/Sources/ContainerCommands/Network/NetworkList.swift
+++ b/Sources/ContainerCommands/Network/NetworkList.swift
@@ -54,7 +54,7 @@ extension Application {
                     PrintableNetwork($0)
                 }
                 let data = try JSONEncoder().encode(printables)
-                print(String(data: data, encoding: .utf8)!)
+                print(String(decoding: data, as: UTF8.self))
 
                 return
             }

--- a/Sources/ContainerCommands/System/DNS/DNSList.swift
+++ b/Sources/ContainerCommands/System/DNS/DNSList.swift
@@ -50,7 +50,7 @@ extension Application {
         func printDomains(domains: [String], format: ListFormat) throws {
             if format == .json {
                 let data = try JSONEncoder().encode(domains)
-                print(String(data: data, encoding: .utf8)!)
+                print(String(decoding: data, as: UTF8.self))
 
                 return
             }

--- a/Sources/ContainerCommands/System/Property/PropertyList.swift
+++ b/Sources/ContainerCommands/System/Property/PropertyList.swift
@@ -50,7 +50,7 @@ extension Application {
         private func printValues(_ vals: [DefaultsStoreValue], format: ListFormat) throws {
             if format == .json {
                 let data = try JSONEncoder().encode(vals)
-                print(String(data: data, encoding: .utf8)!)
+                print(String(decoding: data, as: UTF8.self))
                 return
             }
 

--- a/Sources/ContainerCommands/Volume/VolumeInspect.swift
+++ b/Sources/ContainerCommands/Volume/VolumeInspect.swift
@@ -47,7 +47,7 @@ extension Application.VolumeCommand {
             encoder.dateEncodingStrategy = .iso8601
 
             let data = try encoder.encode(volumes)
-            print(String(data: data, encoding: .utf8)!)
+            print(String(decoding: data, as: UTF8.self))
         }
     }
 }

--- a/Sources/ContainerCommands/Volume/VolumeList.swift
+++ b/Sources/ContainerCommands/Volume/VolumeList.swift
@@ -51,7 +51,7 @@ extension Application.VolumeCommand {
         func printVolumes(volumes: [Volume], format: Application.ListFormat) throws {
             if format == .json {
                 let data = try JSONEncoder().encode(volumes)
-                print(String(data: data, encoding: .utf8)!)
+                print(String(decoding: data, as: UTF8.self))
                 return
             }
 


### PR DESCRIPTION

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update
- [x] Chore

## Motivation and Context
Use the non-optional String(decoding:as:) initializer for converting JSON-encoded Data to String. This is safe for UTF-8 and eliminates force unwraps.

## Testing
No new tests needed for this change. It's a 1:1 API swap with identical behavior - String(decoding:as:) produces the same output as String(data:encoding:)! for valid UTF-8.
