### PR TITLE
Remove XPC timeout based on SIGTERM timeout in container stop

### DIFF
--- a/Sources/Services/ContainerSandboxService/Client/SandboxClient.swift
+++ b/Sources/Services/ContainerSandboxService/Client/SandboxClient.swift
@@ -176,9 +176,8 @@ extension SandboxClient {
         let data = try JSONEncoder().encode(options)
         request.set(key: SandboxKeys.stopOptions.rawValue, value: data)
 
-        let responseTimeout = Duration(.seconds(Int64(options.timeoutInSeconds + 1)))
         do {
-            try await self.client.send(request, responseTimeout: responseTimeout)
+            try await self.client.send(request)
         } catch {
             throw ContainerizationError(
                 .internalError,


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context
`container stop` has an option `-t` for `Seconds to wait before killing the containers` (see [here](https://github.com/apple/container/blob/ce7736105747f48debb37ca1999b562b4bfae23c/Sources/ContainerCommands/Container/ContainerStop.swift#L39)). This timeout is used to determine when the SandboxService should stop waiting for the container to gracefully exit with `SIGTERM` (or another provided signal) and send `SIGKILL`.  

Today, we were setting the `SandboxService.stop` XPC call's timeout to the value provided to `container stop -t` plus 1 second. This is problematic in cases where the code flow to send SIGKILL to the container then forcefully stop the VM does not complete within one second of the SIGTERM timeout being hit. In those cases, we will return that the XPC stop call failed due to hitting the timeout. In some cases this may happen even though the container and VM have both been successfully stopped. 

This PR removes that XPC timeout for `SandboxService.stop` entirely. We cannot reliably determine in the SandboxClient, which may be used by third party runtime plugins to support additional container runtimes, how long it may take for SIGKILL to kill the container and stop related resources.

## Testing
- [x] Tested locally
