### PR TITLE
fix(exec): enforce permissions for non-root exec user

### DIFF
--- a/Sources/ContainerResource/Container/ProcessConfiguration.swift
+++ b/Sources/ContainerResource/Container/ProcessConfiguration.swift
@@ -68,6 +68,24 @@ public struct ProcessConfiguration: Sendable, Codable {
                 return name
             }
         }
+
+        /// Returns true when the user specification explicitly resolves to a non-root user.
+        /// Unknown named users are treated as non-root for safer default behavior.
+        public var isExplicitlyNonRoot: Bool {
+            switch self {
+            case .id(let uid, _):
+                return uid != 0
+            case .raw(let userString):
+                let primaryToken = userString
+                    .split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+                    .first
+                    .map(String.init) ?? ""
+                if let uid = UInt32(primaryToken) {
+                    return uid != 0
+                }
+                return primaryToken.lowercased() != "root"
+            }
+        }
     }
 
     public init(

--- a/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
+++ b/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
@@ -956,6 +956,10 @@ public actor SandboxService {
                 username: ""
             )
         }
+
+        if process.user.isExplicitlyNonRoot {
+            czConfig.process.capabilities = Containerization.LinuxCapabilities()
+        }
     }
 
     private nonisolated func configureProcessConfig(config: ProcessConfiguration, stdio: [FileHandle?], containerConfig: ContainerConfiguration)
@@ -1001,6 +1005,10 @@ public actor SandboxService {
                 additionalGids: config.supplementalGroups,
                 username: ""
             )
+        }
+
+        if config.user.isExplicitlyNonRoot {
+            proc.capabilities = Containerization.LinuxCapabilities()
         }
 
         return proc

--- a/Tests/CLITests/Subcommands/Containers/TestCLIExec.swift
+++ b/Tests/CLITests/Subcommands/Containers/TestCLIExec.swift
@@ -136,4 +136,39 @@ class TestCLIExecCommand: CLITest {
             }
         }
     }
+
+    @Test func testExecUserRespectsFilePermissions() throws {
+        let name = getTestName()
+        try doLongRun(name: name)
+        defer {
+            try? doStop(name: name)
+        }
+
+        let (_, idOutput, idError, idStatus) = try run(arguments: [
+            "exec",
+            "-u",
+            "nobody",
+            name,
+            "id",
+        ])
+        try #require(idStatus == 0, "id should run as nobody: stderr=\(idError)")
+        #expect(idOutput.contains("uid=65534"), "expected uid 65534 for nobody, got: \(idOutput)")
+
+        let (_, output, error, status) = try run(arguments: [
+            "exec",
+            "-u",
+            "nobody",
+            name,
+            "cat",
+            "/etc/shadow",
+        ])
+
+        #expect(status != 0, "expected permission failure, got success with output: \(output)")
+
+        let combined = "\(output)\n\(error)"
+        #expect(
+            combined.localizedCaseInsensitiveContains("permission denied"),
+            "expected permission denied error, got: \(combined)"
+        )
+    }
 }


### PR DESCRIPTION
Drop elevated process capabilities when exec is requested with an explicit non-root user.

Add a CLI regression test that validates /etc/shadow access is denied for exec -u nobody.

Refs: #1352

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Issue #1352 reports that container exec with an explicit non-root user could still read privileged files such as /etc/shadow.  
Although uid and gid were switched correctly, elevated process capabilities were still effectively allowing access.  
This change drops elevated capabilities when exec is requested with an explicit non-root user, so file permission checks follow expected Unix and Docker semantics.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs