### PR TITLE
Remove trailing comma

### DIFF
--- a/Sources/ContainerResource/Network/NetworkConfiguration.swift
+++ b/Sources/ContainerResource/Network/NetworkConfiguration.swift
@@ -60,7 +60,7 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
         ipv4Subnet: CIDRv4? = nil,
         ipv6Subnet: CIDRv6? = nil,
         labels: [String: String] = [:],
-        pluginInfo: NetworkPluginInfo,
+        pluginInfo: NetworkPluginInfo
     ) throws {
         self.id = id
         self.creationDate = Date()


### PR DESCRIPTION
## Type of Change
- [x ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
In Swift we usually do not use trailing commas and it could IMO cause issues.

## Testing
- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

(Unforetunately, I don't have a local instance of Apple Container installed, but I'm pretty confident from looking at the code that this change is correct.)
