### PR TITLE
Try to trigger the network privacy alert on port publish.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -320,6 +320,7 @@ let package = Package(
                 .product(name: "ContainerizationOS", package: "containerization"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 "ContainerAPIClient",
+                "ContainerOS",
                 "ContainerPersistence",
                 "ContainerResource",
                 "ContainerSandboxServiceClient",

--- a/Sources/ContainerOS/LocalNetworkPrivacy.swift
+++ b/Sources/ContainerOS/LocalNetworkPrivacy.swift
@@ -18,8 +18,8 @@
 import Darwin
 
 /// Utility for triggering local network privacy alert.
-/// The local networking privacy feature introduced in macOS
-/// Sequoia requires users to authorize an app before it can
+/// The local networking privacy feature introduced in
+/// macOS 15 requires users to authorize an app before it can
 /// access peers on the local network. This security feature
 /// affects runtime helpers that publish ports on the loopback
 /// interface.

--- a/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
+++ b/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import ContainerAPIClient
+import ContainerOS
 import ContainerPersistence
 import ContainerResource
 import ContainerSandboxServiceClient


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
- Closes #1247.
- Hopefully better UX than waiting until clients attempt to access published ports.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
