### PR TITLE
Downgrade the mapping of warnings to the default log level

### DIFF
--- a/Sources/ContainerLog/OSLogHandler.swift
+++ b/Sources/ContainerLog/OSLogHandler.swift
@@ -93,9 +93,9 @@ extension Logger.Level {
             return .debug
         case .info:
             return .info
-        case .notice:
+        case .notice, .warning:
             return .default
-        case .error, .warning:
+        case .error:
             return .error
         case .critical:
             return .fault


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Incorrect logging of warnings.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
