### PR TITLE
Make ProcessConfiguration.User Equatable

### DIFF
--- a/Sources/ContainerResource/Container/ProcessConfiguration.swift
+++ b/Sources/ContainerResource/Container/ProcessConfiguration.swift
@@ -53,7 +53,7 @@ public struct ProcessConfiguration: Sendable, Codable {
     }
 
     /// The User information for a Process.
-    public enum User: Sendable, Codable, CustomStringConvertible {
+    public enum User: Sendable, Codable, CustomStringConvertible, Equatable {
         /// Given the raw user string  of the form <uid:gid> or <user:group> or <user> lookup the uid/gid within
         /// the container before setting it for the Process.
         case raw(userString: String)


### PR DESCRIPTION
Make `User` comparable.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
[Why is this change needed?]

## Testing
- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
