### PR TITLE
fix: preserve per-reference error context in ClientImage.save() and update callers

### DIFF
--- a/Sources/ContainerCommands/Image/ImageInspect.swift
+++ b/Sources/ContainerCommands/Image/ImageInspect.swift
@@ -54,8 +54,8 @@ extension Application {
                 succeededImages.append(image.reference)
             }
 
-            for missing in result.error {
-                allErrors.append((missing, ContainerizationError(.notFound, message: "Image not found")))
+            for lookupError in result.errors {
+                allErrors.append((lookupError.reference, lookupError.cause))
             }
 
             if !printable.isEmpty {


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
The `ClientImage.save()` method had a `TODO` to improve error handling. Previously, get(names:) returned failed references as plain strings, discarding the underlying error cause (e.g., not found vs. parse failure vs. network error). The save() method then threw a generic .invalidArgument error with no detail about why each reference failed. This made it difficult for users to diagnose and fix issues when saving multiple images. This change introduces ImageLookupError to preserve per-reference error context, updates all callers (save(), ImageInspect, ImageDelete) to use the richer error type, and changes the error code to the more semantically accurate .notFound.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
