### PR TITLE
Pass root directory URL as env variable so that plugins can use it

### DIFF
--- a/Sources/ContainerPlugin/PluginLoader.swift
+++ b/Sources/ContainerPlugin/PluginLoader.swift
@@ -228,6 +228,7 @@ extension PluginLoader {
         var env = Self.filterEnvironment()
         env[ApplicationRoot.environmentName] = appRoot.path(percentEncoded: false)
         env[InstallRoot.environmentName] = installRoot.path(percentEncoded: false)
+        env[PluginStateRoot.environmentName] = rootURL.path(percentEncoded: false)
         if let logRoot {
             env[LogRoot.environmentName] =
                 logRoot.isAbsolute

--- a/Sources/ContainerPlugin/PluginStateRoot.swift
+++ b/Sources/ContainerPlugin/PluginStateRoot.swift
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Provides the application plugin data root path.
+public struct PluginStateRoot {
+    public static let environmentName = "CONTAINER_PLUGIN_STATE_ROOT"
+
+    private let plugin: String
+
+    public init(plugin: String) {
+        self.plugin = plugin
+    }
+
+    public var defaultURL: URL {
+        FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first!.appendingPathComponent(
+            "com.apple.container"
+        ).appendingPathComponent(
+            "plugin-state"
+        ).appendingPathComponent(plugin)
+    }
+
+    private static let envPath = ProcessInfo.processInfo.environment[Self.environmentName]
+
+    public var url: URL { Self.envPath.map { URL(fileURLWithPath: $0) } ?? self.defaultURL }
+
+    public var path: String { url.path(percentEncoded: false) }
+}


### PR DESCRIPTION
This PR adds a `PluginStateRoot` class so that a plugin can figure out its root URL where the plugin specific data should be stored.

## Type of Change
- [ ] Bug fix
- [X] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
[Why is this change needed?]

## Testing
- [X] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
