### PR TITLE
Fix OpenSSL certificate verification in x86_64 containers on Apple Silicon

### DIFF
--- a/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
+++ b/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
@@ -896,13 +896,7 @@ public actor SandboxService {
             }
         }
 
-        #if arch(arm64)
-        if config.platform.architecture == "amd64" {
-            if !czConfig.process.environmentVariables.contains(where: { $0.starts(with: "OPENSSL_ia32cap=") }) {
-                czConfig.process.environmentVariables.append("OPENSSL_ia32cap=0:0:0")
-            }
-        }
-        #endif
+
 
         czConfig.process.terminal = process.terminal
         czConfig.process.workingDirectory = process.workingDirectory
@@ -950,13 +944,7 @@ public actor SandboxService {
             }
         }
 
-        #if arch(arm64)
-        if containerConfig.platform.architecture == "amd64" {
-            if !proc.environmentVariables.contains(where: { $0.starts(with: "OPENSSL_ia32cap=") }) {
-                proc.environmentVariables.append("OPENSSL_ia32cap=0:0:0")
-            }
-        }
-        #endif
+
 
         proc.terminal = config.terminal
         proc.workingDirectory = config.workingDirectory


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
closes #1194

TLS/HTTPS connections was failing when running x86_64 containers (AlmaLinux 10, Rocky Linux 10) via Rosetta 2.x on Apple Silicon. breaking package managers (dnf, apt) and any HTTPS-dependent tools with the error:

```error
error:030000EA:digital envelope routines::provider signature failure
```

Current behavior: 
```swift

func configureInitialProcess(
    czConfig: inout LinuxContainer.Configuration,
    config: ContainerConfiguration
) throws {
    let process = config.initProcess
    czConfig.process.environmentVariables = process.environment
    // Environment variables set, but OpenSSL crypto fails under Rosetta!
}
```

#### Fix
Inject OPENSSL_ia32cap environment variable when Rosetta is detected to disable CPU-optimized crypto routines (AES-NI, AVX) that don't work under emulation. 

OpenSSL falls back to portable C implementations, allowing HTTPS to work correctly.

## Testing
- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
