### PR TITLE
Fix a potential filesystem corruption on virtio block devices

### DIFF
--- a/Sources/ContainerResource/Container/Filesystem.swift
+++ b/Sources/ContainerResource/Container/Filesystem.swift
@@ -91,7 +91,7 @@ public struct Filesystem: Sendable, Codable {
     /// A block based filesystem.
     public static func block(
         format: String, source: String, destination: String, options: MountOptions, cache: CacheMode = .on,
-        sync: SyncMode = .fsync
+        sync: SyncMode = .full
     ) -> Filesystem {
         .init(
             type: .block(format: format, cache: cache, sync: sync),
@@ -104,7 +104,7 @@ public struct Filesystem: Sendable, Codable {
     /// A named volume filesystem.
     public static func volume(
         name: String, format: String, source: String, destination: String, options: MountOptions,
-        cache: CacheMode = .on, sync: SyncMode = .fsync
+        cache: CacheMode = .on, sync: SyncMode = .full
     ) -> Filesystem {
         .init(
             type: .volume(name: name, format: format, cache: cache, sync: sync),


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Ensure that heavy disk operations do not cause file system corruption.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
