### PR TITLE
Don't enable selinux LSM on boot.

### DIFF
--- a/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
+++ b/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
@@ -123,6 +123,7 @@ public actor SandboxService {
 
             var kernel = try bundle.kernel
             kernel.commandLine.kernelArgs.append("oops=panic")
+            kernel.commandLine.kernelArgs.append("lsm=lockdown,capability,landlock,yama,apparmor")
             let vmm = VZVirtualMachineManager(
                 kernel: kernel,
                 initialFilesystem: bundle.initialFilesystem.asMount,


### PR DESCRIPTION
- Closes #1150.
- The problem seems to be that the selinux label attribute enforcement doesn't play well with overlayfs.
- Solution is to set the `lsm` boot line argument. The new value corresponds to what one would see in a Lima VM with Colima. The Kata kernel we use doesn't provide any of those modules, so now if you run `dmesg | grep -i lsm` in a container you will just see: `LSM: initializing lsm=capability`