### PR TITLE
Support loading network configuration from file

### DIFF
--- a/Sources/ContainerResource/Network/NetworkConfiguration.swift
+++ b/Sources/ContainerResource/Network/NetworkConfiguration.swift
@@ -149,3 +149,59 @@ private struct _LegacyPluginInfo: Codable {
     let plugin: String
     let variant: String?
 }
+
+/// Intermediate representation for loading network configuration from a JSON file.
+///
+/// Only `mode` is required. All other fields have sensible defaults.
+/// The network name (ID) is provided separately via the CLI argument, not the file.
+public struct NetworkConfigurationFile: Codable, Sendable {
+    /// The network type (e.g. "nat", "hostOnly").
+    public let mode: NetworkMode
+
+    /// The preferred CIDR address for the IPv4 subnet, if specified.
+    public let ipv4Subnet: String?
+
+    /// The preferred CIDR address for the IPv6 subnet, if specified.
+    public let ipv6Subnet: String?
+
+    /// Key-value labels for the network.
+    public let labels: [String: String]?
+
+    /// The network plugin that manages this network.
+    public let plugin: String?
+
+    /// Plugin-specific options for this network.
+    public let options: [String: String]?
+
+    public init(
+        mode: NetworkMode,
+        ipv4Subnet: String? = nil,
+        ipv6Subnet: String? = nil,
+        labels: [String: String]? = nil,
+        plugin: String? = nil,
+        options: [String: String]? = nil
+    ) {
+        self.mode = mode
+        self.ipv4Subnet = ipv4Subnet
+        self.ipv6Subnet = ipv6Subnet
+        self.labels = labels
+        self.plugin = plugin
+        self.options = options
+    }
+
+    /// Convert to a full ``NetworkConfiguration`` using the supplied network ID.
+    public func toNetworkConfiguration(id: String) throws -> NetworkConfiguration {
+        let v4 = try ipv4Subnet.map { try CIDRv4($0) }
+        let v6 = try ipv6Subnet.map { try CIDRv6($0) }
+        let resourceLabels = try ResourceLabels(labels ?? [:])
+        return try NetworkConfiguration(
+            name: id,
+            mode: mode,
+            ipv4Subnet: v4,
+            ipv6Subnet: v6,
+            labels: resourceLabels,
+            plugin: plugin ?? "container-network-vmnet",
+            options: options ?? [:]
+        )
+    }
+}

