### PR TITLE
Put CLI and container-core-images in a keychain access group.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,12 +117,11 @@ $(STAGING_DIR):
 .PHONY: installer-pkg
 installer-pkg: $(STAGING_DIR)
 	@echo Signing container binaries...
-	@codesign $(CODESIGN_OPTS) --identifier com.apple.container.cli "$(join $(STAGING_DIR), bin/container)"
+	@codesign $(CODESIGN_OPTS) --identifier com.apple.container.cli --entitlements=signing/container.entitlements "$(join $(STAGING_DIR), bin/container)"
 	@codesign $(CODESIGN_OPTS) --identifier com.apple.container.apiserver "$(join $(STAGING_DIR), bin/container-apiserver)"
-	@codesign $(CODESIGN_OPTS) --prefix=com.apple.container. "$(join $(STAGING_DIR), libexec/container/plugins/container-core-images/bin/container-core-images)"
+	@codesign $(CODESIGN_OPTS) --prefix=com.apple.container. --entitlements=signing/container-core-images.entitlements "$(join $(STAGING_DIR), libexec/container/plugins/container-core-images/bin/container-core-images)"
 	@codesign $(CODESIGN_OPTS) --prefix=com.apple.container. --entitlements=signing/container-runtime-linux.entitlements "$(join $(STAGING_DIR), libexec/container/plugins/container-runtime-linux/bin/container-runtime-linux)"
 	@codesign $(CODESIGN_OPTS) --prefix=com.apple.container. --entitlements=signing/container-network-vmnet.entitlements "$(join $(STAGING_DIR), libexec/container/plugins/container-network-vmnet/bin/container-network-vmnet)"
-
 	@echo Creating application installer
 	@pkgbuild --root "$(STAGING_DIR)" --identifier com.apple.container-installer --install-location /usr/local --version ${RELEASE_VERSION} $(PKG_PATH)
 	@rm -rf "$(STAGING_DIR)"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a0d9f0581740922266b0739fae8ec0998c7d5c7d98ff76cccb68a878f27e88ab",
+  "originHash" : "9d09d49729b014b3becca478d9303cabff31461a0f686e1c741d4ed7e5262906",
   "pins" : [
     {
       "identity" : "async-http-client",

--- a/Sources/ContainerCommands/Registry/RegistryList.swift
+++ b/Sources/ContainerCommands/Registry/RegistryList.swift
@@ -38,7 +38,7 @@ extension Application {
             aliases: ["ls"])
 
         public func run() async throws {
-            let keychain = KeychainHelper(securityDomain: Constants.keychainID)
+            let keychain = KeychainHelper(securityDomain: Constants.keychainID, accessGroup: Constants.keychainGroup)
             let registries = try keychain.list()
             try printRegistries(registries: registries, format: format)
         }

--- a/Sources/ContainerCommands/Registry/RegistryLogin.swift
+++ b/Sources/ContainerCommands/Registry/RegistryLogin.swift
@@ -57,7 +57,7 @@ extension Application {
                 }
                 password = String(decoding: passwordData, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
             }
-            let keychain = KeychainHelper(securityDomain: Constants.keychainID)
+            let keychain = KeychainHelper(securityDomain: Constants.keychainID, accessGroup: Constants.keychainGroup)
             if username == "" {
                 username = try keychain.userPrompt(hostname: server)
             }

--- a/Sources/ContainerCommands/Registry/RegistryLogout.swift
+++ b/Sources/ContainerCommands/Registry/RegistryLogout.swift
@@ -34,7 +34,7 @@ extension Application {
         var registry: String
 
         public func run() async throws {
-            let keychain = KeychainHelper(securityDomain: Constants.keychainID)
+            let keychain = KeychainHelper(securityDomain: Constants.keychainID, accessGroup: Constants.keychainGroup)
             let r = Reference.resolveDomain(domain: registry)
             try keychain.delete(hostname: r)
         }

--- a/Sources/Services/ContainerAPIService/Client/Constants.swift
+++ b/Sources/Services/ContainerAPIService/Client/Constants.swift
@@ -18,4 +18,6 @@
 public enum Constants {
     /// The keychain ID to use for registry credentials.
     public static let keychainID = "com.apple.container.registry"
+    /// The application access group to use for registry credentials.
+    public static let keychainGroup = "com.apple.container.keychain"
 }

--- a/Sources/Services/ContainerImagesService/Server/ImagesService.swift
+++ b/Sources/Services/ContainerImagesService/Server/ImagesService.swift
@@ -427,7 +427,7 @@ extension ImagesService {
         if let authentication {
             return try await body(authentication)
         }
-        let keychain = KeychainHelper(securityDomain: Constants.keychainID)
+        let keychain = KeychainHelper(securityDomain: Constants.keychainID, accessGroup: Constants.keychainGroup)
         do {
             authentication = try keychain.lookup(hostname: host)
         } catch let err as KeychainHelper.Error {

--- a/signing/container-core-images.entitlements
+++ b/signing/container-core-images.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.apple.container.keychain</string>
+	</array>
+</dict>
+</plist>

--- a/signing/container.entitlements
+++ b/signing/container.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.apple.container.keychain</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
- Closes #1253 (hopefully).
- Requires apple/containerization#553.
- We share a keychain between the CLI and the image helper, but the user needs to opt-in the image helper for access to entries created by the CLI. Since both apps are notarized with the same team ID, we should be able to use an access group to avoid this step for release builds.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
It's easy to forget to hit "Allow All" in the opt-in dialog, and logins using short-lived access tokens constantly trigger the dialog in any case.

## Testing
- [ ] Tested locally (will look into trying to do a notarized build locally but want to post the PR for now)
- [ ] Added/updated tests
- [ ] Added/updated docs
