### PR TITLE
Fix a compilation error

### DIFF
--- a/Sources/Helpers/APIServer/LocalhostDNSHandler.swift
+++ b/Sources/Helpers/APIServer/LocalhostDNSHandler.swift
@@ -55,7 +55,9 @@ actor LocalhostDNSHandler: DNSHandler {
                     dns[dnsName] = ipv4
                 }
             }
-            Task { await self?.updateDNS(dns) }
+            if let self {
+                Task { await self.updateDNS(dns) }
+            }
         }
     }
 


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Build fails with:
> - note: closure captures reference to mutable var 'self' which is accessible to code in the current task
> - error: passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure [#SendingClosureRisksDataRace]

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