--- a/Sources/Plugins/NetworkVmnet/NetworkVmnetHelper+Start.swift
+++ b/Sources/Plugins/NetworkVmnet/NetworkVmnetHelper+Start.swift
@@ -51,7 +51,7 @@ extension NetworkVmnetHelper {
         var id: String
 
         @Option(name: .long, help: "Network mode")
-        var mode: NetworkMode = .nat
+        var mode: NetworkMode?
 
         @Option(name: .customLong("subnet"), help: "CIDR address for the IPv4 subnet")
         var ipv4Subnet: String?
@@ -60,12 +60,21 @@ extension NetworkVmnetHelper {
         var ipv6Subnet: String?
 
         @Option(name: .long, help: "Variant of the network helper to use.")
-        var variant: Variant = {
+        var variant: Variant?
+
+        @Option(
+            name: .long, help: "Path to a JSON configuration file for the network", completion: .file(),
+            transform: { str in
+                URL(fileURLWithPath: str, relativeTo: .currentDirectory()).absoluteURL.path(percentEncoded: false)
+            })
+        var config: String?
+
+        private static var defaultVariant: Variant {
             guard #available(macOS 26, *) else {
                 return .allocationOnly
             }
             return .reserved
-        }()
+        }
 
         var logRoot = LogRoot.path
 
@@ -80,20 +89,50 @@ extension NetworkVmnetHelper {
 
             do {
                 log.info("configuring XPC server")
-                let ipv4Subnet = try self.ipv4Subnet.map { try CIDRv4($0) }
-                let ipv6Subnet = try self.ipv6Subnet.map { try CIDRv6($0) }
+                let effectiveMode: NetworkMode
+                let effectiveSubnet: String?
+                let effectiveSubnetV6: String?
+                let effectiveVariant: Variant
+                let effectiveLabels: ResourceLabels
 
+                if let configPath = config {
+                    let data = try Data(contentsOf: URL(fileURLWithPath: configPath))
+                    let configFile = try JSONDecoder().decode(NetworkConfigurationFile.self, from: data)
+
+                    // CLI flags override values from the config file.
+                    effectiveMode = mode ?? configFile.mode
+                    effectiveSubnet = ipv4Subnet ?? configFile.ipv4Subnet
+                    effectiveSubnetV6 = ipv6Subnet ?? configFile.ipv6Subnet
+                    if let v = variant {
+                        effectiveVariant = v
+                    } else if let v = configFile.options?["variant"], let parsed = Variant(rawValue: v) {
+                        effectiveVariant = parsed
+                    } else {
+                        effectiveVariant = Self.defaultVariant
+                    }
+                    effectiveLabels = try ResourceLabels(configFile.labels ?? [:])
+                } else {
+                    effectiveMode = mode ?? .nat
+                    effectiveSubnet = ipv4Subnet
+                    effectiveSubnetV6 = ipv6Subnet
+                    effectiveVariant = variant ?? Self.defaultVariant
+                    effectiveLabels = .init()
+                }
+
+                let ipv4Subnet = try effectiveSubnet.map { try CIDRv4($0) }
+                let ipv6Subnet = try effectiveSubnetV6.map { try CIDRv6($0) }
                 let configuration = try NetworkConfiguration(
                     name: id,
-                    mode: mode,
+                    mode: effectiveMode,
                     ipv4Subnet: ipv4Subnet,
                     ipv6Subnet: ipv6Subnet,
+                    labels: effectiveLabels,
                     plugin: NetworkVmnetHelper._commandName,
-                    options: ["variant": self.variant.rawValue]
+                    options: ["variant": effectiveVariant.rawValue]
                 )
                 let network = try Self.createNetwork(
                     configuration: configuration,
-                    variant: self.variant,
+                    variant: effectiveVariant,
                     log: log
                 )
                 try await network.start()

--- a/Tests/ContainerResourceTests/NetworkConfigurationTest.swift
+++ b/Tests/ContainerResourceTests/NetworkConfigurationTest.swift
@@ -16,6 +16,7 @@
 
 import ContainerizationError
 import ContainerizationExtras
+import Foundation
 import Testing
 
 @testable import ContainerResource
@@ -79,6 +80,88 @@ struct NetworkConfigurationTest {
                 #expect(err.message.starts(with: "invalid network name"))
                 return true
             }
+        }
+    }
+
+    // MARK: - NetworkConfigurationFile tests
+
+    @Test func testConfigFileDecodeMinimal() throws {
+        let json = """
+            {"mode": "nat"}
+            """
+        let data = json.data(using: .utf8)!
+        let configFile = try JSONDecoder().decode(NetworkConfigurationFile.self, from: data)
+        #expect(configFile.mode == .nat)
+        #expect(configFile.ipv4Subnet == nil)
+        #expect(configFile.ipv6Subnet == nil)
+        #expect(configFile.labels == nil)
+        #expect(configFile.plugin == nil)
+        #expect(configFile.options == nil)
+
+        let config = try configFile.toNetworkConfiguration(id: "test-net")
+        #expect(config.id == "test-net")
+        #expect(config.mode == .nat)
+        #expect(config.ipv4Subnet == nil)
+        #expect(config.ipv6Subnet == nil)
+        #expect(config.labels.dictionary == [:])
+        #expect(config.plugin == "container-network-vmnet")
+        #expect(config.options == [:])
+    }
+
+    @Test func testConfigFileDecodeComplete() throws {
+        let json = """
+            {
+                "mode": "hostOnly",
+                "ipv4Subnet": "192.168.64.0/24",
+                "ipv6Subnet": "fd00::/64",
+                "labels": {"env": "production"},
+                "plugin": "my-plugin",
+                "options": {"variant": "shared"}
+            }
+            """
+        let data = json.data(using: .utf8)!
+        let configFile = try JSONDecoder().decode(NetworkConfigurationFile.self, from: data)
+        #expect(configFile.mode == .hostOnly)
+        #expect(configFile.ipv4Subnet == "192.168.64.0/24")
+        #expect(configFile.ipv6Subnet == "fd00::/64")
+        #expect(configFile.labels == ["env": "production"])
+        #expect(configFile.plugin == "my-plugin")
+        #expect(configFile.options?["variant"] == "shared")
+
+        let config = try configFile.toNetworkConfiguration(id: "full-net")
+        #expect(config.id == "full-net")
+        #expect(config.mode == .hostOnly)
+        #expect(config.ipv4Subnet != nil)
+        #expect(config.ipv6Subnet != nil)
+        #expect(config.labels.dictionary == ["env": "production"])
+        #expect(config.plugin == "my-plugin")
+        #expect(config.options["variant"] == "shared")
+    }
+
+    @Test func testConfigFileInvalidSubnet() throws {
+        let json = """
+            {"mode": "nat", "ipv4Subnet": "not-a-cidr"}
+            """
+        let data = json.data(using: .utf8)!
+        let configFile = try JSONDecoder().decode(NetworkConfigurationFile.self, from: data)
+        #expect(throws: (any Error).self) {
+            _ = try configFile.toNetworkConfiguration(id: "test-net")
+        }
+    }
+
+    @Test func testConfigFileInvalidId() throws {
+        let json = """
+            {"mode": "nat"}
+            """
+        let data = json.data(using: .utf8)!
+        let configFile = try JSONDecoder().decode(NetworkConfigurationFile.self, from: data)
+        #expect {
+            _ = try configFile.toNetworkConfiguration(id: "INVALID-ID")
+        } throws: { error in
+            guard let err = error as? ContainerizationError else { return false }
+            #expect(err.code == .invalidArgument)
+            #expect(err.message.starts(with: "invalid network name"))
+            return true
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds a `--config` option to `container-network-vmnet start` that accepts a JSON network configuration file, closing #1047
- Introduces `NetworkConfigurationFile` as a `Codable` input model that converts into the current `NetworkConfiguration` schema
- Keeps CLI flags as overrides when both CLI values and a config file are provided
- Supports current network `plugin` / `options` fields, including the vmnet `variant` option

## Test plan
- [x] Added unit tests for minimal and complete config decoding, invalid subnets, and invalid names
- [x] Existing `NetworkConfigurationTest` coverage continues to pass
- [x] `swift test --filter NetworkConfigurationTest` passes (7/7 tests)
