### PR TITLE
Don't bake DNS server into builder container config.

### DIFF
--- a/Sources/ContainerCommands/Builder/BuilderStart.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStart.swift
@@ -267,17 +267,14 @@ extension Application {
             guard let defaultNetwork = try await ClientNetwork.builtin else {
                 throw ContainerizationError(.invalidState, message: "default network is not present")
             }
-            guard case .running(_, let networkStatus) = defaultNetwork else {
+            guard case .running(_, _) = defaultNetwork else {
                 throw ContainerizationError(.invalidState, message: "default network is not running")
             }
             config.networks = [
                 AttachmentConfiguration(network: defaultNetwork.id, options: AttachmentOptions(hostname: Builder.builderContainerId))
             ]
-            let subnet = networkStatus.ipv4Subnet
-            let nameserver = IPv4Address(subnet.lower.value + 1).description
-            let nameservers = dnsNameservers.isEmpty ? [nameserver] : dnsNameservers
             config.dns = ContainerConfiguration.DNSConfiguration(
-                nameservers: nameservers,
+                nameservers: dnsNameservers,
                 domain: dnsDomain,
                 searchDomains: dnsSearchDomains,
                 options: dnsOptions


### PR DESCRIPTION
- Closes #656.
- The SandboxService automatically sets the DNS server as part of bootstrap if no server is given. Setting it in the container config means that the builder will fail if the system restarts and the network subnet changes.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
