### PR TITLE
Add Color Progress Output Mode

### DIFF
--- a/Sources/ContainerCommands/Flags+ProgressConfig.swift
+++ b/Sources/ContainerCommands/Flags+ProgressConfig.swift
@@ -22,7 +22,8 @@ extension Flags.Progress {
     ///
     /// For `.none`, progress updates are disabled. For `.ansi`, the given parameters
     /// are used as-is. For `.plain`, ANSI-incompatible features (spinner, clear on finish)
-    /// are disabled and the output mode is set to `.plain`.
+    /// are disabled and the output mode is set to `.plain`. For `.color`, behavior matches
+    /// `.ansi` but the output mode is set to `.color` to enable color-coded output.
     func makeConfig(
         description: String = "",
         itemsName: String = "it",
@@ -35,7 +36,7 @@ extension Flags.Progress {
         switch progress {
         case .none:
             return try ProgressConfig(disableProgressUpdates: true)
-        case .ansi, .plain:
+        case .ansi, .plain, .color:
             let isPlain = progress == .plain
             return try ProgressConfig(
                 description: description,
@@ -47,7 +48,7 @@ extension Flags.Progress {
                 ignoreSmallSize: ignoreSmallSize,
                 totalTasks: totalTasks,
                 clearOnFinish: !isPlain,
-                outputMode: isPlain ? .plain : .ansi
+                outputMode: isPlain ? .plain : (progress == .color ? .color : .ansi)
             )
         }
     }

--- a/Sources/ContainerCommands/Flags+ProgressConfig.swift
+++ b/Sources/ContainerCommands/Flags+ProgressConfig.swift
@@ -38,6 +38,12 @@ extension Flags.Progress {
             return try ProgressConfig(disableProgressUpdates: true)
         case .ansi, .plain, .color:
             let isPlain = progress == .plain
+            let outputMode: ProgressConfig.OutputMode
+            switch progress {
+            case .plain: outputMode = .plain
+            case .color: outputMode = .color
+            default: outputMode = .ansi
+            }
             return try ProgressConfig(
                 description: description,
                 itemsName: itemsName,
@@ -48,7 +54,7 @@ extension Flags.Progress {
                 ignoreSmallSize: ignoreSmallSize,
                 totalTasks: totalTasks,
                 clearOnFinish: !isPlain,
-                outputMode: isPlain ? .plain : (progress == .color ? .color : .ansi)
+                outputMode: outputMode
             )
         }
     }

--- a/Sources/Services/ContainerAPIService/Client/Flags.swift
+++ b/Sources/Services/ContainerAPIService/Client/Flags.swift
@@ -338,9 +338,10 @@ public struct Flags {
             case none
             case ansi
             case plain
+            case color
         }
 
-        @Option(name: .long, help: ArgumentHelp("Progress type (format: none|ansi|plain)", valueName: "type"))
+        @Option(name: .long, help: ArgumentHelp("Progress type (format: none|ansi|plain|color)", valueName: "type"))
         public var progress: ProgressType = .ansi
     }
 

--- a/Sources/TerminalProgress/ProgressBar+Terminal.swift
+++ b/Sources/TerminalProgress/ProgressBar+Terminal.swift
@@ -22,6 +22,19 @@ enum EscapeSequence {
     static let showCursor = "\u{001B}[?25h"
     static let moveUp = "\u{001B}[1A"
     static let clearToEndOfLine = "\u{001B}[K"
+
+    // Color codes
+    static let reset = "\u{001B}[0m"
+    static let bold = "\u{001B}[1m"
+    static let dim = "\u{001B}[2m"
+    static let green = "\u{001B}[32m"
+    static let yellow = "\u{001B}[33m"
+    static let cyan = "\u{001B}[36m"
+
+    /// Wraps text in an ANSI color code with a reset suffix.
+    static func colored(_ text: String, _ code: String) -> String {
+        "\(code)\(text)\(reset)"
+    }
 }
 
 extension ProgressBar {
@@ -41,7 +54,7 @@ extension ProgressBar {
         state.withLock { s in
             clear(state: &s)
             switch config.outputMode {
-            case .ansi:
+            case .ansi, .color:
                 resetCursor()
             case .plain:
                 break
@@ -89,11 +102,12 @@ extension ProgressBar {
         case .plain:
             guard !text.isEmpty else { return }
             display("\(text)\(terminating)")
-        case .ansi:
+        case .ansi, .color:
             // Clears previously printed lines.
             var lines = ""
             if terminating.hasSuffix("\r") && termWidth > 0 {
-                let lineCount = (text.count - 1) / termWidth
+                let textLength = config.outputMode == .color ? text.visibleLength : text.count
+                let lineCount = (textLength - 1) / termWidth
                 for _ in 0..<lineCount {
                     lines += EscapeSequence.moveUp
                 }
@@ -102,5 +116,12 @@ extension ProgressBar {
             let output = "\(text)\(EscapeSequence.clearToEndOfLine)\(terminating)\(lines)"
             display(output)
         }
+    }
+}
+
+extension String {
+    /// The visible character count, excluding ANSI escape sequences.
+    var visibleLength: Int {
+        replacingOccurrences(of: "\u{001B}\\[[0-9;]*[a-zA-Z]", with: "", options: .regularExpression).count
     }
 }

--- a/Sources/TerminalProgress/ProgressBar.swift
+++ b/Sources/TerminalProgress/ProgressBar.swift
@@ -34,7 +34,7 @@ public final class ProgressBar: Sendable {
     public init(config: ProgressConfig) {
         self.config = config
         switch config.outputMode {
-        case .ansi:
+        case .ansi, .color:
             term = isatty(config.terminal.fileDescriptor) == 1 ? config.terminal : nil
         case .plain:
             term = config.terminal
@@ -45,7 +45,7 @@ public final class ProgressBar: Sendable {
             totalSize: config.initialTotalSize)
         self.state = Mutex(state)
         switch config.outputMode {
-        case .ansi:
+        case .ansi, .color:
             display(EscapeSequence.hideCursor)
         case .plain:
             break
@@ -140,7 +140,7 @@ public final class ProgressBar: Sendable {
                 clear(state: &s)
             }
             switch config.outputMode {
-            case .ansi:
+            case .ansi, .color:
                 resetCursor()
             case .plain:
                 break
@@ -213,7 +213,8 @@ extension ProgressBar {
 
         for detail in DetailLevel.allCases {
             let output = draw(state: state, detail: detail)
-            if output.count <= targetWidth {
+            let length = config.outputMode == .color ? output.visibleLength : output.count
+            if length <= targetWidth {
                 return output
             }
         }
@@ -222,30 +223,37 @@ extension ProgressBar {
     }
 
     func draw(state: State, detail: DetailLevel) -> String {
+        let useColor = config.outputMode == .color
+
+        /// Wraps text in ANSI color when color mode is active; returns text unchanged otherwise.
+        func colored(_ text: String, _ code: String) -> String {
+            useColor ? EscapeSequence.colored(text, code) : text
+        }
+
         var components = [String]()
 
         // Spinner - always shown if configured (unless using progress bar)
         if config.showSpinner && !config.showProgressBar {
             if !state.finished {
                 let spinnerIcon = config.theme.getSpinnerIcon(state.iteration)
-                components.append("\(spinnerIcon)")
+                components.append(colored("\(spinnerIcon)", EscapeSequence.cyan))
             } else {
-                components.append("\(config.theme.done)")
+                components.append(colored("\(config.theme.done)", EscapeSequence.green))
             }
         }
 
         // Tasks [x/y] - always shown if configured
         if config.showTasks, let totalTasks = state.totalTasks {
             let tasks = min(state.tasks, totalTasks)
-            components.append("[\(tasks)/\(totalTasks)]")
+            components.append(colored("[\(tasks)/\(totalTasks)]", EscapeSequence.cyan))
         }
 
         // Description - dropped at noDescription level
         if detail.rawValue < DetailLevel.noDescription.rawValue {
             if config.showDescription && !state.description.isEmpty {
-                components.append("\(state.description)")
+                components.append(colored("\(state.description)", EscapeSequence.bold))
                 if !state.subDescription.isEmpty {
-                    components.append("\(state.subDescription)")
+                    components.append(colored("\(state.subDescription)", EscapeSequence.bold))
                 }
             }
         }
@@ -256,17 +264,26 @@ extension ProgressBar {
 
         // Percent - always shown if configured
         if config.showPercent && total > 0 && allowProgress {
-            components.append("\(state.finished ? "100%" : state.percent)")
+            let percentText = state.finished ? "100%" : state.percent
+            let percentColor = state.finished ? EscapeSequence.green : EscapeSequence.yellow
+            components.append(colored(percentText, percentColor))
         }
 
         // Progress bar - always shown if configured
         if config.showProgressBar, total > 0, allowProgress {
-            let usedWidth = components.joined(separator: " ").count + 45
+            let joinedComponents = components.joined(separator: " ")
+            let usedWidth = (useColor ? joinedComponents.visibleLength : joinedComponents.count) + 45
             let remainingWidth = max(config.width - usedWidth, 1)
             let barLength = min(remainingWidth, state.finished ? remainingWidth : Int(Int64(remainingWidth) * value / total))
             let barPaddingLength = remainingWidth - barLength
-            let bar = "\(String(repeating: config.theme.bar, count: barLength))\(String(repeating: " ", count: barPaddingLength))"
-            components.append("|\(bar)|")
+            if useColor {
+                let filledBar = EscapeSequence.colored(String(repeating: config.theme.bar, count: barLength), EscapeSequence.green)
+                let emptyBar = String(repeating: " ", count: barPaddingLength)
+                components.append("|\(filledBar)\(emptyBar)|")
+            } else {
+                let bar = "\(String(repeating: config.theme.bar, count: barLength))\(String(repeating: " ", count: barPaddingLength))"
+                components.append("|\(bar)|")
+            }
         }
 
         // Additional components in parens - progressively dropped
@@ -340,7 +357,7 @@ extension ProgressBar {
 
             if additionalComponents.count > 0 {
                 let joinedAdditionalComponents = additionalComponents.joined(separator: ", ")
-                components.append("(\(joinedAdditionalComponents))")
+                components.append(colored("(\(joinedAdditionalComponents))", EscapeSequence.dim))
             }
         }
 
@@ -348,7 +365,7 @@ extension ProgressBar {
         if detail.rawValue < DetailLevel.noTime.rawValue && config.showTime {
             let timeDifferenceSeconds = secondsSinceStart(from: state.startTime)
             let formattedTime = timeDifferenceSeconds.formattedTime()
-            components.append("[\(formattedTime)]")
+            components.append(colored("[\(formattedTime)]", EscapeSequence.dim))
         }
 
         return components.joined(separator: " ")

--- a/Sources/TerminalProgress/ProgressBar.swift
+++ b/Sources/TerminalProgress/ProgressBar.swift
@@ -272,6 +272,7 @@ extension ProgressBar {
         // Progress bar - always shown if configured
         if config.showProgressBar, total > 0, allowProgress {
             let joinedComponents = components.joined(separator: " ")
+            // 45 reserves space for components rendered after the bar (size, speed, time, etc.)
             let usedWidth = (useColor ? joinedComponents.visibleLength : joinedComponents.count) + 45
             let remainingWidth = max(config.width - usedWidth, 1)
             let barLength = min(remainingWidth, state.finished ? remainingWidth : Int(Int64(remainingWidth) * value / total))

--- a/Sources/TerminalProgress/ProgressConfig.swift
+++ b/Sources/TerminalProgress/ProgressConfig.swift
@@ -169,6 +169,8 @@ extension ProgressConfig {
         case ansi
         /// Plain text mode with newline-separated output, no ANSI codes.
         case plain
+        /// ANSI escape code mode with cursor control and color-coded output.
+        case color
     }
 
     /// An enumeration of errors that can occur when creating a `ProgressConfig`.

--- a/Tests/TerminalProgressTests/ProgressBarTests.swift
+++ b/Tests/TerminalProgressTests/ProgressBarTests.swift
@@ -952,4 +952,249 @@ final class ProgressBarTests: XCTestCase {
         let config = try ProgressConfig(description: "Task")
         XCTAssertEqual(config.outputMode, .ansi)
     }
+
+    // MARK: - Color mode tests
+
+    func testColorModeConfig() async throws {
+        let config = try ProgressConfig(
+            description: "Task",
+            outputMode: .color
+        )
+        XCTAssertEqual(config.outputMode, .color)
+    }
+
+    func testVisibleLengthPlainText() async throws {
+        let text = "hello"
+        XCTAssertEqual(text.visibleLength, 5)
+    }
+
+    func testVisibleLengthWithAnsiCodes() async throws {
+        let text = "\u{001B}[36mhello\u{001B}[0m"
+        XCTAssertEqual(text.visibleLength, 5)
+    }
+
+    func testVisibleLengthEmptyString() async throws {
+        XCTAssertEqual("".visibleLength, 0)
+    }
+
+    func testColorModeDraw() async throws {
+        let config = try ProgressConfig(
+            description: "Task",
+            outputMode: .color
+        )
+        let progress = ProgressBar(config: config)
+        let output = progress.draw()
+        let stripped = output.replacingOccurrences(
+            of: "\u{001B}\\[[0-9;]*[a-zA-Z]", with: "", options: .regularExpression
+        )
+        XCTAssertEqual(stripped, "⠋ Task [0s]")
+    }
+
+    func testColorModeDrawContainsAnsiCodes() async throws {
+        let config = try ProgressConfig(
+            description: "Task",
+            outputMode: .color
+        )
+        let progress = ProgressBar(config: config)
+        let output = progress.draw()
+        XCTAssertTrue(output.contains("\u{001B}["))
+        XCTAssertTrue(output.contains(EscapeSequence.cyan))   // spinner
+        XCTAssertTrue(output.contains(EscapeSequence.bold))   // description
+        XCTAssertTrue(output.contains(EscapeSequence.dim))    // time
+        XCTAssertTrue(output.contains(EscapeSequence.reset))  // reset
+    }
+
+    func testColorModeDrawFinished() async throws {
+        let config = try ProgressConfig(
+            description: "Task",
+            outputMode: .color
+        )
+        let progress = ProgressBar(config: config)
+        progress.finish()
+        let output = progress.draw()
+        let stripped = output.replacingOccurrences(
+            of: "\u{001B}\\[[0-9;]*[a-zA-Z]", with: "", options: .regularExpression
+        )
+        XCTAssertEqual(stripped, "✔ Task [0s]")
+        XCTAssertTrue(output.contains(EscapeSequence.green))  // done icon
+    }
+
+    func testColorModeDrawWithTasks() async throws {
+        let config = try ProgressConfig(
+            description: "Task",
+            showTasks: true,
+            totalTasks: 2,
+            outputMode: .color
+        )
+        let progress = ProgressBar(config: config)
+        let output = progress.draw()
+        let stripped = output.replacingOccurrences(
+            of: "\u{001B}\\[[0-9;]*[a-zA-Z]", with: "", options: .regularExpression
+        )
+        XCTAssertEqual(stripped, "⠋ [0/2] Task [0s]")
+        XCTAssertTrue(output.contains(EscapeSequence.cyan))  // tasks
+    }
+
+    func testColorModeDrawWithPercent() async throws {
+        let config = try ProgressConfig(
+            description: "Task",
+            showItems: true,
+            totalItems: 2,
+            outputMode: .color
+        )
+        let progress = ProgressBar(config: config)
+        progress.set(items: 1)
+        let output = progress.draw()
+        let stripped = output.replacingOccurrences(
+            of: "\u{001B}\\[[0-9;]*[a-zA-Z]", with: "", options: .regularExpression
+        )
+        XCTAssertEqual(stripped, "⠋ Task 50% (1 of 2 it) [0s]")
+        XCTAssertTrue(output.contains(EscapeSequence.yellow))  // in-progress percent
+    }
+
+    func testColorModeDrawWithPercentFinished() async throws {
+        let config = try ProgressConfig(
+            description: "Task",
+            showItems: true,
+            totalItems: 2,
+            outputMode: .color
+        )
+        let progress = ProgressBar(config: config)
+        progress.set(items: 1)
+        progress.finish()
+        let output = progress.draw()
+        let stripped = output.replacingOccurrences(
+            of: "\u{001B}\\[[0-9;]*[a-zA-Z]", with: "", options: .regularExpression
+        )
+        XCTAssertEqual(stripped, "✔ Task 100% (2 it) [0s]")
+        XCTAssertTrue(output.contains(EscapeSequence.green))  // finished percent
+    }
+
+    func testColorModeDrawWithSize() async throws {
+        let config = try ProgressConfig(
+            description: "Task",
+            showSize: true,
+            showSpeed: false,
+            totalSize: 4,
+            outputMode: .color
+        )
+        let progress = ProgressBar(config: config)
+        progress.set(size: 2)
+        let output = progress.draw()
+        let stripped = output.replacingOccurrences(
+            of: "\u{001B}\\[[0-9;]*[a-zA-Z]", with: "", options: .regularExpression
+        )
+        XCTAssertEqual(stripped, "⠋ Task 50% (2/4 bytes) [0s]")
+        XCTAssertTrue(output.contains(EscapeSequence.dim))  // parens content
+    }
+
+    func testColorModeDrawVisibleLengthMatchesContent() async throws {
+        let config = try ProgressConfig(
+            description: "Task",
+            showTasks: true,
+            showItems: true,
+            totalTasks: 2,
+            totalItems: 4,
+            outputMode: .color
+        )
+        let progress = ProgressBar(config: config)
+        progress.set(items: 2)
+        let colorOutput = progress.draw()
+
+        let plainConfig = try ProgressConfig(
+            description: "Task",
+            showTasks: true,
+            showItems: true,
+            totalTasks: 2,
+            totalItems: 4
+        )
+        let plainProgress = ProgressBar(config: plainConfig)
+        plainProgress.set(items: 2)
+        let plainOutput = plainProgress.draw()
+
+        XCTAssertEqual(colorOutput.visibleLength, plainOutput.count)
+    }
+
+    func testColorModeNoAnsiCodesInContent() async throws {
+        let config = try ProgressConfig(
+            description: "Task",
+            outputMode: .color
+        )
+        let progress = ProgressBar(config: config)
+        let output = progress.draw()
+        let stripped = output.replacingOccurrences(
+            of: "\u{001B}\\[[0-9;]*[a-zA-Z]", with: "", options: .regularExpression
+        )
+        XCTAssertFalse(stripped.contains("\u{001B}"))
+    }
+
+    func testColorModeDrawWithProgressBar() async throws {
+        let config = try ProgressConfig(
+            description: "Task",
+            showProgressBar: true,
+            totalItems: 2,
+            width: 57,
+            outputMode: .color
+        )
+        let progress = ProgressBar(config: config)
+        progress.set(items: 1)
+        let output = progress.draw()
+        let stripped = output.replacingOccurrences(
+            of: "\u{001B}\\[[0-9;]*[a-zA-Z]", with: "", options: .regularExpression
+        )
+        XCTAssertEqual(stripped, "Task 50% |██  | [0s]")
+        XCTAssertTrue(output.contains(EscapeSequence.green))
+    }
+
+    func testColorModeRequiresTTY() async throws {
+        let pipe = Pipe()
+        let config = try ProgressConfig(
+            terminal: pipe.fileHandleForWriting,
+            description: "Task",
+            outputMode: .color
+        )
+        let progress = ProgressBar(config: config)
+        // Pipe is not a TTY, so render should produce no output (same as ansi)
+        progress.render(force: true)
+        progress.finish()
+        try pipe.fileHandleForWriting.close()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        XCTAssertTrue(data.isEmpty)
+    }
+
+    func testColorModeDrawOutputContainsColorCodes() async throws {
+        // Verify draw() includes ANSI codes even without a TTY
+        // (draw is separate from terminal rendering)
+        let config = try ProgressConfig(
+            description: "Task",
+            outputMode: .color
+        )
+        let progress = ProgressBar(config: config)
+        let output = progress.draw()
+        XCTAssertTrue(output.contains(EscapeSequence.cyan))
+        XCTAssertTrue(output.contains(EscapeSequence.bold))
+        XCTAssertTrue(output.contains(EscapeSequence.dim))
+        XCTAssertTrue(output.contains(EscapeSequence.reset))
+    }
+
+    func testColorModeRenderTerminatorIsCarriageReturn() async throws {
+        // Verify color mode uses \r terminator (not \n like plain mode)
+        let config = try ProgressConfig(
+            description: "Task",
+            outputMode: .color
+        )
+        // The render() method sets terminating based on outputMode
+        // For non-plain modes, it's "\r"
+        // We verify this indirectly: color mode is not plain
+        XCTAssertNotEqual(config.outputMode, .plain)
+        // And the render logic uses: config.outputMode == .plain ? "\n" : "\r"
+        // So color gets "\r" — confirmed by code path analysis
+    }
+
+    func testOutputModeDefaultIsNotColor() async throws {
+        let config = try ProgressConfig(description: "Task")
+        XCTAssertNotEqual(config.outputMode, .color)
+        XCTAssertEqual(config.outputMode, .ansi)
+    }
 }

--- a/Tests/TerminalProgressTests/ProgressBarTests.swift
+++ b/Tests/TerminalProgressTests/ProgressBarTests.swift
@@ -998,9 +998,9 @@ final class ProgressBarTests: XCTestCase {
         let progress = ProgressBar(config: config)
         let output = progress.draw()
         XCTAssertTrue(output.contains("\u{001B}["))
-        XCTAssertTrue(output.contains(EscapeSequence.cyan))   // spinner
-        XCTAssertTrue(output.contains(EscapeSequence.bold))   // description
-        XCTAssertTrue(output.contains(EscapeSequence.dim))    // time
+        XCTAssertTrue(output.contains(EscapeSequence.cyan))  // spinner
+        XCTAssertTrue(output.contains(EscapeSequence.bold))  // description
+        XCTAssertTrue(output.contains(EscapeSequence.dim))  // time
         XCTAssertTrue(output.contains(EscapeSequence.reset))  // reset
     }
 

--- a/Tests/TerminalProgressTests/ProgressBarTests.swift
+++ b/Tests/TerminalProgressTests/ProgressBarTests.swift
@@ -1179,17 +1179,35 @@ final class ProgressBarTests: XCTestCase {
     }
 
     func testColorModeRenderTerminatorIsCarriageReturn() async throws {
-        // Verify color mode uses \r terminator (not \n like plain mode)
-        let config = try ProgressConfig(
+        // Color mode is TTY-only so we cannot capture its raw terminal output via a pipe.
+        // Instead, verify that plain mode emits \n (newlines) while color mode shares the
+        // ansi code path which emits \r (carriage returns). We confirm this by checking
+        // that plain output uses \n and that color mode is distinct from plain.
+        let plainPipe = Pipe()
+        let plainConfig = try ProgressConfig(
+            terminal: plainPipe.fileHandleForWriting,
+            description: "Task",
+            showSpinner: false,
+            clearOnFinish: false,
+            outputMode: .plain
+        )
+        let plainProgress = ProgressBar(config: plainConfig)
+        plainProgress.render(force: true)
+        plainProgress.finish()
+        try plainPipe.fileHandleForWriting.close()
+
+        let plainData = plainPipe.fileHandleForReading.readDataToEndOfFile()
+        let plainOutput = String(decoding: plainData, as: UTF8.self)
+        // Plain mode uses \n terminators
+        XCTAssertTrue(plainOutput.contains("\n"))
+        XCTAssertFalse(plainOutput.contains("\r"))
+
+        // Color mode follows the ansi path (not plain), so it uses \r
+        let colorConfig = try ProgressConfig(
             description: "Task",
             outputMode: .color
         )
-        // The render() method sets terminating based on outputMode
-        // For non-plain modes, it's "\r"
-        // We verify this indirectly: color mode is not plain
-        XCTAssertNotEqual(config.outputMode, .plain)
-        // And the render logic uses: config.outputMode == .plain ? "\n" : "\r"
-        // So color gets "\r" — confirmed by code path analysis
+        XCTAssertNotEqual(colorConfig.outputMode, .plain)
     }
 
     func testOutputModeDefaultIsNotColor() async throws {

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -89,7 +89,7 @@ container run [<options>] <image> [<arguments> ...]
 
 **Progress Options**
 
-*   `--progress <type>`: Progress type (format: none|ansi|plain) (default: ansi)
+*   `--progress <type>`: Progress type (format: none|ansi|plain|color) (default: ansi)
 
 **Examples**
 
@@ -510,7 +510,7 @@ container image pull [--debug] [--scheme <scheme>] [--progress <type>] [--arch <
 **Options**
 
 *   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https, auto) (default: auto)
-*   `--progress <type>`: Progress type (format: none|ansi|plain) (default: ansi)
+*   `--progress <type>`: Progress type (format: none|ansi|plain|color) (default: ansi)
 *   `-a, --arch <arch>`: Limit the pull to the specified architecture
 *   `--os <os>`: Limit the pull to the specified OS
 *   `--platform <platform>`: Limit the pull to the specified platform (format: os/arch[/variant], takes precedence over --os and --arch)
@@ -532,7 +532,7 @@ container image push [--scheme <scheme>] [--progress <type>] [--arch <arch>] [--
 **Options**
 
 *   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https, auto) (default: auto)
-*   `--progress <type>`: Progress type (format: none|ansi|plain) (default: ansi)
+*   `--progress <type>`: Progress type (format: none|ansi|plain|color) (default: ansi)
 *   `-a, --arch <arch>`: Limit the push to the specified architecture
 *   `--os <os>`: Limit the push to the specified OS
 *   `--platform <platform>`: Limit the push to the specified platform (format: os/arch[/variant], takes precedence over --os and --arch)


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
###  Color Progress Output Mode

Adds a color progress output mode (`--progress color`) that renders ANSI-colored progress output with visual differentiation between progress states.

Unlike the existing `ansi` mode (which only uses cursor control), `color` introduces color-coded output:

- **Cyan** → spinner / active tasks  
- **Bold text** → task description  
- **Yellow / Green** → percentage (in-progress / complete)  
- **Green** → progress bar  
- **Dim text** → secondary information  

Like `ansi` mode, this feature requires a TTY.

  Closes #1366

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [x] Added/updated docs

## Visuals
| Light | Dark | Plain | Ansi |
|--------|--------|--------|--------|
| <video src="https://github.com/user-attachments/assets/274550ea-a49b-4e2c-a819-2b000f3ebee3"> | <video src="https://github.com/user-attachments/assets/8451be7c-e666-4454-9525-798a30c8f62d"> | <video src="https://github.com/user-attachments/assets/d51e9749-c056-4542-8dd2-79aac989a842"> | <video src="https://github.com/user-attachments/assets/e7bbf3e9-ffab-44cb-8a9e-1962a0d32285"> |