### PR TITLE
Fix: Avoid staging Dockerfiles into read-only build contexts

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -122,6 +122,12 @@ let package = Package(
                 "ContainerBuild"
             ]
         ),
+        .testTarget(
+            name: "ContainerCommandsTests",
+            dependencies: [
+                "ContainerCommands"
+            ]
+        ),
         .executableTarget(
             name: "container-apiserver",
             dependencies: [

--- a/Sources/ContainerCommands/BuildCommand.swift
+++ b/Sources/ContainerCommands/BuildCommand.swift
@@ -30,6 +30,26 @@ extension Application {
     public struct BuildCommand: AsyncLoggableCommand {
         private static let hiddenDockerDir = ".com.apple.container.dockerfiles"
 
+        static func stagedDockerfileArtifacts(
+            buildFileData: Data,
+            ignoreFileData: Data?
+        ) -> (hiddenDockerDir: String, dockerfileData: Data, ignoreFileData: Data)? {
+            guard var stagedIgnoreFileData = ignoreFileData else {
+                return nil
+            }
+
+            if !stagedIgnoreFileData.isEmpty, stagedIgnoreFileData.last != 0x0A {
+                stagedIgnoreFileData.append(0x0A)
+            }
+            stagedIgnoreFileData.append("\(Self.hiddenDockerDir)\n".data(using: .utf8) ?? Data())
+
+            return (
+                hiddenDockerDir: Self.hiddenDockerDir,
+                dockerfileData: buildFileData,
+                ignoreFileData: stagedIgnoreFileData
+            )
+        }
+
         public init() {}
         public static var configuration: CommandConfiguration {
             var config = CommandConfiguration()
@@ -246,18 +266,23 @@ extension Application {
                     buildFileData = try Data(contentsOf: URL(filePath: tempFile.path()))
                 } else {
                     let ignoreFileURL = URL(filePath: dockerfile + ".dockerignore")
+                    let rootIgnoreFileURL = URL(fileURLWithPath: contextDir).appendingPathComponent(".dockerignore")
                     buildFileData = try Data(contentsOf: URL(filePath: dockerfile))
                     ignoreFileData = try? Data(contentsOf: ignoreFileURL)
+                    if ignoreFileData == nil {
+                        ignoreFileData = try? Data(contentsOf: rootIgnoreFileURL)
+                    }
 
-                    if var ignoreFileData {
-                        hiddenDockerDir = Self.hiddenDockerDir
-                        let hiddenDirInContext = URL(fileURLWithPath: contextDir).appendingPathComponent(Self.hiddenDockerDir)
+                    if let stagedArtifacts = Self.stagedDockerfileArtifacts(
+                        buildFileData: buildFileData,
+                        ignoreFileData: ignoreFileData
+                    ) {
+                        hiddenDockerDir = stagedArtifacts.hiddenDockerDir
+                        let hiddenDirInContext = URL(fileURLWithPath: contextDir).appendingPathComponent(stagedArtifacts.hiddenDockerDir)
 
                         try FileManager.default.createDirectory(at: hiddenDirInContext, withIntermediateDirectories: true)
-                        try buildFileData.write(to: hiddenDirInContext.appendingPathComponent("Dockerfile"))
-
-                        ignoreFileData.append("\n\(Self.hiddenDockerDir)".data(using: .utf8) ?? Data())
-                        try ignoreFileData.write(to: hiddenDirInContext.appendingPathComponent("Dockerfile.dockerignore"))
+                        try stagedArtifacts.dockerfileData.write(to: hiddenDirInContext.appendingPathComponent("Dockerfile"))
+                        try stagedArtifacts.ignoreFileData.write(to: hiddenDirInContext.appendingPathComponent("Dockerfile.dockerignore"))
                     }
                 }
 

--- a/Tests/ContainerCommandsTests/BuildCommandTests.swift
+++ b/Tests/ContainerCommandsTests/BuildCommandTests.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import ContainerCommands
+
+struct BuildCommandTests {
+    @Test
+    func testStagedDockerfileArtifactsSkipStagingWithoutIgnoreFile() {
+        let artifacts = Application.BuildCommand.stagedDockerfileArtifacts(
+            buildFileData: Data("FROM scratch\n".utf8),
+            ignoreFileData: nil
+        )
+
+        #expect(artifacts == nil)
+    }
+
+    @Test
+    func testStagedDockerfileArtifactsAppendHiddenDirectoryToIgnoreFile() throws {
+        let artifacts = Application.BuildCommand.stagedDockerfileArtifacts(
+            buildFileData: Data("FROM scratch\n".utf8),
+            ignoreFileData: Data("node_modules".utf8)
+        )
+
+        let staged = try #require(artifacts)
+        #expect(staged.hiddenDockerDir == ".com.apple.container.dockerfiles")
+        #expect(String(decoding: staged.dockerfileData, as: UTF8.self) == "FROM scratch\n")
+        #expect(
+            String(decoding: staged.ignoreFileData, as: UTF8.self)
+                == "node_modules\n.com.apple.container.dockerfiles\n"
+        )
+    }
+}


### PR DESCRIPTION
## Type of Change
- [X] Bug fix

## Motivation and Context

While building our docker-compose-like compose system for container, we noticed an issue in the build phase. The current build path always creates `.com.apple.container.dockerfiles/` inside the context and writes a staged Dockerfile there.

That introduces an issue for:

  - read-only checkouts
  - mounted source trees
  - otherwise immutable build contexts

Those builds can fail before BuildKit starts, even when there is no .dockerignore to rewrite.  Here, we fix container build so it does not require write access to the build context unless it actually needs to synthesize staged Dockerfile artifacts.

### Fix

  - Add a small helper that only produces staged Dockerfile artifacts when an ignore file exists.
  - Fall back to the root .dockerignore if Dockerfile.dockerignore is absent.
  - Skip hidden-directory creation entirely when there is no ignore file to extend.

This preserves the existing staged-ignore behavior where it is needed, while avoiding unnecessary writes for simple read-only contexts.

## Testing
- [X] Tested locally
- [X] Added/updated tests
- [ ] Added/updated docs
