### PR TITLE
fix: handle launchctl bootout permission errors in ensure-container-stopped.sh

### DIFF
--- a/scripts/ensure-container-stopped.sh
+++ b/scripts/ensure-container-stopped.sh
@@ -44,11 +44,14 @@ done
 if $ALL_DOMAINS; then
     uid=$(id -u)
     for domain in "gui/$uid" "user/$uid" "system"; do
+        if [ "$domain" = "system" ] && [ "$uid" -ne 0 ]; then
+            continue
+        fi
         launchctl print "$domain" 2>/dev/null \
             | grep -oE 'com\.apple\.container\.[^ ]+' \
             | sort -u \
             | while read -r service; do
-                launchctl bootout "$domain/$service"
+                launchctl bootout "$domain/$service" 2>/dev/null || true
             done
     done
 else

--- a/scripts/ensure-container-stopped.sh
+++ b/scripts/ensure-container-stopped.sh
@@ -51,7 +51,7 @@ if $ALL_DOMAINS; then
             | grep -oE 'com\.apple\.container\.[^ ]+' \
             | sort -u \
             | while read -r service; do
-                launchctl bootout "$domain/$service" 2>/dev/null || true
+                launchctl bootout "$domain/$service"
             done
     done
 else


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
fixes #1281 

Right now, running brew install container fails with "Operation not permitted" because the post-install script tries to stop system domain services, which requires root access.

The Fix: Updated the script to skip the system domain when not running as root, and strictly ignore bootout errors so they don't crash the installation.

```bash
if [ "$domain" = "system" ] && [ "$uid" -ne 0 ]; then
    continue
fi

```

added them as co authored,  tested by: @Renish-patel, @shilpan97

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
