### PR TITLE
volumes: Allow "."

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/Parser.swift
+++ b/Sources/Services/ContainerAPIService/Client/Parser.swift
@@ -515,8 +515,8 @@ public struct Parser {
             let src = String(parts[0])
             let dst = String(parts[1])
 
-            // Check if it's a filesystem path
-            guard src.contains("/") else {
+            // Check if it's a filesystem path (absolute, or relative like ".", "..", "./foo", "../foo")
+            guard src.contains("/") || src == "." || src == ".." else {
                 // Named volume - validate name syntax only
                 guard VolumeStorage.isValidVolumeName(src) else {
                     throw ContainerizationError(.invalidArgument, message: "invalid volume name '\(src)': must match \(VolumeStorage.volumeNamePattern)")

--- a/Tests/ContainerAPIClientTests/ParserTest.swift
+++ b/Tests/ContainerAPIClientTests/ParserTest.swift
@@ -392,6 +392,48 @@ struct ParserTest {
                 #expect(Bool(false), "Expected filesystem mount, got volume")
             }
         }
+
+        // Test volume with bare "." as source (current directory)
+        do {
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("test-volume-dot-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer {
+                try? FileManager.default.removeItem(at: tempDir)
+            }
+
+            let result = try Parser.volume(".:/docs:ro", relativeTo: tempDir)
+
+            switch result {
+            case .filesystem(let fs):
+                let expectedPath = tempDir.standardizedFileURL.path
+                #expect(fs.source.trimmingCharacters(in: CharacterSet(charactersIn: "/")) == expectedPath.trimmingCharacters(in: CharacterSet(charactersIn: "/")))
+                #expect(fs.destination == "/docs")
+                #expect(fs.options.contains("ro"))
+            case .volume:
+                #expect(Bool(false), "Expected filesystem mount, got volume")
+            }
+        }
+
+        // Test volume with ".." as source (parent directory)
+        do {
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("test-volume-dotdot-\(UUID().uuidString)")
+            let childDir = tempDir.appendingPathComponent("child")
+            try FileManager.default.createDirectory(at: childDir, withIntermediateDirectories: true)
+            defer {
+                try? FileManager.default.removeItem(at: tempDir)
+            }
+
+            let result = try Parser.volume("..:/data", relativeTo: childDir)
+
+            switch result {
+            case .filesystem(let fs):
+                let expectedPath = tempDir.standardizedFileURL.path
+                #expect(fs.source.trimmingCharacters(in: CharacterSet(charactersIn: "/")) == expectedPath.trimmingCharacters(in: CharacterSet(charactersIn: "/")))
+                #expect(fs.destination == "/data")
+            case .volume:
+                #expect(Bool(false), "Expected filesystem mount, got volume")
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
We should allow passing . for the src of a volume.