### PR TITLE
Minimal runtime variant plumbing.

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
+++ b/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
@@ -113,7 +113,7 @@ public struct ContainerClient: Sendable {
     }
 
     /// Bootstrap the container's init process.
-    public func bootstrap(id: String, stdio: [FileHandle?]) async throws -> ClientProcess {
+    public func bootstrap(id: String, stdio: [FileHandle?], variant: String? = nil) async throws -> ClientProcess {
         let request = XPCMessage(route: .containerBootstrap)
 
         for (i, h) in stdio.enumerated() {
@@ -130,6 +130,10 @@ public struct ContainerClient: Sendable {
             if let h {
                 request.set(key: key, value: h)
             }
+        }
+
+        if let variant {
+            request.set(key: .variant, value: variant)
         }
 
         do {

--- a/Sources/Services/ContainerAPIService/Client/Flags.swift
+++ b/Sources/Services/ContainerAPIService/Client/Flags.swift
@@ -293,6 +293,9 @@ public struct Flags {
         )
         public var publishSockets: [String] = []
 
+        @Flag(name: .long, help: "Mount the container's root filesystem as read-only")
+        public var readOnly = false
+
         @Flag(name: [.customLong("rm"), .long], help: "Remove the container after it stops")
         public var remove = false
 
@@ -305,9 +308,6 @@ public struct Flags {
         @Option(name: .customLong("tmpfs"), help: "Add a tmpfs mount to the container at the given path")
         public var tmpFs: [String] = []
 
-        @Option(name: [.customLong("volume"), .short], help: "Bind mount a volume into the container")
-        public var volumes: [String] = []
-
         @Flag(
             name: .long,
             help:
@@ -315,8 +315,8 @@ public struct Flags {
         )
         public var virtualization: Bool = false
 
-        @Flag(name: .long, help: "Mount the container's root filesystem as read-only")
-        public var readOnly = false
+        @Option(name: [.customLong("volume"), .short], help: "Bind mount a volume into the container")
+        public var volumes: [String] = []
 
         @Option(name: .long, help: "Set the runtime handler for the container (default: container-runtime-linux)")
         public var runtime: String?

--- a/Sources/Services/ContainerAPIService/Client/XPC+.swift
+++ b/Sources/Services/ContainerAPIService/Client/XPC+.swift
@@ -32,6 +32,8 @@ public enum XPCKeys: String {
     case containerConfig
     /// Container options key.
     case containerOptions
+    /// Plugin variant key.
+    case variant
     /// Vsock port number key.
     case port
     /// Exit code for a process

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift
@@ -55,7 +55,8 @@ public struct ContainersHarness: Sendable {
             )
         }
         let stdio = message.stdio()
-        try await service.bootstrap(id: id, stdio: stdio)
+        let variant = message.variant()
+        try await service.bootstrap(id: id, stdio: stdio, variant: variant)
         return message.reply()
     }
 

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -378,7 +378,7 @@ public actor ContainersService {
     }
 
     /// Bootstrap the init process of the container.
-    public func bootstrap(id: String, stdio: [FileHandle?]) async throws {
+    public func bootstrap(id: String, stdio: [FileHandle?], variant: String? = nil) async throws {
         log.debug(
             "ContainersService: enter",
             metadata: [
@@ -424,8 +424,8 @@ public actor ContainersService {
                 }
 
                 try Self.registerService(
-                    plugin: self.runtimePlugins.first { $0.name == config.runtimeHandler }!,
                     loader: self.pluginLoader,
+                    plugin: self.runtimePlugins.first { $0.name == config.runtimeHandler }!,
                     configuration: config,
                     path: path,
                     debug: self.debugHelpers
@@ -1078,14 +1078,17 @@ public actor ContainersService {
     }
 
     private static func registerService(
-        plugin: Plugin,
         loader: PluginLoader,
+        plugin: Plugin,
+        variant: String? = nil,
         configuration: ContainerConfiguration,
         path: URL,
         debug: Bool
     ) throws {
         let args = [
             "start",
+            variant != nil ? "--variant" : nil,
+            variant,
             "--root", path.path,
             "--uuid", configuration.id,
             debug ? "--debug" : nil,
@@ -1178,5 +1181,9 @@ extension XPCMessage {
             throw ContainerizationError(.invalidArgument, message: "empty process configuration")
         }
         return try JSONDecoder().decode(ProcessConfiguration.self, from: data)
+    }
+
+    func variant() -> String? {
+        self.string(key: .variant)
     }
 }

--- a/Tests/ContainerPluginTests/PluginLoaderTest.swift
+++ b/Tests/ContainerPluginTests/PluginLoaderTest.swift
@@ -177,6 +177,85 @@ struct PluginLoaderTest {
     }
 
     @Test
+    func testRegisterWithLaunchdDefaultArgs() async throws {
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+        let factory = try setupMock(tempURL: tempURL)
+        let loader = try PluginLoader(
+            appRoot: tempURL,
+            installRoot: URL(filePath: "/usr/local/"),
+            logRoot: nil,
+            pluginDirectories: [tempURL],
+            pluginFactories: [factory]
+        )
+
+        let plugin = loader.findPlugin(name: "service")!
+        let stateRoot = tempURL.appendingPathComponent("test-state")
+        try loader.registerWithLaunchd(plugin: plugin, pluginStateRoot: stateRoot)
+
+        let plistURL = stateRoot.appendingPathComponent("service.plist")
+        let plistData = try Data(contentsOf: plistURL)
+        let plist = try PropertyListSerialization.propertyList(from: plistData, format: nil) as! [String: Any]
+        let programArguments = plist["ProgramArguments"] as! [String]
+
+        #expect(programArguments.contains("start"))
+    }
+
+    @Test
+    func testRegisterWithLaunchdCustomArgs() async throws {
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+        let factory = try setupMock(tempURL: tempURL)
+        let loader = try PluginLoader(
+            appRoot: tempURL,
+            installRoot: URL(filePath: "/usr/local/"),
+            logRoot: nil,
+            pluginDirectories: [tempURL],
+            pluginFactories: [factory]
+        )
+
+        let plugin = loader.findPlugin(name: "service")!
+        let stateRoot = tempURL.appendingPathComponent("test-state")
+        try loader.registerWithLaunchd(plugin: plugin, pluginStateRoot: stateRoot, args: ["run", "--verbose"])
+
+        let plistURL = stateRoot.appendingPathComponent("service.plist")
+        let plistData = try Data(contentsOf: plistURL)
+        let plist = try PropertyListSerialization.propertyList(from: plistData, format: nil) as! [String: Any]
+        let programArguments = plist["ProgramArguments"] as! [String]
+
+        #expect(programArguments.contains("run"))
+        #expect(programArguments.contains("--verbose"))
+        #expect(!programArguments.contains("start"))
+    }
+
+    @Test
+    func testRegisterWithLaunchdCustomArgsAndDebug() async throws {
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+        let factory = try setupMock(tempURL: tempURL)
+        let loader = try PluginLoader(
+            appRoot: tempURL,
+            installRoot: URL(filePath: "/usr/local/"),
+            logRoot: nil,
+            pluginDirectories: [tempURL],
+            pluginFactories: [factory]
+        )
+
+        let plugin = loader.findPlugin(name: "service")!
+        let stateRoot = tempURL.appendingPathComponent("test-state")
+        try loader.registerWithLaunchd(plugin: plugin, pluginStateRoot: stateRoot, args: ["run"], debug: true)
+
+        let plistURL = stateRoot.appendingPathComponent("service.plist")
+        let plistData = try Data(contentsOf: plistURL)
+        let plist = try PropertyListSerialization.propertyList(from: plistData, format: nil) as! [String: Any]
+        let programArguments = plist["ProgramArguments"] as! [String]
+
+        #expect(programArguments.contains("run"))
+        #expect(programArguments.contains("--debug"))
+        #expect(!programArguments.contains("start"))
+    }
+
+    @Test
     func testRegisterWithLaunchdDebugTrue() async throws {
         let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         defer { try? FileManager.default.removeItem(at: tempURL) }


### PR DESCRIPTION
- Adds plugin variant selection to bootstrap() on the Container API service in such a way that we can revert the change soon without compatibility issues when we work out a more permanent approach, and requires no persistent data migration.
- Restore lexical ordering on ManagementFlags (except `--runtime`, will take care of that next PR).
- Add a couple plugin loader tests to improve coverage.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Testing runtime variants out prior to building out the proper design.

## Testing
- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
