### PR TITLE
Update builder to 0.11.0.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,8 +182,13 @@ coverage: init-block
 integration: init-block
 	@echo Ensuring apiserver stopped before the CLI integration tests...
 	@bin/container system stop && sleep 3 && scripts/ensure-container-stopped.sh
+	@if [ -n "$(APP_ROOT)" ]; then \
+		echo "Clearing application data under $(APP_ROOT) (preserving kernels)..." ; \
+		mkdir -p $(APP_ROOT) ; \
+		find "$(APP_ROOT)" -mindepth 1 -maxdepth 1 ! -name kernels -exec rm -rf {} + ; \
+	fi
 	@echo Running the integration tests...
-	@bin/container --debug system start --timeout 60 $(SYSTEM_START_OPTS) && \
+	@bin/container --debug system start --timeout 60 --enable-kernel-install $(SYSTEM_START_OPTS) && \
 	echo "Starting CLI integration tests" && \
 	{ \
 		exit_code=0; \

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ import PackageDescription
 
 let releaseVersion = ProcessInfo.processInfo.environment["RELEASE_VERSION"] ?? "0.0.0"
 let gitCommit = ProcessInfo.processInfo.environment["GIT_COMMIT"] ?? "unspecified"
-let builderShimVersion = "0.10.0"
+let builderShimVersion = "0.11.0"
 let scVersion = "0.29.0"
 
 let package = Package(


### PR DESCRIPTION
- Part of #1295.
- Needed for #1342.
- If APP_ROOT is defined, remove everything but kernel from data directory before starting integration test.
- Adds `--enable-kernel-install` for system start on integration test.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Fix builder bug.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
