### PR TITLE
Add "ps" alias to ContainerList command

### DIFF
--- a/Sources/ContainerCommands/Container/ContainerList.swift
+++ b/Sources/ContainerCommands/Container/ContainerList.swift
@@ -26,7 +26,7 @@ extension Application {
         public static let configuration = CommandConfiguration(
             commandName: "list",
             abstract: "List running containers",
-            aliases: ["ls"])
+            aliases: ["ls", "ps"])
 
         @Flag(name: .shortAndLong, help: "Include containers that are not running")
         var all = false


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Users coming from Docker habitually type "container ps" to list containers, which currently fails. 
This adds "ps" as an alias to the list command as requested in [1213](https://github.com/apple/container/issues/1213).

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
