### PR TITLE
Add --all-tags flag to image push

### DIFF
--- a/Sources/ContainerCommands/Image/ImagePush.swift
+++ b/Sources/ContainerCommands/Image/ImagePush.swift
@@ -39,7 +39,7 @@ extension Application {
         var imageUploadFlags: Flags.ImageUpload
 
         @Option(
-            name: .long,
+            name: .shortAndLong,
             help: "Limit the push to the specified architecture"
         )
         var arch: String?
@@ -52,7 +52,7 @@ extension Application {
         @Option(help: "Limit the push to the specified platform (format: os/arch[/variant], takes precedence over --os and --arch) [environment: CONTAINER_DEFAULT_PLATFORM]")
         var platform: String?
 
-        @Flag(name: .shortAndLong, help: "Push all tags of an image")
+        @Flag(name: .long, help: "Push all tags of an image")
         var allTags: Bool = false
 
         @OptionGroup
@@ -66,10 +66,10 @@ extension Application {
             if allTags {
                 let ref = try Reference.parse(reference)
                 if ref.tag != nil {
-                    throw ContainerizationError(.invalidArgument, message: "tag can't be used with --all-tags/-a")
+                    throw ContainerizationError(.invalidArgument, message: "tag can't be used with --all-tags")
                 }
                 if ref.digest != nil {
-                    throw ContainerizationError(.invalidArgument, message: "digest can't be used with --all-tags/-a")
+                    throw ContainerizationError(.invalidArgument, message: "digest can't be used with --all-tags")
                 }
             }
         }
@@ -115,29 +115,7 @@ extension Application {
                 log.warning("--platform/--arch/--os with --all-tags filters each tag push to the specified platform; tags without matching manifests may fail")
             }
 
-            // Enumerate matching tags for display before pushing.
-            let allImages = try await ClientImage.list()
             let normalized = try ClientImage.normalizeReference(reference)
-            let parsedRef = try Reference.parse(normalized)
-            let repoName: String
-            if let resolved = parsedRef.resolvedDomain {
-                repoName = "\(resolved)/\(parsedRef.path)"
-            } else {
-                repoName = parsedRef.name
-            }
-
-            let matchingTags = allImages.filter { img in
-                guard !Utility.isInfraImage(name: img.reference) else { return false }
-                guard let ref = try? Reference.parse(img.reference) else { return false }
-                let resolvedName: String
-                if let resolved = ref.resolvedDomain {
-                    resolvedName = "\(resolved)/\(ref.path)"
-                } else {
-                    resolvedName = ref.name
-                }
-                return resolvedName == repoName
-            }
-
             let displayRepo = try ClientImage.denormalizeReference(normalized)
             let displayName = try Reference.parse(displayRepo).name
             print("The push refers to repository [\(displayName)]")
@@ -147,7 +125,7 @@ extension Application {
             case .none: progressConfig = try ProgressConfig(disableProgressUpdates: true)
             case .ansi:
                 progressConfig = try ProgressConfig(
-                    description: "Pushing \(matchingTags.count) tags",
+                    description: "Pushing tags",
                     showPercent: false,
                     showItems: false,
                     showSpeed: false,
@@ -160,13 +138,13 @@ extension Application {
                 progress.finish()
             }
             progress.start()
-            try await ClientImage.pushAllTags(
+            let pushed = try await ClientImage.pushAllTags(
                 reference: reference, platform: platform, scheme: scheme,
                 maxConcurrentUploads: imageUploadFlags.maxConcurrentUploads, progressUpdate: progress.handler)
             progress.finish()
 
             let formatter = ByteCountFormatter()
-            for img in matchingTags {
+            for img in pushed {
                 let tag = (try? Reference.parse(img.reference))?.tag ?? "<none>"
                 let size = formatter.string(fromByteCount: img.descriptor.size)
                 print("\(tag): digest: \(img.descriptor.digest) size: \(size)")

--- a/Sources/ContainerCommands/Image/ImagePush.swift
+++ b/Sources/ContainerCommands/Image/ImagePush.swift
@@ -17,7 +17,9 @@
 import ArgumentParser
 import ContainerAPIClient
 import Containerization
+import ContainerizationError
 import ContainerizationOCI
+import Foundation
 import TerminalProgress
 
 extension Application {
@@ -33,8 +35,11 @@ extension Application {
         @OptionGroup
         var progressFlags: Flags.Progress
 
+        @OptionGroup
+        var imageUploadFlags: Flags.ImageUpload
+
         @Option(
-            name: .shortAndLong,
+            name: .long,
             help: "Limit the push to the specified architecture"
         )
         var arch: String?
@@ -47,6 +52,9 @@ extension Application {
         @Option(help: "Limit the push to the specified platform (format: os/arch[/variant], takes precedence over --os and --arch) [environment: CONTAINER_DEFAULT_PLATFORM]")
         var platform: String?
 
+        @Flag(name: .shortAndLong, help: "Push all tags of an image")
+        var allTags: Bool = false
+
         @OptionGroup
         public var logOptions: Flags.Logging
 
@@ -54,10 +62,30 @@ extension Application {
 
         public init() {}
 
+        public func validate() throws {
+            if allTags {
+                let ref = try Reference.parse(reference)
+                if ref.tag != nil {
+                    throw ContainerizationError(.invalidArgument, message: "tag can't be used with --all-tags/-a")
+                }
+                if ref.digest != nil {
+                    throw ContainerizationError(.invalidArgument, message: "digest can't be used with --all-tags/-a")
+                }
+            }
+        }
+
         public func run() async throws {
             let p = try DefaultPlatform.resolve(platform: platform, os: os, arch: arch, log: log)
-
             let scheme = try RequestScheme(registry.scheme)
+
+            if allTags {
+                try await pushAllTags(platform: p, scheme: scheme)
+            } else {
+                try await pushSingle(platform: p, scheme: scheme)
+            }
+        }
+
+        private func pushSingle(platform: Platform?, scheme: RequestScheme) async throws {
             let image = try await ClientImage.get(reference: reference)
 
             var progressConfig: ProgressConfig
@@ -78,8 +106,71 @@ extension Application {
                 progress.finish()
             }
             progress.start()
-            _ = try await image.push(platform: p, scheme: scheme, progressUpdate: progress.handler)
+            try await image.push(platform: platform, scheme: scheme, progressUpdate: progress.handler)
             progress.finish()
+        }
+
+        private func pushAllTags(platform: Platform?, scheme: RequestScheme) async throws {
+            if self.platform != nil || arch != nil || os != nil {
+                log.warning("--platform/--arch/--os with --all-tags filters each tag push to the specified platform; tags without matching manifests may fail")
+            }
+
+            // Enumerate matching tags for display before pushing.
+            let allImages = try await ClientImage.list()
+            let normalized = try ClientImage.normalizeReference(reference)
+            let parsedRef = try Reference.parse(normalized)
+            let repoName: String
+            if let resolved = parsedRef.resolvedDomain {
+                repoName = "\(resolved)/\(parsedRef.path)"
+            } else {
+                repoName = parsedRef.name
+            }
+
+            let matchingTags = allImages.filter { img in
+                guard !Utility.isInfraImage(name: img.reference) else { return false }
+                guard let ref = try? Reference.parse(img.reference) else { return false }
+                let resolvedName: String
+                if let resolved = ref.resolvedDomain {
+                    resolvedName = "\(resolved)/\(ref.path)"
+                } else {
+                    resolvedName = ref.name
+                }
+                return resolvedName == repoName
+            }
+
+            let displayRepo = try ClientImage.denormalizeReference(normalized)
+            let displayName = try Reference.parse(displayRepo).name
+            print("The push refers to repository [\(displayName)]")
+
+            var progressConfig: ProgressConfig
+            switch self.progressFlags.progress {
+            case .none: progressConfig = try ProgressConfig(disableProgressUpdates: true)
+            case .ansi:
+                progressConfig = try ProgressConfig(
+                    description: "Pushing \(matchingTags.count) tags",
+                    showPercent: false,
+                    showItems: false,
+                    showSpeed: false,
+                    ignoreSmallSize: true
+                )
+            }
+
+            let progress = ProgressBar(config: progressConfig)
+            defer {
+                progress.finish()
+            }
+            progress.start()
+            try await ClientImage.pushAllTags(
+                reference: reference, platform: platform, scheme: scheme,
+                maxConcurrentUploads: imageUploadFlags.maxConcurrentUploads, progressUpdate: progress.handler)
+            progress.finish()
+
+            let formatter = ByteCountFormatter()
+            for img in matchingTags {
+                let tag = (try? Reference.parse(img.reference))?.tag ?? "<none>"
+                let size = formatter.string(fromByteCount: img.descriptor.size)
+                print("\(tag): digest: \(img.descriptor.digest) size: \(size)")
+            }
         }
     }
 }

--- a/Sources/ContainerCommands/Image/ImagePush.swift
+++ b/Sources/ContainerCommands/Image/ImagePush.swift
@@ -41,7 +41,7 @@ extension Application {
         var imageUploadFlags: Flags.ImageUpload
 
         @Option(
-            name: .long,
+            name: .shortAndLong,
             help: "Limit the push to the specified architecture"
         )
         var arch: String?
@@ -54,7 +54,7 @@ extension Application {
         @Option(help: "Limit the push to the specified platform (format: os/arch[/variant], takes precedence over --os and --arch) [environment: CONTAINER_DEFAULT_PLATFORM]")
         var platform: String?
 
-        @Flag(name: .shortAndLong, help: "Push all tags of an image")
+        @Flag(name: .long, help: "Push all tags of an image")
         var allTags: Bool = false
 
         @OptionGroup
@@ -68,10 +68,10 @@ extension Application {
             if allTags {
                 let ref = try Reference.parse(reference)
                 if ref.tag != nil {
-                    throw ContainerizationError(.invalidArgument, message: "tag can't be used with --all-tags/-a")
+                    throw ContainerizationError(.invalidArgument, message: "tag can't be used with --all-tags")
                 }
                 if ref.digest != nil {
-                    throw ContainerizationError(.invalidArgument, message: "digest can't be used with --all-tags/-a")
+                    throw ContainerizationError(.invalidArgument, message: "digest can't be used with --all-tags")
                 }
             }
         }
@@ -114,40 +114,13 @@ extension Application {
                 log.warning("--platform/--arch/--os with --all-tags filters each tag push to the specified platform; tags without matching manifests may fail")
             }
 
-            // Enumerate matching tags for display before pushing.
-            let allImages = try await ClientImage.list()
             let normalized = try ClientImage.normalizeReference(reference, containerSystemConfig: containerSystemConfig)
-            let parsedRef = try Reference.parse(normalized)
-            let repoName: String
-            if let resolved = parsedRef.resolvedDomain {
-                repoName = "\(resolved)/\(parsedRef.path)"
-            } else {
-                repoName = parsedRef.name
-            }
-
-            let matchingTags = allImages.filter { img in
-                guard
-                    !Utility.isInfraImage(
-                        name: img.reference,
-                        builderImage: containerSystemConfig.build.image,
-                        initImage: containerSystemConfig.vminit.image)
-                else { return false }
-                guard let ref = try? Reference.parse(img.reference) else { return false }
-                let resolvedName: String
-                if let resolved = ref.resolvedDomain {
-                    resolvedName = "\(resolved)/\(ref.path)"
-                } else {
-                    resolvedName = ref.name
-                }
-                return resolvedName == repoName
-            }
-
             let displayRepo = try ClientImage.denormalizeReference(normalized, containerSystemConfig: containerSystemConfig)
             let displayName = try Reference.parse(displayRepo).name
             print("The push refers to repository [\(displayName)]")
 
             let progressConfig = try self.progressFlags.makeConfig(
-                description: "Pushing \(matchingTags.count) tags",
+                description: "Pushing tags",
                 ignoreSmallSize: true
             )
 
@@ -156,13 +129,13 @@ extension Application {
                 progress.finish()
             }
             progress.start()
-            try await ClientImage.pushAllTags(
+            let pushed = try await ClientImage.pushAllTags(
                 reference: reference, platform: platform, scheme: scheme, containerSystemConfig: containerSystemConfig,
                 maxConcurrentUploads: imageUploadFlags.maxConcurrentUploads, progressUpdate: progress.handler)
             progress.finish()
 
             let formatter = ByteCountFormatter()
-            for img in matchingTags {
+            for img in pushed {
                 let tag = (try? Reference.parse(img.reference))?.tag ?? "<none>"
                 let size = formatter.string(fromByteCount: img.descriptor.size)
                 print("\(tag): digest: \(img.descriptor.digest) size: \(size)")

--- a/Sources/ContainerCommands/Image/ImagePush.swift
+++ b/Sources/ContainerCommands/Image/ImagePush.swift
@@ -19,7 +19,9 @@ import ContainerAPIClient
 import ContainerPersistence
 import ContainerPlugin
 import Containerization
+import ContainerizationError
 import ContainerizationOCI
+import Foundation
 import TerminalProgress
 
 extension Application {
@@ -35,8 +37,11 @@ extension Application {
         @OptionGroup
         var progressFlags: Flags.Progress
 
+        @OptionGroup
+        var imageUploadFlags: Flags.ImageUpload
+
         @Option(
-            name: .shortAndLong,
+            name: .long,
             help: "Limit the push to the specified architecture"
         )
         var arch: String?
@@ -49,6 +54,9 @@ extension Application {
         @Option(help: "Limit the push to the specified platform (format: os/arch[/variant], takes precedence over --os and --arch) [environment: CONTAINER_DEFAULT_PLATFORM]")
         var platform: String?
 
+        @Flag(name: .shortAndLong, help: "Push all tags of an image")
+        var allTags: Bool = false
+
         @OptionGroup
         public var logOptions: Flags.Logging
 
@@ -56,11 +64,31 @@ extension Application {
 
         public init() {}
 
+        public func validate() throws {
+            if allTags {
+                let ref = try Reference.parse(reference)
+                if ref.tag != nil {
+                    throw ContainerizationError(.invalidArgument, message: "tag can't be used with --all-tags/-a")
+                }
+                if ref.digest != nil {
+                    throw ContainerizationError(.invalidArgument, message: "digest can't be used with --all-tags/-a")
+                }
+            }
+        }
+
         public func run() async throws {
             let containerSystemConfig: ContainerSystemConfig = try await Application.loadContainerSystemConfig()
             let p = try DefaultPlatform.resolve(platform: platform, os: os, arch: arch, log: log)
-
             let scheme = try RequestScheme(registry.scheme)
+
+            if allTags {
+                try await pushAllTags(platform: p, scheme: scheme, containerSystemConfig: containerSystemConfig)
+            } else {
+                try await pushSingle(platform: p, scheme: scheme, containerSystemConfig: containerSystemConfig)
+            }
+        }
+
+        private func pushSingle(platform: Platform?, scheme: RequestScheme, containerSystemConfig: ContainerSystemConfig) async throws {
             let image = try await ClientImage.get(reference: reference, containerSystemConfig: containerSystemConfig)
 
             let progressConfig = try self.progressFlags.makeConfig(
@@ -76,9 +104,69 @@ extension Application {
                 progress.finish()
             }
             progress.start()
-            _ = try await image.push(platform: p, scheme: scheme, containerSystemConfig: containerSystemConfig, progressUpdate: progress.handler)
+            try await image.push(platform: platform, scheme: scheme, containerSystemConfig: containerSystemConfig, progressUpdate: progress.handler)
             progress.finish()
             print(image.reference)
+        }
+
+        private func pushAllTags(platform: Platform?, scheme: RequestScheme, containerSystemConfig: ContainerSystemConfig) async throws {
+            if self.platform != nil || arch != nil || os != nil {
+                log.warning("--platform/--arch/--os with --all-tags filters each tag push to the specified platform; tags without matching manifests may fail")
+            }
+
+            // Enumerate matching tags for display before pushing.
+            let allImages = try await ClientImage.list()
+            let normalized = try ClientImage.normalizeReference(reference, containerSystemConfig: containerSystemConfig)
+            let parsedRef = try Reference.parse(normalized)
+            let repoName: String
+            if let resolved = parsedRef.resolvedDomain {
+                repoName = "\(resolved)/\(parsedRef.path)"
+            } else {
+                repoName = parsedRef.name
+            }
+
+            let matchingTags = allImages.filter { img in
+                guard
+                    !Utility.isInfraImage(
+                        name: img.reference,
+                        builderImage: containerSystemConfig.build.image,
+                        initImage: containerSystemConfig.vminit.image)
+                else { return false }
+                guard let ref = try? Reference.parse(img.reference) else { return false }
+                let resolvedName: String
+                if let resolved = ref.resolvedDomain {
+                    resolvedName = "\(resolved)/\(ref.path)"
+                } else {
+                    resolvedName = ref.name
+                }
+                return resolvedName == repoName
+            }
+
+            let displayRepo = try ClientImage.denormalizeReference(normalized, containerSystemConfig: containerSystemConfig)
+            let displayName = try Reference.parse(displayRepo).name
+            print("The push refers to repository [\(displayName)]")
+
+            let progressConfig = try self.progressFlags.makeConfig(
+                description: "Pushing \(matchingTags.count) tags",
+                ignoreSmallSize: true
+            )
+
+            let progress = ProgressBar(config: progressConfig)
+            defer {
+                progress.finish()
+            }
+            progress.start()
+            try await ClientImage.pushAllTags(
+                reference: reference, platform: platform, scheme: scheme, containerSystemConfig: containerSystemConfig,
+                maxConcurrentUploads: imageUploadFlags.maxConcurrentUploads, progressUpdate: progress.handler)
+            progress.finish()
+
+            let formatter = ByteCountFormatter()
+            for img in matchingTags {
+                let tag = (try? Reference.parse(img.reference))?.tag ?? "<none>"
+                let size = formatter.string(fromByteCount: img.descriptor.size)
+                print("\(tag): digest: \(img.descriptor.digest) size: \(size)")
+            }
         }
     }
 }

--- a/Sources/Services/ContainerAPIService/Client/ClientImage.swift
+++ b/Sources/Services/ContainerAPIService/Client/ClientImage.swift
@@ -283,9 +283,10 @@ extension ClientImage {
         return image
     }
 
+    @discardableResult
     public static func pushAllTags(
         reference: String, platform: Platform? = nil, scheme: RequestScheme = .auto, maxConcurrentUploads: Int = 3, progressUpdate: ProgressUpdateHandler? = nil
-    ) async throws {
+    ) async throws -> [ClientImage] {
         guard maxConcurrentUploads > 0 else {
             throw ContainerizationError(.invalidArgument, message: "maximum number of concurrent uploads must be greater than 0, got \(maxConcurrentUploads)")
         }
@@ -321,8 +322,13 @@ extension ClientImage {
             progressUpdateClient = await ProgressUpdateClient(for: progressUpdate, request: request)
         }
 
-        _ = try await client.send(request)
+        let response = try await client.send(request)
         await progressUpdateClient?.finish()
+
+        let imageDescriptions = try response.imageDescriptions()
+        return imageDescriptions.map { desc in
+            ClientImage(description: desc)
+        }
     }
 
     public static func delete(reference: String, garbageCollect: Bool = false) async throws {

--- a/Sources/Services/ContainerAPIService/Client/ClientImage.swift
+++ b/Sources/Services/ContainerAPIService/Client/ClientImage.swift
@@ -283,6 +283,48 @@ extension ClientImage {
         return image
     }
 
+    public static func pushAllTags(
+        reference: String, platform: Platform? = nil, scheme: RequestScheme = .auto, maxConcurrentUploads: Int = 3, progressUpdate: ProgressUpdateHandler? = nil
+    ) async throws {
+        guard maxConcurrentUploads > 0 else {
+            throw ContainerizationError(.invalidArgument, message: "maximum number of concurrent uploads must be greater than 0, got \(maxConcurrentUploads)")
+        }
+
+        // Normalize the reference, then extract the repository name without the tag.
+        let normalized = try Self.normalizeReference(reference)
+        let parsedRef = try Reference.parse(normalized)
+
+        let repositoryName: String
+        if let resolved = parsedRef.resolvedDomain {
+            repositoryName = "\(resolved)/\(parsedRef.path)"
+        } else {
+            repositoryName = parsedRef.name
+        }
+
+        guard let host = parsedRef.domain else {
+            throw ContainerizationError(.invalidArgument, message: "could not extract host from reference \(normalized)")
+        }
+
+        let client = newXPCClient()
+        let request = newRequest(.imagePush)
+
+        request.set(key: .imageRepository, value: repositoryName)
+        request.set(key: .allTags, value: true)
+        try request.set(platform: platform)
+
+        let insecure = try scheme.schemeFor(host: host) == .http
+        request.set(key: .insecureFlag, value: insecure)
+        request.set(key: .maxConcurrentUploads, value: Int64(maxConcurrentUploads))
+
+        var progressUpdateClient: ProgressUpdateClient?
+        if let progressUpdate {
+            progressUpdateClient = await ProgressUpdateClient(for: progressUpdate, request: request)
+        }
+
+        _ = try await client.send(request)
+        await progressUpdateClient?.finish()
+    }
+
     public static func delete(reference: String, garbageCollect: Bool = false) async throws {
         let client = newXPCClient()
         let request = newRequest(.imageDelete)

--- a/Sources/Services/ContainerAPIService/Client/ClientImage.swift
+++ b/Sources/Services/ContainerAPIService/Client/ClientImage.swift
@@ -293,16 +293,10 @@ extension ClientImage {
             throw ContainerizationError(.invalidArgument, message: "maximum number of concurrent uploads must be greater than 0, got \(maxConcurrentUploads)")
         }
 
-        // Normalize the reference, then extract the repository name without the tag.
         let normalized = try Self.normalizeReference(reference, containerSystemConfig: containerSystemConfig)
         let parsedRef = try Reference.parse(normalized)
 
-        let repositoryName: String
-        if let resolved = parsedRef.resolvedDomain {
-            repositoryName = "\(resolved)/\(parsedRef.path)"
-        } else {
-            repositoryName = parsedRef.name
-        }
+        let repositoryName = Utility.repositoryName(for: parsedRef)
 
         guard let host = parsedRef.domain else {
             throw ContainerizationError(.invalidArgument, message: "could not extract host from reference \(normalized)")

--- a/Sources/Services/ContainerAPIService/Client/ClientImage.swift
+++ b/Sources/Services/ContainerAPIService/Client/ClientImage.swift
@@ -284,10 +284,11 @@ extension ClientImage {
         return image
     }
 
+    @discardableResult
     public static func pushAllTags(
         reference: String, platform: Platform? = nil, scheme: RequestScheme = .auto, containerSystemConfig: ContainerSystemConfig,
         maxConcurrentUploads: Int = 3, progressUpdate: ProgressUpdateHandler? = nil
-    ) async throws {
+    ) async throws -> [ClientImage] {
         guard maxConcurrentUploads > 0 else {
             throw ContainerizationError(.invalidArgument, message: "maximum number of concurrent uploads must be greater than 0, got \(maxConcurrentUploads)")
         }
@@ -323,8 +324,13 @@ extension ClientImage {
             progressUpdateClient = await ProgressUpdateClient(for: progressUpdate, request: request)
         }
 
-        _ = try await client.send(request)
+        let response = try await client.send(request)
         await progressUpdateClient?.finish()
+
+        let imageDescriptions = try response.imageDescriptions()
+        return imageDescriptions.map { desc in
+            ClientImage(description: desc)
+        }
     }
 
     public static func delete(reference: String, garbageCollect: Bool = false) async throws {

--- a/Sources/Services/ContainerAPIService/Client/ClientImage.swift
+++ b/Sources/Services/ContainerAPIService/Client/ClientImage.swift
@@ -284,6 +284,49 @@ extension ClientImage {
         return image
     }
 
+    public static func pushAllTags(
+        reference: String, platform: Platform? = nil, scheme: RequestScheme = .auto, containerSystemConfig: ContainerSystemConfig,
+        maxConcurrentUploads: Int = 3, progressUpdate: ProgressUpdateHandler? = nil
+    ) async throws {
+        guard maxConcurrentUploads > 0 else {
+            throw ContainerizationError(.invalidArgument, message: "maximum number of concurrent uploads must be greater than 0, got \(maxConcurrentUploads)")
+        }
+
+        // Normalize the reference, then extract the repository name without the tag.
+        let normalized = try Self.normalizeReference(reference, containerSystemConfig: containerSystemConfig)
+        let parsedRef = try Reference.parse(normalized)
+
+        let repositoryName: String
+        if let resolved = parsedRef.resolvedDomain {
+            repositoryName = "\(resolved)/\(parsedRef.path)"
+        } else {
+            repositoryName = parsedRef.name
+        }
+
+        guard let host = parsedRef.domain else {
+            throw ContainerizationError(.invalidArgument, message: "could not extract host from reference \(normalized)")
+        }
+
+        let client = newXPCClient()
+        let request = newRequest(.imagePush)
+
+        request.set(key: .imageRepository, value: repositoryName)
+        request.set(key: .allTags, value: true)
+        try request.set(platform: platform)
+
+        let insecure = try scheme.schemeFor(host: host, internalDnsDomain: containerSystemConfig.dns.domain) == .http
+        request.set(key: .insecureFlag, value: insecure)
+        request.set(key: .maxConcurrentUploads, value: Int64(maxConcurrentUploads))
+
+        var progressUpdateClient: ProgressUpdateClient?
+        if let progressUpdate {
+            progressUpdateClient = await ProgressUpdateClient(for: progressUpdate, request: request)
+        }
+
+        _ = try await client.send(request)
+        await progressUpdateClient?.finish()
+    }
+
     public static func delete(reference: String, garbageCollect: Bool = false) async throws {
         let client = newXPCClient()
         let request = newRequest(.imageDelete)

--- a/Sources/Services/ContainerAPIService/Client/Flags.swift
+++ b/Sources/Services/ContainerAPIService/Client/Flags.swift
@@ -353,4 +353,15 @@ public struct Flags {
         @Option(name: .long, help: "Maximum number of concurrent downloads (default: 3)")
         public var maxConcurrentDownloads: Int = 3
     }
+
+    public struct ImageUpload: ParsableArguments {
+        public init() {}
+
+        public init(maxConcurrentUploads: Int) {
+            self.maxConcurrentUploads = maxConcurrentUploads
+        }
+
+        @Option(name: .long, help: ArgumentHelp("Maximum number of concurrent uploads with --all-tags", valueName: "count"))
+        public var maxConcurrentUploads: Int = 3
+    }
 }

--- a/Sources/Services/ContainerAPIService/Client/Flags.swift
+++ b/Sources/Services/ContainerAPIService/Client/Flags.swift
@@ -392,4 +392,15 @@ public struct Flags {
         @Option(name: .long, help: "Maximum number of concurrent downloads (default: 3)")
         public var maxConcurrentDownloads: Int = 3
     }
+
+    public struct ImageUpload: ParsableArguments {
+        public init() {}
+
+        public init(maxConcurrentUploads: Int) {
+            self.maxConcurrentUploads = maxConcurrentUploads
+        }
+
+        @Option(name: .long, help: ArgumentHelp("Maximum number of concurrent uploads with --all-tags", valueName: "count"))
+        public var maxConcurrentUploads: Int = 3
+    }
 }

--- a/Sources/Services/ContainerAPIService/Client/Utility.swift
+++ b/Sources/Services/ContainerAPIService/Client/Utility.swift
@@ -43,6 +43,10 @@ public struct Utility {
         return false
     }
 
+    public static func repositoryName(for ref: Reference) -> String {
+        ref.resolvedDomain.map { "\($0)/\(ref.path)" } ?? ref.name
+    }
+
     public static func trimDigest(digest: String) -> String {
         var digest = digest
         digest.trimPrefix("sha256:")

--- a/Sources/Services/ContainerImagesService/Client/ImageServiceXPCKeys.swift
+++ b/Sources/Services/ContainerImagesService/Client/ImageServiceXPCKeys.swift
@@ -36,6 +36,9 @@ public enum ImagesServiceXPCKeys: String {
     case insecureFlag
     case garbageCollect
     case maxConcurrentDownloads
+    case maxConcurrentUploads
+    case allTags
+    case imageRepository
     case forceLoad
     case rejectedMembers
 

--- a/Sources/Services/ContainerImagesService/Server/ImagesService.swift
+++ b/Sources/Services/ContainerImagesService/Server/ImagesService.swift
@@ -136,7 +136,9 @@ public actor ImagesService {
         }
     }
 
-    public func pushAllTags(repositoryName: String, platform: Platform?, insecure: Bool, maxConcurrentUploads: Int, progressUpdate: ProgressUpdateHandler?) async throws {
+    public func pushAllTags(repositoryName: String, platform: Platform?, insecure: Bool, maxConcurrentUploads: Int, progressUpdate: ProgressUpdateHandler?) async throws
+        -> [ImageDescription]
+    {
         self.log.debug(
             "ImagesService: enter",
             metadata: [
@@ -220,6 +222,8 @@ public actor ImagesService {
                 throw ContainerizationError(.internalError, message: "failed to push one or more tags:\n\(details)")
             }
         }
+
+        return matchingImages.map { $0.description.fromCZ }
     }
 
     public func tag(old: String, new: String) async throws -> ImageDescription {

--- a/Sources/Services/ContainerImagesService/Server/ImagesService.swift
+++ b/Sources/Services/ContainerImagesService/Server/ImagesService.swift
@@ -136,6 +136,92 @@ public actor ImagesService {
         }
     }
 
+    public func pushAllTags(repositoryName: String, platform: Platform?, insecure: Bool, maxConcurrentUploads: Int, progressUpdate: ProgressUpdateHandler?) async throws {
+        self.log.debug(
+            "ImagesService: enter",
+            metadata: [
+                "func": "\(#function)",
+                "repositoryName": "\(repositoryName)",
+                "platform": "\(String(describing: platform))",
+                "insecure": "\(insecure)",
+                "maxConcurrentUploads": "\(maxConcurrentUploads)",
+            ]
+        )
+        defer {
+            self.log.debug(
+                "ImagesService: exit",
+                metadata: [
+                    "func": "\(#function)",
+                    "repositoryName": "\(repositoryName)",
+                    "platform": "\(String(describing: platform))",
+                ]
+            )
+        }
+
+        let allImages = try await imageStore.list()
+        let matchingImages = allImages.filter { image in
+            guard !Utility.isInfraImage(name: image.reference) else { return false }
+            guard let ref = try? Reference.parse(image.reference) else { return false }
+            let resolvedName: String
+            if let resolved = ref.resolvedDomain {
+                resolvedName = "\(resolved)/\(ref.path)"
+            } else {
+                resolvedName = ref.name
+            }
+            return resolvedName == repositoryName
+        }
+
+        guard !matchingImages.isEmpty else {
+            throw ContainerizationError(.notFound, message: "no tags found for repository \(repositoryName)")
+        }
+
+        let maxConcurrent = maxConcurrentUploads > 0 ? maxConcurrentUploads : 3
+
+        try await Self.withAuthentication(ref: repositoryName) { auth in
+            let progress = ContainerizationProgressAdapter.handler(from: progressUpdate)
+            var iterator = matchingImages.makeIterator()
+            var failures: [(reference: String, message: String)] = []
+
+            await withTaskGroup(of: (String, String?).self) { group in
+                for _ in 0..<maxConcurrent {
+                    guard let image = iterator.next() else { break }
+                    let ref = image.reference
+                    group.addTask {
+                        do {
+                            try await self.imageStore.push(
+                                reference: ref, platform: platform, insecure: insecure, auth: auth, progress: progress)
+                            return (ref, nil)
+                        } catch {
+                            return (ref, String(describing: error))
+                        }
+                    }
+                }
+                for await (ref, error) in group {
+                    if let error {
+                        failures.append((ref, error))
+                    }
+                    if let image = iterator.next() {
+                        let nextRef = image.reference
+                        group.addTask {
+                            do {
+                                try await self.imageStore.push(
+                                    reference: nextRef, platform: platform, insecure: insecure, auth: auth, progress: progress)
+                                return (nextRef, nil)
+                            } catch {
+                                return (nextRef, String(describing: error))
+                            }
+                        }
+                    }
+                }
+            }
+
+            if !failures.isEmpty {
+                let details = failures.map { "\($0.reference): \($0.message)" }.joined(separator: "\n")
+                throw ContainerizationError(.internalError, message: "failed to push one or more tags:\n\(details)")
+            }
+        }
+    }
+
     public func tag(old: String, new: String) async throws -> ImageDescription {
         self.log.debug(
             "ImagesService: enter",

--- a/Sources/Services/ContainerImagesService/Server/ImagesService.swift
+++ b/Sources/Services/ContainerImagesService/Server/ImagesService.swift
@@ -141,6 +141,91 @@ public actor ImagesService {
         }
     }
 
+    public func pushAllTags(repositoryName: String, platform: Platform?, insecure: Bool, maxConcurrentUploads: Int, progressUpdate: ProgressUpdateHandler?) async throws {
+        self.log.debug(
+            "ImagesService: enter",
+            metadata: [
+                "func": "\(#function)",
+                "repositoryName": "\(repositoryName)",
+                "platform": "\(String(describing: platform))",
+                "insecure": "\(insecure)",
+                "maxConcurrentUploads": "\(maxConcurrentUploads)",
+            ]
+        )
+        defer {
+            self.log.debug(
+                "ImagesService: exit",
+                metadata: [
+                    "func": "\(#function)",
+                    "repositoryName": "\(repositoryName)",
+                    "platform": "\(String(describing: platform))",
+                ]
+            )
+        }
+
+        let allImages = try await imageStore.list()
+        let matchingImages = allImages.filter { image in
+            guard let ref = try? Reference.parse(image.reference) else { return false }
+            let resolvedName: String
+            if let resolved = ref.resolvedDomain {
+                resolvedName = "\(resolved)/\(ref.path)"
+            } else {
+                resolvedName = ref.name
+            }
+            return resolvedName == repositoryName
+        }
+
+        guard !matchingImages.isEmpty else {
+            throw ContainerizationError(.notFound, message: "no tags found for repository \(repositoryName)")
+        }
+
+        let maxConcurrent = maxConcurrentUploads > 0 ? maxConcurrentUploads : 3
+
+        try await Self.withAuthentication(ref: repositoryName) { auth in
+            let progress = ContainerizationProgressAdapter.handler(from: progressUpdate)
+            var iterator = matchingImages.makeIterator()
+            var failures: [(reference: String, message: String)] = []
+
+            await withTaskGroup(of: (String, String?).self) { group in
+                for _ in 0..<maxConcurrent {
+                    guard let image = iterator.next() else { break }
+                    let ref = image.reference
+                    group.addTask {
+                        do {
+                            try await self.imageStore.push(
+                                reference: ref, platform: platform, insecure: insecure, auth: auth, progress: progress)
+                            return (ref, nil)
+                        } catch {
+                            return (ref, String(describing: error))
+                        }
+                    }
+                }
+                for await (ref, error) in group {
+                    if let error {
+                        failures.append((ref, error))
+                    }
+                    if let image = iterator.next() {
+                        let nextRef = image.reference
+                        group.addTask {
+                            do {
+                                try await self.imageStore.push(
+                                    reference: nextRef, platform: platform, insecure: insecure, auth: auth, progress: progress)
+                                return (nextRef, nil)
+                            } catch {
+                                return (nextRef, String(describing: error))
+                            }
+                        }
+                    }
+                }
+            }
+
+            if !failures.isEmpty {
+                let details = failures.map { "\($0.reference): \($0.message)" }.joined(separator: "\n")
+                throw ContainerizationError(.internalError, message: "failed to push one or more tags:\n\(details)")
+            }
+        }
+    }
+
     public func tag(old: String, new: String) async throws -> ImageDescription {
         self.log.debug(
             "ImagesService: enter",

--- a/Sources/Services/ContainerImagesService/Server/ImagesService.swift
+++ b/Sources/Services/ContainerImagesService/Server/ImagesService.swift
@@ -141,7 +141,9 @@ public actor ImagesService {
         }
     }
 
-    public func pushAllTags(repositoryName: String, platform: Platform?, insecure: Bool, maxConcurrentUploads: Int, progressUpdate: ProgressUpdateHandler?) async throws {
+    public func pushAllTags(repositoryName: String, platform: Platform?, insecure: Bool, maxConcurrentUploads: Int, progressUpdate: ProgressUpdateHandler?) async throws
+        -> [ImageDescription]
+    {
         self.log.debug(
             "ImagesService: enter",
             metadata: [
@@ -224,6 +226,8 @@ public actor ImagesService {
                 throw ContainerizationError(.internalError, message: "failed to push one or more tags:\n\(details)")
             }
         }
+
+        return matchingImages.map { $0.description.fromCZ }
     }
 
     public func tag(old: String, new: String) async throws -> ImageDescription {

--- a/Sources/Services/ContainerImagesService/Server/ImagesService.swift
+++ b/Sources/Services/ContainerImagesService/Server/ImagesService.swift
@@ -168,63 +168,23 @@ public actor ImagesService {
         let allImages = try await imageStore.list()
         let matchingImages = allImages.filter { image in
             guard let ref = try? Reference.parse(image.reference) else { return false }
-            let resolvedName: String
-            if let resolved = ref.resolvedDomain {
-                resolvedName = "\(resolved)/\(ref.path)"
-            } else {
-                resolvedName = ref.name
-            }
-            return resolvedName == repositoryName
+            return Utility.repositoryName(for: ref) == repositoryName
         }
 
         guard !matchingImages.isEmpty else {
             throw ContainerizationError(.notFound, message: "no tags found for repository \(repositoryName)")
         }
 
-        let maxConcurrent = maxConcurrentUploads > 0 ? maxConcurrentUploads : 3
+        guard maxConcurrentUploads > 0 else {
+            throw ContainerizationError(.invalidArgument, message: "maximum number of concurrent uploads must be greater than 0, got \(maxConcurrentUploads)")
+        }
 
         try await Self.withAuthentication(ref: repositoryName) { auth in
-            let progress = ContainerizationProgressAdapter.handler(from: progressUpdate)
-            var iterator = matchingImages.makeIterator()
-            var failures: [(reference: String, message: String)] = []
-
-            await withTaskGroup(of: (String, String?).self) { group in
-                for _ in 0..<maxConcurrent {
-                    guard let image = iterator.next() else { break }
-                    let ref = image.reference
-                    group.addTask {
-                        do {
-                            try await self.imageStore.push(
-                                reference: ref, platform: platform, insecure: insecure, auth: auth, progress: progress)
-                            return (ref, nil)
-                        } catch {
-                            return (ref, String(describing: error))
-                        }
-                    }
-                }
-                for await (ref, error) in group {
-                    if let error {
-                        failures.append((ref, error))
-                    }
-                    if let image = iterator.next() {
-                        let nextRef = image.reference
-                        group.addTask {
-                            do {
-                                try await self.imageStore.push(
-                                    reference: nextRef, platform: platform, insecure: insecure, auth: auth, progress: progress)
-                                return (nextRef, nil)
-                            } catch {
-                                return (nextRef, String(describing: error))
-                            }
-                        }
-                    }
-                }
-            }
-
-            if !failures.isEmpty {
-                let details = failures.map { "\($0.reference): \($0.message)" }.joined(separator: "\n")
-                throw ContainerizationError(.internalError, message: "failed to push one or more tags:\n\(details)")
-            }
+            try await self.imageStore.push(
+                references: matchingImages.map { $0.reference },
+                platform: platform, insecure: insecure, auth: auth,
+                maxConcurrentUploads: maxConcurrentUploads,
+                progress: ContainerizationProgressAdapter.handler(from: progressUpdate))
         }
 
         return matchingImages.map { $0.description.fromCZ }

--- a/Sources/Services/ContainerImagesService/Server/ImagesServiceHarness.swift
+++ b/Sources/Services/ContainerImagesService/Server/ImagesServiceHarness.swift
@@ -80,9 +80,14 @@ public struct ImagesServiceHarness: Sendable {
                 )
             }
             let maxConcurrentUploads = message.int64(key: .maxConcurrentUploads)
-            try await service.pushAllTags(
+            let pushed = try await service.pushAllTags(
                 repositoryName: repository, platform: platform, insecure: insecure,
                 maxConcurrentUploads: Int(maxConcurrentUploads), progressUpdate: progressUpdateService?.handler)
+
+            let reply = message.reply()
+            let imageData = try JSONEncoder().encode(pushed)
+            reply.set(key: .imageDescriptions, value: imageData)
+            return reply
         } else {
             let ref = message.string(key: .imageReference)
             guard let ref else {

--- a/Sources/Services/ContainerImagesService/Server/ImagesServiceHarness.swift
+++ b/Sources/Services/ContainerImagesService/Server/ImagesServiceHarness.swift
@@ -62,22 +62,37 @@ public struct ImagesServiceHarness: Sendable {
 
     @Sendable
     public func push(_ message: XPCMessage) async throws -> XPCMessage {
-        let ref = message.string(key: .imageReference)
-        guard let ref else {
-            throw ContainerizationError(
-                .invalidArgument,
-                message: "missing image reference"
-            )
-        }
         let platformData = message.dataNoCopy(key: .ociPlatform)
         var platform: Platform? = nil
         if let platformData {
             platform = try JSONDecoder().decode(ContainerizationOCI.Platform.self, from: platformData)
         }
         let insecure = message.bool(key: .insecureFlag)
+        let allTags = message.bool(key: .allTags)
 
         let progressUpdateService = ProgressUpdateService(message: message)
-        try await service.push(reference: ref, platform: platform, insecure: insecure, progressUpdate: progressUpdateService?.handler)
+        if allTags {
+            let repository = message.string(key: .imageRepository)
+            guard let repository else {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "missing image repository"
+                )
+            }
+            let maxConcurrentUploads = message.int64(key: .maxConcurrentUploads)
+            try await service.pushAllTags(
+                repositoryName: repository, platform: platform, insecure: insecure,
+                maxConcurrentUploads: Int(maxConcurrentUploads), progressUpdate: progressUpdateService?.handler)
+        } else {
+            let ref = message.string(key: .imageReference)
+            guard let ref else {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "missing image reference"
+                )
+            }
+            try await service.push(reference: ref, platform: platform, insecure: insecure, progressUpdate: progressUpdateService?.handler)
+        }
 
         let reply = message.reply()
         return reply

--- a/Sources/Services/ContainerImagesService/Server/ImagesServiceHarness.swift
+++ b/Sources/Services/ContainerImagesService/Server/ImagesServiceHarness.swift
@@ -71,24 +71,7 @@ public struct ImagesServiceHarness: Sendable {
         let allTags = message.bool(key: .allTags)
 
         let progressUpdateService = ProgressUpdateService(message: message)
-        if allTags {
-            let repository = message.string(key: .imageRepository)
-            guard let repository else {
-                throw ContainerizationError(
-                    .invalidArgument,
-                    message: "missing image repository"
-                )
-            }
-            let maxConcurrentUploads = message.int64(key: .maxConcurrentUploads)
-            let pushed = try await service.pushAllTags(
-                repositoryName: repository, platform: platform, insecure: insecure,
-                maxConcurrentUploads: Int(maxConcurrentUploads), progressUpdate: progressUpdateService?.handler)
-
-            let reply = message.reply()
-            let imageData = try JSONEncoder().encode(pushed)
-            reply.set(key: .imageDescriptions, value: imageData)
-            return reply
-        } else {
+        guard allTags else {
             let ref = message.string(key: .imageReference)
             guard let ref else {
                 throw ContainerizationError(
@@ -97,9 +80,24 @@ public struct ImagesServiceHarness: Sendable {
                 )
             }
             try await service.push(reference: ref, platform: platform, insecure: insecure, progressUpdate: progressUpdateService?.handler)
+            return message.reply()
         }
 
+        let repository = message.string(key: .imageRepository)
+        guard let repository else {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "missing image repository"
+            )
+        }
+        let maxConcurrentUploads = message.int64(key: .maxConcurrentUploads)
+        let pushed = try await service.pushAllTags(
+            repositoryName: repository, platform: platform, insecure: insecure,
+            maxConcurrentUploads: Int(maxConcurrentUploads), progressUpdate: progressUpdateService?.handler)
+
         let reply = message.reply()
+        let imageData = try JSONEncoder().encode(pushed)
+        reply.set(key: .imageDescriptions, value: imageData)
         return reply
     }
 

--- a/Tests/CLITests/Subcommands/Images/TestCLIImagesCommand.swift
+++ b/Tests/CLITests/Subcommands/Images/TestCLIImagesCommand.swift
@@ -311,6 +311,49 @@ class TestCLIImagesCommand: CLITest {
             "Expected validation error message in output")
     }
 
+    @Test func testAllTagsRejectsTaggedReference() throws {
+        let (_, _, error, status) = try run(arguments: [
+            "image",
+            "push",
+            "--all-tags",
+            "alpine:latest",
+        ])
+
+        #expect(status != 0, "Expected --all-tags with a tag to fail")
+        #expect(
+            error.contains("tag can't be used with --all-tags/-a"),
+            "Expected tag validation error message in output")
+    }
+
+    @Test func testAllTagsRejectsDigestReference() throws {
+        let (_, _, error, status) = try run(arguments: [
+            "image",
+            "push",
+            "--all-tags",
+            "alpine@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        ])
+
+        #expect(status != 0, "Expected --all-tags with a digest to fail")
+        #expect(
+            error.contains("digest can't be used with --all-tags/-a"),
+            "Expected digest validation error message in output")
+    }
+
+    @Test func testMaxConcurrentUploadsValidation() throws {
+        let (_, _, error, status) = try run(arguments: [
+            "image",
+            "push",
+            "--all-tags",
+            "--max-concurrent-uploads", "0",
+            "alpine",
+        ])
+
+        #expect(status != 0, "Expected command to fail with maxConcurrentUploads=0")
+        #expect(
+            error.contains("maximum number of concurrent uploads must be greater than 0"),
+            "Expected validation error message in output")
+    }
+
     @Test func testImageLoadRejectsInvalidMembersWithoutForce() throws {
         do {
             // 0. Generate unique malicious filename for this test run

--- a/Tests/CLITests/Subcommands/Images/TestCLIImagesCommand.swift
+++ b/Tests/CLITests/Subcommands/Images/TestCLIImagesCommand.swift
@@ -321,7 +321,7 @@ class TestCLIImagesCommand: CLITest {
 
         #expect(status != 0, "Expected --all-tags with a tag to fail")
         #expect(
-            error.contains("tag can't be used with --all-tags/-a"),
+            error.contains("tag can't be used with --all-tags"),
             "Expected tag validation error message in output")
     }
 
@@ -335,7 +335,7 @@ class TestCLIImagesCommand: CLITest {
 
         #expect(status != 0, "Expected --all-tags with a digest to fail")
         #expect(
-            error.contains("digest can't be used with --all-tags/-a"),
+            error.contains("digest can't be used with --all-tags"),
             "Expected digest validation error message in output")
     }
 

--- a/Tests/CLITests/Subcommands/Images/TestCLIImagesCommand.swift
+++ b/Tests/CLITests/Subcommands/Images/TestCLIImagesCommand.swift
@@ -338,7 +338,7 @@ class TestCLIImagesCommand: CLITest {
 
         #expect(status != 0, "Expected --all-tags with a tag to fail")
         #expect(
-            error.contains("tag can't be used with --all-tags/-a"),
+            error.contains("tag can't be used with --all-tags"),
             "Expected tag validation error message in output")
     }
 
@@ -352,7 +352,7 @@ class TestCLIImagesCommand: CLITest {
 
         #expect(status != 0, "Expected --all-tags with a digest to fail")
         #expect(
-            error.contains("digest can't be used with --all-tags/-a"),
+            error.contains("digest can't be used with --all-tags"),
             "Expected digest validation error message in output")
     }
 

--- a/Tests/CLITests/Subcommands/Images/TestCLIImagesCommand.swift
+++ b/Tests/CLITests/Subcommands/Images/TestCLIImagesCommand.swift
@@ -328,6 +328,49 @@ class TestCLIImagesCommand: CLITest {
             "Expected validation error message in output")
     }
 
+    @Test func testAllTagsRejectsTaggedReference() throws {
+        let (_, _, error, status) = try run(arguments: [
+            "image",
+            "push",
+            "--all-tags",
+            "alpine:latest",
+        ])
+
+        #expect(status != 0, "Expected --all-tags with a tag to fail")
+        #expect(
+            error.contains("tag can't be used with --all-tags/-a"),
+            "Expected tag validation error message in output")
+    }
+
+    @Test func testAllTagsRejectsDigestReference() throws {
+        let (_, _, error, status) = try run(arguments: [
+            "image",
+            "push",
+            "--all-tags",
+            "alpine@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        ])
+
+        #expect(status != 0, "Expected --all-tags with a digest to fail")
+        #expect(
+            error.contains("digest can't be used with --all-tags/-a"),
+            "Expected digest validation error message in output")
+    }
+
+    @Test func testMaxConcurrentUploadsValidation() throws {
+        let (_, _, error, status) = try run(arguments: [
+            "image",
+            "push",
+            "--all-tags",
+            "--max-concurrent-uploads", "0",
+            "alpine",
+        ])
+
+        #expect(status != 0, "Expected command to fail with maxConcurrentUploads=0")
+        #expect(
+            error.contains("maximum number of concurrent uploads must be greater than 0"),
+            "Expected validation error message in output")
+    }
+
     @Test func testImageLoadRejectsInvalidMembersWithoutForce() throws {
         do {
             // 0. Generate unique malicious filename for this test run

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -522,18 +522,20 @@ Pushes an image to a registry. The flags mirror those for `image pull` with the 
 **Usage**
 
 ```bash
-container image push [--scheme <scheme>] [--progress <type>] [--arch <arch>] [--os <os>] [--platform <platform>] [--debug] <reference>
+container image push [--scheme <scheme>] [--progress <type>] [--arch <arch>] [--os <os>] [--platform <platform>] [--all-tags] [--max-concurrent-uploads <count>] [--debug] <reference>
 ```
 
 **Arguments**
 
-*   `<reference>`: Image reference to push
+*   `<reference>`: Image reference to push. When using `--all-tags`, this should be a repository name without a tag.
 
 **Options**
 
 *   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https, auto) (default: auto)
 *   `--progress <type>`: Progress type (format: none|ansi) (default: ansi)
-*   `-a, --arch <arch>`: Limit the push to the specified architecture
+*   `-a, --all-tags`: Push all tags of an image
+*   `--max-concurrent-uploads <count>`: Maximum number of concurrent uploads with --all-tags (default: 3)
+*   `--arch <arch>`: Limit the push to the specified architecture
 *   `--os <os>`: Limit the push to the specified OS
 *   `--platform <platform>`: Limit the push to the specified platform (format: os/arch[/variant], takes precedence over --os and --arch)
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -533,9 +533,9 @@ container image push [--scheme <scheme>] [--progress <type>] [--arch <arch>] [--
 
 *   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https, auto) (default: auto)
 *   `--progress <type>`: Progress type (format: none|ansi) (default: ansi)
-*   `-a, --all-tags`: Push all tags of an image
+*   `--all-tags`: Push all tags of an image
 *   `--max-concurrent-uploads <count>`: Maximum number of concurrent uploads with --all-tags (default: 3)
-*   `--arch <arch>`: Limit the push to the specified architecture
+*   `-a, --arch <arch>`: Limit the push to the specified architecture
 *   `--os <os>`: Limit the push to the specified OS
 *   `--platform <platform>`: Limit the push to the specified platform (format: os/arch[/variant], takes precedence over --os and --arch)
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -559,18 +559,20 @@ Pushes an image to a registry. The flags mirror those for `image pull` with the 
 **Usage**
 
 ```bash
-container image push [--scheme <scheme>] [--progress <type>] [--arch <arch>] [--os <os>] [--platform <platform>] [--debug] <reference>
+container image push [--scheme <scheme>] [--progress <type>] [--arch <arch>] [--os <os>] [--platform <platform>] [--all-tags] [--max-concurrent-uploads <count>] [--debug] <reference>
 ```
 
 **Arguments**
 
-*   `<reference>`: Image reference to push
+*   `<reference>`: Image reference to push. When using `--all-tags`, this should be a repository name without a tag.
 
 **Options**
 
 *   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https, auto) (default: auto)
 *   `--progress <type>`: Progress type (format: none|ansi|plain|color) (default: ansi)
-*   `-a, --arch <arch>`: Limit the push to the specified architecture
+*   `-a, --all-tags`: Push all tags of an image
+*   `--max-concurrent-uploads <count>`: Maximum number of concurrent uploads with --all-tags (default: 3)
+*   `--arch <arch>`: Limit the push to the specified architecture
 *   `--os <os>`: Limit the push to the specified OS
 *   `--platform <platform>`: Limit the push to the specified platform (format: os/arch[/variant], takes precedence over --os and --arch)
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -570,9 +570,9 @@ container image push [--scheme <scheme>] [--progress <type>] [--arch <arch>] [--
 
 *   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https, auto) (default: auto)
 *   `--progress <type>`: Progress type (format: none|ansi|plain|color) (default: ansi)
-*   `-a, --all-tags`: Push all tags of an image
+*   `--all-tags`: Push all tags of an image
 *   `--max-concurrent-uploads <count>`: Maximum number of concurrent uploads with --all-tags (default: 3)
-*   `--arch <arch>`: Limit the push to the specified architecture
+*   `-a, --arch <arch>`: Limit the push to the specified architecture
 *   `--os <os>`: Limit the push to the specified OS
 *   `--platform <platform>`: Limit the push to the specified platform (format: os/arch[/variant], takes precedence over --os and --arch)
 


### PR DESCRIPTION
- Closes #1334.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context
Adds `--all-tags` (`-a`) support to `container image push`, which pushes all locally tagged versions of a repository in parallel with bounded concurrency (`--max-concurrent-uploads`, default 3). It continues pushing remaining tags if one fails.

Usage: `container image push --all-tags myregistry.io/myimage`
Example:
```
❯ container image push --all-tags ghcr.io/sometest/alltagstest
The push refers to repository [ghcr.io/sometest/alltagstest]
v1: digest: sha256:28a33e0598da2b341d05e53803c5982377039baedfc8a82a4910d5acc4788c99 size: 5 KB
v2: digest: sha256:28a33e0598da2b341d05e53803c5982377039baedfc8a82a4910d5acc4788c99 size: 5 KB
latest: digest: sha256:28a33e0598da2b341d05e53803c5982377039baedfc8a82a4910d5acc4788c99 size: 5 KB
```

Note: `-a` on `push` now means `--all-tags`, not `--arch`. `--arch` remains available as a long-form flag.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [x] Added/updated docs
