### PR TITLE
Move --debug flag after `apiserver start`

### DIFF
--- a/Sources/ContainerCommands/System/SystemStart.swift
+++ b/Sources/ContainerCommands/System/SystemStart.swift
@@ -62,11 +62,12 @@ extension Application {
 
             var args = [executableUrl.absolutePath()]
 
+            args.append("start")
+
             if logOptions.debug {
                 args.append("--debug")
             }
 
-            args.append("start")
             let apiServerDataUrl = appRoot.appending(path: "apiserver")
             try! FileManager.default.createDirectory(at: apiServerDataUrl, withIntermediateDirectories: true)
 


### PR DESCRIPTION
Fix starting api server with debug flag (#1183)

## Type of Change
- [X] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
API server currently doesn't start with `container system start --debug` as it sets the command `/usr/local/bin/container-apiserver --debug start` which returns unknown options error.

The command should be `/usr/local/bin/container-apiserver start --debug`.

## Testing
- [X] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
