### PR TITLE
Archiver: preserve symlinks and explicit build-context entries

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -235,6 +235,7 @@ let package = Package(
             name: "ContainerAPIClientTests",
             dependencies: [
                 .product(name: "Containerization", package: "containerization"),
+                .product(name: "ContainerizationArchive", package: "containerization"),
                 .product(name: "SystemPackage", package: "swift-system"),
                 "ContainerAPIClient",
                 "ContainerPersistence",

--- a/Sources/ContainerBuild/BuildFSSync.swift
+++ b/Sources/ContainerBuild/BuildFSSync.swift
@@ -23,6 +23,8 @@ import Foundation
 import GRPCCore
 
 actor BuildFSSync: BuildPipelineHandler {
+    private static let archiveRootURL = URL(filePath: "/", directoryHint: .isDirectory)
+
     let contextDir: URL
 
     init(_ contextDir: URL) throws {
@@ -114,7 +116,6 @@ actor BuildFSSync: BuildPipelineHandler {
     }
 
     private struct DirEntry: Hashable {
-        let url: URL
         let isDirectory: Bool
         let relativePath: String
 
@@ -133,30 +134,32 @@ actor BuildFSSync: BuildPipelineHandler {
         _ buildID: String
     ) async throws {
         let wantsTar = packet.mode() == "tar"
+        let contextPath = contextDir.path
+        let contextPrefix = contextPath.hasSuffix("/") ? contextPath : contextPath + "/"
 
         var entries: [String: Set<DirEntry>] = [:]
         let followPaths: [String] = packet.followPaths() ?? []
 
         let followPathsWalked = try walk(root: self.contextDir, includePatterns: followPaths)
         for url in followPathsWalked {
-            guard self.contextDir.absoluteURL.cleanPath != url.absoluteURL.cleanPath else {
+            let path = url.path
+            guard path != contextPath else {
                 continue
             }
-            guard self.contextDir.parentOf(url) else {
+            guard let relPath = Self.relativeChildPath(path: path, contextPath: contextPath, contextPrefix: contextPrefix) else {
                 continue
             }
 
-            let relPath = try url.relativeChildPath(to: contextDir)
-            let parentPath = try url.deletingLastPathComponent().relativeChildPath(to: contextDir)
-            let entry = DirEntry(url: url, isDirectory: url.hasDirectoryPath, relativePath: relPath)
+            let parentPath = Self.relativeParentPath(path: path, contextPath: contextPath, contextPrefix: contextPrefix)
+            let entry = DirEntry(isDirectory: url.hasDirectoryPath, relativePath: relPath)
             entries[parentPath, default: []].insert(entry)
 
             if url.isSymlink {
                 let target: URL = url.resolvingSymlinksInPath()
-                if self.contextDir.parentOf(target) {
-                    let relPath = try target.relativeChildPath(to: self.contextDir)
-                    let entry = DirEntry(url: target, isDirectory: target.hasDirectoryPath, relativePath: relPath)
-                    let parentPath: String = try target.deletingLastPathComponent().relativeChildPath(to: self.contextDir)
+                let targetPath = target.path
+                if let relPath = Self.relativeChildPath(path: targetPath, contextPath: contextPath, contextPrefix: contextPrefix) {
+                    let entry = DirEntry(isDirectory: target.hasDirectoryPath, relativePath: relPath)
+                    let parentPath = Self.relativeParentPath(path: targetPath, contextPath: contextPath, contextPrefix: contextPrefix)
                     entries[parentPath, default: []].insert(entry)
                 }
             }
@@ -200,35 +203,18 @@ actor BuildFSSync: BuildPipelineHandler {
             format: .paxRestricted,
             filter: .none)
 
+        let archiveEntries = fileOrder.map { rel in
+            Archiver.ArchiveEntryInfo(
+                pathOnHost: contextDir.appending(path: rel, directoryHint: .notDirectory),
+                pathInArchive: URL(filePath: rel, directoryHint: .notDirectory, relativeTo: Self.archiveRootURL)
+            )
+        }
+
         let tarHash = try Archiver.compress(
-            source: contextDir,
+            entries: archiveEntries,
             destination: tarURL,
             writerConfiguration: writerCfg
-        ) { url in
-            guard let rel = try? url.relativeChildPath(to: contextDir) else {
-                return nil
-            }
-
-            guard let parent = try? url.deletingLastPathComponent().relativeChildPath(to: self.contextDir) else {
-                return nil
-            }
-
-            guard let items = entries[parent] else {
-                return nil
-            }
-
-            let include = items.contains { item in
-                item.relativePath == rel
-            }
-
-            guard include else {
-                return nil
-            }
-
-            return Archiver.ArchiveEntryInfo(
-                pathOnHost: url,
-                pathInArchive: URL(fileURLWithPath: rel))
-        }
+        )
 
         let hash = tarHash.compactMap { String(format: "%02x", $0) }.joined()
         let header = BuildTransfer(
@@ -321,6 +307,21 @@ actor BuildFSSync: BuildPipelineHandler {
                 )
             }
         }
+    }
+
+    private static func relativeChildPath(path: String, contextPath: String, contextPrefix: String) -> String? {
+        if path == contextPath {
+            return ""
+        }
+        guard path.hasPrefix(contextPrefix) else {
+            return nil
+        }
+        return String(path.dropFirst(contextPrefix.count))
+    }
+
+    private static func relativeParentPath(path: String, contextPath: String, contextPrefix: String) -> String {
+        let parentPath = (path as NSString).deletingLastPathComponent
+        return relativeChildPath(path: parentPath, contextPath: contextPath, contextPrefix: contextPrefix) ?? ""
     }
 
     struct FileInfo: Codable {

--- a/Sources/Services/ContainerAPIService/Client/Archiver.swift
+++ b/Sources/Services/ContainerAPIService/Client/Archiver.swift
@@ -17,9 +17,27 @@
 import ContainerizationArchive
 import ContainerizationOS
 import CryptoKit
+import Darwin
 import Foundation
 
 public final class Archiver: Sendable {
+    private struct FileStatus {
+        enum EntryType {
+            case directory
+            case regular
+            case symbolicLink
+        }
+
+        let entryType: EntryType
+        let permissions: UInt16
+        let size: Int64
+        let owner: UInt32
+        let group: UInt32
+        let creationDate: Date?
+        let modificationDate: Date?
+        let symlinkTarget: String?
+    }
+
     public struct ArchiveEntryInfo: Sendable, Codable {
         public let pathOnHost: URL
         public let pathInArchive: URL
@@ -41,6 +59,19 @@ public final class Archiver: Sendable {
             self.group = group
             self.permissions = permissions
         }
+    }
+
+    private struct ArchiveEntryHashInfo: Encodable {
+        let pathOnHost: String
+        let pathInArchive: String
+        let fileType: String
+        let size: Int64?
+        let permissions: mode_t
+        let owner: uid_t?
+        let group: gid_t?
+        let symlinkTarget: String?
+        let creationDate: Date?
+        let modificationDate: Date?
     }
 
     public static func compress(
@@ -83,23 +114,12 @@ public final class Archiver: Sendable {
                     entryInfo.append(info)
                 }
             }
-
-            let archiver = try ArchiveWriter(
-                configuration: writerConfiguration
+            try Self._compressEntries(
+                entryInfo,
+                destination: destination,
+                writerConfiguration: writerConfiguration,
+                hasher: &hasher
             )
-            try archiver.open(file: destination)
-
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = .sortedKeys
-
-            for info in entryInfo {
-                guard let entry = try Self._createEntry(entryInfo: info) else {
-                    throw Error.failedToCreateEntry
-                }
-                hasher.update(data: try encoder.encode(entry))
-                try Self._compressFile(item: info.pathOnHost, entry: entry, archiver: archiver, hasher: &hasher)
-            }
-            try archiver.finishEncoding()
         } catch {
             try? fileManager.removeItem(at: destination)
             throw error
@@ -108,32 +128,195 @@ public final class Archiver: Sendable {
         return hasher.finalize()
     }
 
+    public static func compress(
+        entries: [ArchiveEntryInfo],
+        destination: URL,
+        writerConfiguration: ArchiveWriterConfiguration = ArchiveWriterConfiguration(format: .paxRestricted, filter: .gzip)
+    ) throws -> SHA256.Digest {
+        let destination = destination.standardizedFileURL
+        let fileManager = FileManager.default
+        try? fileManager.removeItem(at: destination)
+
+        var hasher = SHA256()
+
+        do {
+            let directory = destination.deletingLastPathComponent()
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            try Self._compressEntries(
+                entries,
+                destination: destination,
+                writerConfiguration: writerConfiguration,
+                hasher: &hasher
+            )
+        } catch {
+            try? fileManager.removeItem(at: destination)
+            throw error
+        }
+
+        return hasher.finalize()
+    }
+
+    public static func uncompress(source: URL, destination: URL) throws {
+        let source = source.standardizedFileURL
+        let destination = destination.standardizedFileURL
+
+        // TODO: ArchiveReader needs some enhancement to support buffered uncompression
+        let reader = try ArchiveReader(
+            format: .paxRestricted,
+            filter: .gzip,
+            file: source
+        )
+
+        for (entry, data) in reader {
+            guard let path = entry.path else {
+                continue
+            }
+            let uncompressPath = destination.appendingPathComponent(path)
+
+            let fileManager = FileManager.default
+            switch entry.fileType {
+            case .blockSpecial, .characterSpecial, .socket:
+                continue
+            case .directory:
+                try fileManager.createDirectory(
+                    at: uncompressPath,
+                    withIntermediateDirectories: true,
+                    attributes: [
+                        FileAttributeKey.posixPermissions: entry.permissions
+                    ]
+                )
+            case .regular:
+                try fileManager.createDirectory(
+                    at: uncompressPath.deletingLastPathComponent(),
+                    withIntermediateDirectories: true,
+                    attributes: [
+                        FileAttributeKey.posixPermissions: 0o755
+                    ]
+                )
+                let success = fileManager.createFile(
+                    atPath: uncompressPath.path,
+                    contents: data,
+                    attributes: [
+                        FileAttributeKey.posixPermissions: entry.permissions
+                    ]
+                )
+                if !success {
+                    throw POSIXError.fromErrno()
+                }
+                try data.write(to: uncompressPath)
+            case .symbolicLink:
+                guard let target = entry.symlinkTarget else {
+                    continue
+                }
+                try fileManager.createDirectory(
+                    at: uncompressPath.deletingLastPathComponent(),
+                    withIntermediateDirectories: true,
+                    attributes: [
+                        FileAttributeKey.posixPermissions: 0o755
+                    ]
+                )
+                try fileManager.createSymbolicLink(atPath: uncompressPath.path, withDestinationPath: target)
+                continue
+            default:
+                continue
+            }
+
+            // FIXME: uid/gid for compress.
+            try fileManager.setAttributes(
+                [.posixPermissions: NSNumber(value: entry.permissions)],
+                ofItemAtPath: uncompressPath.path
+            )
+
+            if let creationDate = entry.creationDate {
+                try fileManager.setAttributes(
+                    [.creationDate: creationDate],
+                    ofItemAtPath: uncompressPath.path
+                )
+            }
+
+            if let modificationDate = entry.modificationDate {
+                try fileManager.setAttributes(
+                    [.modificationDate: modificationDate],
+                    ofItemAtPath: uncompressPath.path
+                )
+            }
+        }
+    }
+
     // MARK: private functions
-    private static func _compressFile(item: URL, entry: WriteEntry, archiver: ArchiveWriter, hasher: inout SHA256) throws {
+    private static func _compressEntries(
+        _ entryInfo: [ArchiveEntryInfo],
+        destination: URL,
+        writerConfiguration: ArchiveWriterConfiguration,
+        hasher: inout SHA256
+    ) throws {
+        let archivedPathsByHostPath = entryInfo.reduce(into: [String: [URL]]()) { result, info in
+            result[info.pathOnHost.path, default: []].append(info.pathInArchive)
+        }
+
+        let archiver = try ArchiveWriter(configuration: writerConfiguration)
+        try archiver.open(file: destination)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+
+        for info in entryInfo {
+            guard let entry = try Self._createEntry(entryInfo: info, archivedPathsByHostPath: archivedPathsByHostPath) else {
+                throw Error.failedToCreateEntry
+            }
+            let hashInfo = ArchiveEntryHashInfo(
+                pathOnHost: info.pathOnHost.path,
+                pathInArchive: info.pathInArchive.relativePath,
+                fileType: entry.fileType.rawValue,
+                size: entry.size,
+                permissions: entry.permissions,
+                owner: entry.owner,
+                group: entry.group,
+                symlinkTarget: entry.symlinkTarget,
+                creationDate: entry.creationDate,
+                modificationDate: entry.modificationDate
+            )
+            hasher.update(data: try encoder.encode(hashInfo))
+            try Self._compressFile(itemPath: info.pathOnHost.path, entry: entry, archiver: archiver, hasher: &hasher)
+        }
+        try archiver.finishEncoding()
+    }
+
+    private static func _compressFile(itemPath: String, entry: WriteEntry, archiver: ArchiveWriter, hasher: inout SHA256) throws {
+        guard entry.fileType == .regular else {
+            let writer = archiver.makeTransactionWriter()
+            try writer.writeHeader(entry: entry)
+            try writer.finish()
+            return
+        }
+
         let writer = archiver.makeTransactionWriter()
+
         let bufferSize = Int(1.mib())
         let readBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
         defer { readBuffer.deallocate() }
+
         try writer.writeHeader(entry: entry)
-        if entry.fileType == .regular {
-            // We need to write the data into the archive only if its a regular file
-            // Symlinks and directories require us to only write the archive header
-            guard let stream = InputStream(url: item) else {
-                throw Error.failedToCreateInputStream(item)
+        try itemPath.withCString { fileSystemPath in
+            let fd = open(fileSystemPath, O_RDONLY)
+            guard fd >= 0 else {
+                throw POSIXError.fromErrno()
             }
-            stream.open()
-            defer { stream.close() }
+            defer { close(fd) }
+
             while true {
-                let byteRead = stream.read(readBuffer, maxLength: bufferSize)
-                if byteRead < 0 {
-                    // stream.read returns -1 on error (e.g. TCC access denial under /Users/)
-                    let streamError = stream.streamError
-                    throw Error.failedToReadFile(item, streamError)
+                let bytesRead = read(fd, readBuffer, bufferSize)
+                if bytesRead < 0 {
+                    if errno == EINTR {
+                        continue
+                    }
+                    throw POSIXError.fromErrno()
                 }
-                if byteRead == 0 {
+                if bytesRead == 0 {
                     break
                 }
-                let data = Data(bytesNoCopy: UnsafeMutableRawPointer(mutating: readBuffer), count: byteRead, deallocator: .none)
+
+                let data = Data(bytesNoCopy: readBuffer, count: bytesRead, deallocator: .none)
                 hasher.update(data: data)
                 try data.withUnsafeBytes { pointer in
                     try writer.writeChunk(data: pointer)
@@ -143,49 +326,41 @@ public final class Archiver: Sendable {
         try writer.finish()
     }
 
-    private static func _createEntry(entryInfo: ArchiveEntryInfo, pathPrefix: String = "") throws -> WriteEntry? {
+    private static func _createEntry(
+        entryInfo: ArchiveEntryInfo,
+        archivedPathsByHostPath: [String: [URL]] = [:],
+        pathPrefix: String = ""
+    ) throws -> WriteEntry? {
         let entry = WriteEntry()
-        let fileManager = FileManager.default
-        let attributes = try fileManager.attributesOfItem(atPath: entryInfo.pathOnHost.path)
+        let hostPath = entryInfo.pathOnHost.path
+        let status = try Self._fileStatus(atPath: hostPath)
 
-        if let fileType = attributes[.type] as? FileAttributeType {
-            switch fileType {
-            case .typeBlockSpecial, .typeCharacterSpecial, .typeSocket:
-                return nil
-            case .typeDirectory:
-                entry.fileType = .directory
-            case .typeRegular:
-                entry.fileType = .regular
-            case .typeSymbolicLink:
-                entry.fileType = .symbolicLink
-                let symlinkTarget = try fileManager.destinationOfSymbolicLink(atPath: entryInfo.pathOnHost.path)
-                entry.symlinkTarget = symlinkTarget
-            default:
-                return nil
-            }
+        switch status.entryType {
+        case .directory:
+            entry.fileType = .directory
+            entry.size = 0
+        case .regular:
+            entry.fileType = .regular
+            entry.size = status.size
+        case .symbolicLink:
+            entry.fileType = .symbolicLink
+            entry.size = 0
+            entry.symlinkTarget = Self._rewriteArchivedAbsoluteSymlinkTarget(
+                status.symlinkTarget ?? "",
+                entryInfo: entryInfo,
+                archivedPathsByHostPath: archivedPathsByHostPath
+            )
         }
-        if let posixPermissions = attributes[.posixPermissions] as? NSNumber {
-            #if os(macOS)
-            entry.permissions = posixPermissions.uint16Value
-            #else
-            entry.permissions = posixPermissions.uint32Value
-            #endif
-        }
-        if let fileSize = attributes[.size] as? UInt64 {
-            entry.size = Int64(fileSize)
-        }
-        if let uid = attributes[.ownerAccountID] as? NSNumber {
-            entry.owner = uid.uint32Value
-        }
-        if let gid = attributes[.groupOwnerAccountID] as? NSNumber {
-            entry.group = gid.uint32Value
-        }
-        if let creationDate = attributes[.creationDate] as? Date {
-            entry.creationDate = creationDate
-        }
-        if let modificationDate = attributes[.modificationDate] as? Date {
-            entry.modificationDate = modificationDate
-        }
+
+        #if os(macOS)
+        entry.permissions = status.permissions
+        #else
+        entry.permissions = UInt32(status.permissions)
+        #endif
+        entry.owner = status.owner
+        entry.group = status.group
+        entry.creationDate = status.creationDate
+        entry.modificationDate = status.modificationDate
 
         // Apply explicit overrides from ArchiveEntryInfo when provided
         if let overrideOwner = entryInfo.owner {
@@ -207,6 +382,83 @@ public final class Archiver: Sendable {
         return entry
     }
 
+    private static func _fileStatus(atPath path: String) throws -> FileStatus {
+        try path.withCString { fileSystemPath in
+            var status = stat()
+            guard lstat(fileSystemPath, &status) == 0 else {
+                throw POSIXError.fromErrno()
+            }
+
+            let mode = status.st_mode & S_IFMT
+            let entryType: FileStatus.EntryType
+            let symlinkTarget: String?
+
+            switch mode {
+            case S_IFDIR:
+                entryType = .directory
+                symlinkTarget = nil
+            case S_IFREG:
+                entryType = .regular
+                symlinkTarget = nil
+            case S_IFLNK:
+                entryType = .symbolicLink
+                symlinkTarget = try Self._symlinkTarget(fileSystemPath: fileSystemPath, sizeHint: Int(status.st_size))
+            default:
+                throw Error.failedToCreateEntry
+            }
+
+            return FileStatus(
+                entryType: entryType,
+                permissions: UInt16(status.st_mode & 0o7777),
+                size: Int64(status.st_size),
+                owner: status.st_uid,
+                group: status.st_gid,
+                creationDate: Self._creationDate(from: status),
+                modificationDate: Self._modificationDate(from: status),
+                symlinkTarget: symlinkTarget
+            )
+        }
+    }
+
+    private static func _symlinkTarget(fileSystemPath: UnsafePointer<CChar>, sizeHint: Int) throws -> String {
+        let capacity = max(sizeHint + 1, Int(PATH_MAX))
+        let buffer = UnsafeMutablePointer<CChar>.allocate(capacity: capacity)
+        defer { buffer.deallocate() }
+
+        let count = readlink(fileSystemPath, buffer, capacity - 1)
+        guard count >= 0 else {
+            throw POSIXError.fromErrno()
+        }
+
+        buffer[count] = 0
+        return String(cString: buffer)
+    }
+
+    private static func _creationDate(from status: stat) -> Date? {
+        #if os(macOS)
+        return Date(
+            timeIntervalSince1970: TimeInterval(status.st_birthtimespec.tv_sec)
+                + TimeInterval(status.st_birthtimespec.tv_nsec) / 1_000_000_000
+        )
+        #else
+        return nil
+        #endif
+    }
+
+    private static func _modificationDate(from status: stat) -> Date? {
+        #if os(macOS)
+        return Date(
+            timeIntervalSince1970: TimeInterval(status.st_mtimespec.tv_sec)
+                + TimeInterval(status.st_mtimespec.tv_nsec) / 1_000_000_000
+        )
+        #else
+        return Date(
+            timeIntervalSince1970: TimeInterval(status.st_mtim.tv_sec)
+                + TimeInterval(status.st_mtim.tv_nsec) / 1_000_000_000
+        )
+        #endif
+    }
+
     private static func _trimPathPrefix(_ path: String, pathPrefix: String) -> String {
         guard !path.isEmpty && !pathPrefix.isEmpty else {
             return path
@@ -220,14 +472,67 @@ public final class Archiver: Sendable {
         let trimmedPath = String(decodedPath.suffix(from: pathPrefix.endIndex))
         return trimmedPath
     }
+
+    private static func _rewriteArchivedAbsoluteSymlinkTarget(
+        _ symlinkTarget: String,
+        entryInfo: ArchiveEntryInfo,
+        archivedPathsByHostPath: [String: [URL]]
+    ) -> String {
+        guard symlinkTarget.hasPrefix("/") else {
+            return symlinkTarget
+        }
+
+        let targetPath = URL(fileURLWithPath: symlinkTarget)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .path
+        guard let targetArchivePaths = archivedPathsByHostPath[targetPath], targetArchivePaths.count == 1, let targetArchivePath = targetArchivePaths.first else {
+            return symlinkTarget
+        }
+
+        let sourceDirectory = entryInfo.pathInArchive.deletingLastPathComponent().relativePath
+        return Self._relativeArchivePath(fromDirectory: sourceDirectory, to: targetArchivePath.relativePath)
+    }
+
+    private static func _relativeArchivePath(fromDirectory: String, to path: String) -> String {
+        let fromComponents = Self._archivePathComponents(fromDirectory)
+        let toComponents = Self._archivePathComponents(path)
+
+        var commonPrefixCount = 0
+        while commonPrefixCount < fromComponents.count,
+            commonPrefixCount < toComponents.count,
+            fromComponents[commonPrefixCount] == toComponents[commonPrefixCount]
+        {
+            commonPrefixCount += 1
+        }
+
+        let upwardTraversal = Array(repeating: "..", count: fromComponents.count - commonPrefixCount)
+        let remainder = Array(toComponents.dropFirst(commonPrefixCount))
+        let relativeComponents = upwardTraversal + remainder
+        return relativeComponents.isEmpty ? "." : relativeComponents.joined(separator: "/")
+    }
+
+    private static func _archivePathComponents(_ path: String) -> [String] {
+        NSString(string: path).pathComponents.filter { component in
+            component != "/" && component != "."
+        }
+    }
+
+    private static func _isSymbolicLink(_ path: URL) throws -> Bool {
+        let resourceValues = try path.resourceValues(forKeys: [.isSymbolicLinkKey])
+        if let isSymbolicLink = resourceValues.isSymbolicLink {
+            if isSymbolicLink {
+                return true
+            }
+        }
+        return false
+    }
 }
 
 extension Archiver {
     public enum Error: Swift.Error, CustomStringConvertible {
         case failedToCreateEntry
         case fileDoesNotExist(_ url: URL)
-        case failedToCreateInputStream(_ url: URL)
-        case failedToReadFile(_ url: URL, _ underlying: Swift.Error?)
 
         public var description: String {
             switch self {
@@ -235,45 +540,7 @@ extension Archiver {
                 return "failed to create entry"
             case .fileDoesNotExist(let url):
                 return "file \(url.path) does not exist"
-            case .failedToCreateInputStream(let url):
-                return "failed to create input stream for \(url.path)"
-            case .failedToReadFile(let url, let underlying):
-                if let underlying {
-                    return "failed to read file \(url.path): \(underlying)"
-                }
-                return "failed to read file \(url.path)"
             }
         }
-    }
-}
-
-extension WriteEntry: @retroactive Encodable {
-    enum CodingKeys: String, CodingKey {
-        case path
-        case fileType
-        case size
-        case permissions
-        case owner
-        case group
-        case symlinkTarget
-        case hardlink
-        case creationDate
-        case modificationDate
-        case contentAccessDate
-    }
-
-    public func encode(to encoder: any Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encodeIfPresent(fileType.rawValue, forKey: .fileType)
-        try container.encodeIfPresent(permissions, forKey: .permissions)
-        try container.encodeIfPresent(path, forKey: .path)
-        try container.encodeIfPresent(size, forKey: .size)
-        try container.encodeIfPresent(owner, forKey: .owner)
-        try container.encodeIfPresent(group, forKey: .group)
-        try container.encodeIfPresent(symlinkTarget, forKey: .symlinkTarget)
-        try container.encodeIfPresent(hardlink, forKey: .hardlink)
-        try container.encodeIfPresent(creationDate, forKey: .creationDate)
-        try container.encodeIfPresent(modificationDate, forKey: .modificationDate)
-        try container.encodeIfPresent(contentAccessDate, forKey: .contentAccessDate)
     }
 }

--- a/Sources/Services/ContainerAPIService/Client/Archiver.swift
+++ b/Sources/Services/ContainerAPIService/Client/Archiver.swift
@@ -160,86 +160,14 @@ public final class Archiver: Sendable {
         let source = source.standardizedFileURL
         let destination = destination.standardizedFileURL
 
-        // TODO: ArchiveReader needs some enhancement to support buffered uncompression
         let reader = try ArchiveReader(
             format: .paxRestricted,
             filter: .gzip,
             file: source
         )
-
-        for (entry, data) in reader {
-            guard let path = entry.path else {
-                continue
-            }
-            let uncompressPath = destination.appendingPathComponent(path)
-
-            let fileManager = FileManager.default
-            switch entry.fileType {
-            case .blockSpecial, .characterSpecial, .socket:
-                continue
-            case .directory:
-                try fileManager.createDirectory(
-                    at: uncompressPath,
-                    withIntermediateDirectories: true,
-                    attributes: [
-                        FileAttributeKey.posixPermissions: entry.permissions
-                    ]
-                )
-            case .regular:
-                try fileManager.createDirectory(
-                    at: uncompressPath.deletingLastPathComponent(),
-                    withIntermediateDirectories: true,
-                    attributes: [
-                        FileAttributeKey.posixPermissions: 0o755
-                    ]
-                )
-                let success = fileManager.createFile(
-                    atPath: uncompressPath.path,
-                    contents: data,
-                    attributes: [
-                        FileAttributeKey.posixPermissions: entry.permissions
-                    ]
-                )
-                if !success {
-                    throw POSIXError.fromErrno()
-                }
-                try data.write(to: uncompressPath)
-            case .symbolicLink:
-                guard let target = entry.symlinkTarget else {
-                    continue
-                }
-                try fileManager.createDirectory(
-                    at: uncompressPath.deletingLastPathComponent(),
-                    withIntermediateDirectories: true,
-                    attributes: [
-                        FileAttributeKey.posixPermissions: 0o755
-                    ]
-                )
-                try fileManager.createSymbolicLink(atPath: uncompressPath.path, withDestinationPath: target)
-                continue
-            default:
-                continue
-            }
-
-            // FIXME: uid/gid for compress.
-            try fileManager.setAttributes(
-                [.posixPermissions: NSNumber(value: entry.permissions)],
-                ofItemAtPath: uncompressPath.path
-            )
-
-            if let creationDate = entry.creationDate {
-                try fileManager.setAttributes(
-                    [.creationDate: creationDate],
-                    ofItemAtPath: uncompressPath.path
-                )
-            }
-
-            if let modificationDate = entry.modificationDate {
-                try fileManager.setAttributes(
-                    [.modificationDate: modificationDate],
-                    ofItemAtPath: uncompressPath.path
-                )
-            }
+        let rejectedMembers = try reader.extractContents(to: destination)
+        if !rejectedMembers.isEmpty {
+            throw Error.rejectedArchiveMembers(rejectedMembers)
         }
     }
 
@@ -250,10 +178,6 @@ public final class Archiver: Sendable {
         writerConfiguration: ArchiveWriterConfiguration,
         hasher: inout SHA256
     ) throws {
-        let archivedPathsByHostPath = entryInfo.reduce(into: [String: [URL]]()) { result, info in
-            result[info.pathOnHost.path, default: []].append(info.pathInArchive)
-        }
-
         let archiver = try ArchiveWriter(configuration: writerConfiguration)
         try archiver.open(file: destination)
 
@@ -261,7 +185,7 @@ public final class Archiver: Sendable {
         encoder.outputFormatting = .sortedKeys
 
         for info in entryInfo {
-            guard let entry = try Self._createEntry(entryInfo: info, archivedPathsByHostPath: archivedPathsByHostPath) else {
+            guard let entry = try Self._createEntry(entryInfo: info) else {
                 throw Error.failedToCreateEntry
             }
             let hashInfo = ArchiveEntryHashInfo(
@@ -328,7 +252,6 @@ public final class Archiver: Sendable {
 
     private static func _createEntry(
         entryInfo: ArchiveEntryInfo,
-        archivedPathsByHostPath: [String: [URL]] = [:],
         pathPrefix: String = ""
     ) throws -> WriteEntry? {
         let entry = WriteEntry()
@@ -345,11 +268,8 @@ public final class Archiver: Sendable {
         case .symbolicLink:
             entry.fileType = .symbolicLink
             entry.size = 0
-            entry.symlinkTarget = Self._rewriteArchivedAbsoluteSymlinkTarget(
-                status.symlinkTarget ?? "",
-                entryInfo: entryInfo,
-                archivedPathsByHostPath: archivedPathsByHostPath
-            )
+            // Match Docker build-context semantics and preserve the original target verbatim.
+            entry.symlinkTarget = status.symlinkTarget
         }
 
         #if os(macOS)
@@ -473,51 +393,6 @@ public final class Archiver: Sendable {
         return trimmedPath
     }
 
-    private static func _rewriteArchivedAbsoluteSymlinkTarget(
-        _ symlinkTarget: String,
-        entryInfo: ArchiveEntryInfo,
-        archivedPathsByHostPath: [String: [URL]]
-    ) -> String {
-        guard symlinkTarget.hasPrefix("/") else {
-            return symlinkTarget
-        }
-
-        let targetPath = URL(fileURLWithPath: symlinkTarget)
-            .standardizedFileURL
-            .resolvingSymlinksInPath()
-            .path
-        guard let targetArchivePaths = archivedPathsByHostPath[targetPath], targetArchivePaths.count == 1, let targetArchivePath = targetArchivePaths.first else {
-            return symlinkTarget
-        }
-
-        let sourceDirectory = entryInfo.pathInArchive.deletingLastPathComponent().relativePath
-        return Self._relativeArchivePath(fromDirectory: sourceDirectory, to: targetArchivePath.relativePath)
-    }
-
-    private static func _relativeArchivePath(fromDirectory: String, to path: String) -> String {
-        let fromComponents = Self._archivePathComponents(fromDirectory)
-        let toComponents = Self._archivePathComponents(path)
-
-        var commonPrefixCount = 0
-        while commonPrefixCount < fromComponents.count,
-            commonPrefixCount < toComponents.count,
-            fromComponents[commonPrefixCount] == toComponents[commonPrefixCount]
-        {
-            commonPrefixCount += 1
-        }
-
-        let upwardTraversal = Array(repeating: "..", count: fromComponents.count - commonPrefixCount)
-        let remainder = Array(toComponents.dropFirst(commonPrefixCount))
-        let relativeComponents = upwardTraversal + remainder
-        return relativeComponents.isEmpty ? "." : relativeComponents.joined(separator: "/")
-    }
-
-    private static func _archivePathComponents(_ path: String) -> [String] {
-        NSString(string: path).pathComponents.filter { component in
-            component != "/" && component != "."
-        }
-    }
-
     private static func _isSymbolicLink(_ path: URL) throws -> Bool {
         let resourceValues = try path.resourceValues(forKeys: [.isSymbolicLinkKey])
         if let isSymbolicLink = resourceValues.isSymbolicLink {
@@ -530,9 +405,10 @@ public final class Archiver: Sendable {
 }
 
 extension Archiver {
-    public enum Error: Swift.Error, CustomStringConvertible {
+    public enum Error: Swift.Error, CustomStringConvertible, Equatable {
         case failedToCreateEntry
         case fileDoesNotExist(_ url: URL)
+        case rejectedArchiveMembers([String])
 
         public var description: String {
             switch self {
@@ -540,6 +416,8 @@ extension Archiver {
                 return "failed to create entry"
             case .fileDoesNotExist(let url):
                 return "file \(url.path) does not exist"
+            case .rejectedArchiveMembers(let members):
+                return "rejected archive members: \(members.joined(separator: ", "))"
             }
         }
     }

--- a/Tests/ContainerAPIClientTests/ArchiverTests.swift
+++ b/Tests/ContainerAPIClientTests/ArchiverTests.swift
@@ -17,9 +17,55 @@
 import Foundation
 import Testing
 
+import ContainerizationArchive
+
 @testable import ContainerAPIClient
 
 struct ArchiverTests {
+    private enum EntryType {
+        case regular(String)
+        case directory
+        case symlink(String)
+    }
+
+    private func createTestArchive(
+        name: String,
+        entries: [(path: String, type: EntryType)],
+        baseDirectory: URL
+    ) throws -> URL {
+        let archiveURL = baseDirectory.appendingPathComponent("\(name).tar.gz")
+        let archiver = try ArchiveWriter(format: .paxRestricted, filter: .gzip, file: archiveURL)
+
+        for entry in entries {
+            let writeEntry = WriteEntry()
+            writeEntry.path = entry.path
+            writeEntry.permissions = 0o644
+            writeEntry.owner = 1000
+            writeEntry.group = 1000
+
+            switch entry.type {
+            case .regular(let content):
+                writeEntry.fileType = .regular
+                let data = try #require(content.data(using: .utf8))
+                writeEntry.size = numericCast(data.count)
+                try archiver.writeEntry(entry: writeEntry, data: data)
+            case .directory:
+                writeEntry.fileType = .directory
+                writeEntry.permissions = 0o755
+                writeEntry.size = 0
+                try archiver.writeEntry(entry: writeEntry, data: nil)
+            case .symlink(let target):
+                writeEntry.fileType = .symbolicLink
+                writeEntry.symlinkTarget = target
+                writeEntry.size = 0
+                try archiver.writeEntry(entry: writeEntry, data: nil)
+            }
+        }
+
+        try archiver.finishEncoding()
+        return archiveURL
+    }
+
     @Test
     func testCompressAndUncompressPreservesRelativeSymbolicLink() throws {
         let fileManager = FileManager.default
@@ -100,7 +146,7 @@ struct ArchiverTests {
     }
 
     @Test
-    func testCompressAndUncompressRewritesArchivedAbsoluteSymbolicLinkTarget() throws {
+    func testCompressAndUncompressPreservesInternalAbsoluteSymbolicLinkTarget() throws {
         let fileManager = FileManager.default
         let tempURL = try fileManager.url(
             for: .itemReplacementDirectory,
@@ -135,12 +181,12 @@ struct ArchiverTests {
         let extractedLinkURL = destinationURL.appendingPathComponent("link.txt")
         let values = try extractedLinkURL.resourceValues(forKeys: [.isSymbolicLinkKey])
         #expect(values.isSymbolicLink == true)
-        #expect(try fileManager.destinationOfSymbolicLink(atPath: extractedLinkURL.path) == "target.txt")
+        #expect(try fileManager.destinationOfSymbolicLink(atPath: extractedLinkURL.path) == targetURL.path)
         #expect(try String(contentsOf: extractedLinkURL, encoding: .utf8) == "hello")
     }
 
     @Test
-    func testCompressAndUncompressRewritesArchivedAbsoluteSymbolicLinkTargetThroughSymlinkedAncestor() throws {
+    func testCompressAndUncompressPreservesAbsoluteSymbolicLinkTargetThroughSymlinkedAncestor() throws {
         let fileManager = FileManager.default
         let tempURL = try fileManager.url(
             for: .itemReplacementDirectory,
@@ -184,7 +230,10 @@ struct ArchiverTests {
         let extractedLinkURL = destinationURL.appendingPathComponent("link.txt")
         let values = try extractedLinkURL.resourceValues(forKeys: [.isSymbolicLinkKey])
         #expect(values.isSymbolicLink == true)
-        #expect(try fileManager.destinationOfSymbolicLink(atPath: extractedLinkURL.path) == "real/target.txt")
+        #expect(
+            try fileManager.destinationOfSymbolicLink(atPath: extractedLinkURL.path)
+                == sourceURL.appendingPathComponent("alias/target.txt").path
+        )
         #expect(try String(contentsOf: extractedLinkURL, encoding: .utf8) == "hello")
     }
 
@@ -285,6 +334,35 @@ struct ArchiverTests {
 
         #expect(fileManager.fileExists(atPath: destinationURL.appendingPathComponent("include.txt").path))
         #expect(!fileManager.fileExists(atPath: destinationURL.appendingPathComponent("exclude.txt").path))
+    }
+
+    @Test
+    func testUncompressRejectsPathTraversalMembers() throws {
+        let fileManager = FileManager.default
+        let tempURL = try fileManager.url(
+            for: .itemReplacementDirectory,
+            in: .userDomainMask,
+            appropriateFor: .temporaryDirectory,
+            create: true
+        )
+        defer { try? fileManager.removeItem(at: tempURL) }
+
+        let archiveURL = try createTestArchive(
+            name: "traversal",
+            entries: [
+                (path: "safe.txt", type: .regular("safe")),
+                (path: "../outside.txt", type: .regular("evil")),
+            ],
+            baseDirectory: tempURL
+        )
+        let destinationURL = tempURL.appendingPathComponent("destination")
+
+        #expect(throws: Archiver.Error.rejectedArchiveMembers(["../outside.txt"])) {
+            try Archiver.uncompress(source: archiveURL, destination: destinationURL)
+        }
+
+        #expect(fileManager.fileExists(atPath: destinationURL.appendingPathComponent("safe.txt").path))
+        #expect(!fileManager.fileExists(atPath: tempURL.appendingPathComponent("outside.txt").path))
     }
 
     private func archiveDigest(sourceURL: URL, destinationURL: URL) throws -> String {

--- a/Tests/ContainerAPIClientTests/ArchiverTests.swift
+++ b/Tests/ContainerAPIClientTests/ArchiverTests.swift
@@ -1,0 +1,303 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import ContainerAPIClient
+
+struct ArchiverTests {
+    @Test
+    func testCompressAndUncompressPreservesRelativeSymbolicLink() throws {
+        let fileManager = FileManager.default
+        let tempURL = try fileManager.url(
+            for: .itemReplacementDirectory,
+            in: .userDomainMask,
+            appropriateFor: .temporaryDirectory,
+            create: true
+        )
+        defer { try? fileManager.removeItem(at: tempURL) }
+
+        let sourceURL = tempURL.appendingPathComponent("source")
+        let archiveURL = tempURL.appendingPathComponent("archive.tar.gz")
+        let destinationURL = tempURL.appendingPathComponent("destination")
+        try fileManager.createDirectory(at: sourceURL, withIntermediateDirectories: true)
+
+        let targetURL = sourceURL.appendingPathComponent("target.txt")
+        try #require("hello".data(using: .utf8)).write(to: targetURL)
+        let linkURL = sourceURL.appendingPathComponent("link.txt")
+        try fileManager.createSymbolicLink(atPath: linkURL.path, withDestinationPath: "target.txt")
+
+        _ = try Archiver.compress(source: sourceURL, destination: archiveURL) { url in
+            let sourcePath = sourceURL.standardizedFileURL.path
+            let path = url.standardizedFileURL.path
+            let relativePath = String(path.dropFirst(sourcePath.count + 1))
+            return Archiver.ArchiveEntryInfo(
+                pathOnHost: url,
+                pathInArchive: URL(fileURLWithPath: relativePath)
+            )
+        }
+
+        try Archiver.uncompress(source: archiveURL, destination: destinationURL)
+
+        let extractedLinkURL = destinationURL.appendingPathComponent("link.txt")
+        let values = try extractedLinkURL.resourceValues(forKeys: [.isSymbolicLinkKey])
+        #expect(values.isSymbolicLink == true)
+        #expect(try fileManager.destinationOfSymbolicLink(atPath: extractedLinkURL.path) == "target.txt")
+        #expect(try String(contentsOf: destinationURL.appendingPathComponent("target.txt"), encoding: .utf8) == "hello")
+    }
+
+    @Test
+    func testCompressAndUncompressPreservesAbsoluteSymbolicLink() throws {
+        let fileManager = FileManager.default
+        let tempURL = try fileManager.url(
+            for: .itemReplacementDirectory,
+            in: .userDomainMask,
+            appropriateFor: .temporaryDirectory,
+            create: true
+        )
+        defer { try? fileManager.removeItem(at: tempURL) }
+
+        let sourceURL = tempURL.appendingPathComponent("source")
+        let archiveURL = tempURL.appendingPathComponent("archive.tar.gz")
+        let destinationURL = tempURL.appendingPathComponent("destination")
+        try fileManager.createDirectory(at: sourceURL, withIntermediateDirectories: true)
+
+        let externalTargetURL = tempURL.appendingPathComponent("external-target.txt")
+        try #require("external".data(using: .utf8)).write(to: externalTargetURL)
+        let linkURL = sourceURL.appendingPathComponent("absolute-link.txt")
+        try fileManager.createSymbolicLink(atPath: linkURL.path, withDestinationPath: externalTargetURL.path)
+
+        _ = try Archiver.compress(source: sourceURL, destination: archiveURL) { url in
+            let sourcePath = sourceURL.standardizedFileURL.path
+            let path = url.standardizedFileURL.path
+            let relativePath = String(path.dropFirst(sourcePath.count + 1))
+            return Archiver.ArchiveEntryInfo(
+                pathOnHost: url,
+                pathInArchive: URL(fileURLWithPath: relativePath)
+            )
+        }
+
+        try Archiver.uncompress(source: archiveURL, destination: destinationURL)
+
+        let extractedLinkURL = destinationURL.appendingPathComponent("absolute-link.txt")
+        let values = try extractedLinkURL.resourceValues(forKeys: [.isSymbolicLinkKey])
+        #expect(values.isSymbolicLink == true)
+        #expect(try fileManager.destinationOfSymbolicLink(atPath: extractedLinkURL.path) == externalTargetURL.path)
+    }
+
+    @Test
+    func testCompressAndUncompressRewritesArchivedAbsoluteSymbolicLinkTarget() throws {
+        let fileManager = FileManager.default
+        let tempURL = try fileManager.url(
+            for: .itemReplacementDirectory,
+            in: .userDomainMask,
+            appropriateFor: .temporaryDirectory,
+            create: true
+        )
+        defer { try? fileManager.removeItem(at: tempURL) }
+
+        let sourceURL = tempURL.appendingPathComponent("source")
+        let archiveURL = tempURL.appendingPathComponent("archive.tar.gz")
+        let destinationURL = tempURL.appendingPathComponent("destination")
+        try fileManager.createDirectory(at: sourceURL, withIntermediateDirectories: true)
+
+        let targetURL = sourceURL.appendingPathComponent("target.txt")
+        try #require("hello".data(using: .utf8)).write(to: targetURL)
+        let linkURL = sourceURL.appendingPathComponent("link.txt")
+        try fileManager.createSymbolicLink(atPath: linkURL.path, withDestinationPath: targetURL.path)
+
+        _ = try Archiver.compress(source: sourceURL, destination: archiveURL) { url in
+            let sourcePath = sourceURL.standardizedFileURL.path
+            let path = url.standardizedFileURL.path
+            let relativePath = String(path.dropFirst(sourcePath.count + 1))
+            return Archiver.ArchiveEntryInfo(
+                pathOnHost: url,
+                pathInArchive: URL(fileURLWithPath: relativePath)
+            )
+        }
+
+        try Archiver.uncompress(source: archiveURL, destination: destinationURL)
+
+        let extractedLinkURL = destinationURL.appendingPathComponent("link.txt")
+        let values = try extractedLinkURL.resourceValues(forKeys: [.isSymbolicLinkKey])
+        #expect(values.isSymbolicLink == true)
+        #expect(try fileManager.destinationOfSymbolicLink(atPath: extractedLinkURL.path) == "target.txt")
+        #expect(try String(contentsOf: extractedLinkURL, encoding: .utf8) == "hello")
+    }
+
+    @Test
+    func testCompressAndUncompressRewritesArchivedAbsoluteSymbolicLinkTargetThroughSymlinkedAncestor() throws {
+        let fileManager = FileManager.default
+        let tempURL = try fileManager.url(
+            for: .itemReplacementDirectory,
+            in: .userDomainMask,
+            appropriateFor: .temporaryDirectory,
+            create: true
+        )
+        defer { try? fileManager.removeItem(at: tempURL) }
+
+        let sourceURL = tempURL.appendingPathComponent("source")
+        let archiveURL = tempURL.appendingPathComponent("archive.tar.gz")
+        let destinationURL = tempURL.appendingPathComponent("destination")
+        try fileManager.createDirectory(at: sourceURL, withIntermediateDirectories: true)
+
+        let realDirectoryURL = sourceURL.appendingPathComponent("real")
+        try fileManager.createDirectory(at: realDirectoryURL, withIntermediateDirectories: true)
+        let targetURL = realDirectoryURL.appendingPathComponent("target.txt")
+        try #require("hello".data(using: .utf8)).write(to: targetURL)
+
+        let aliasURL = sourceURL.appendingPathComponent("alias")
+        try fileManager.createSymbolicLink(atPath: aliasURL.path, withDestinationPath: "real")
+
+        let linkURL = sourceURL.appendingPathComponent("link.txt")
+        try fileManager.createSymbolicLink(
+            atPath: linkURL.path,
+            withDestinationPath: sourceURL.appendingPathComponent("alias/target.txt").path
+        )
+
+        _ = try Archiver.compress(source: sourceURL, destination: archiveURL) { url in
+            let sourcePath = sourceURL.standardizedFileURL.path
+            let path = url.standardizedFileURL.path
+            let relativePath = String(path.dropFirst(sourcePath.count + 1))
+            return Archiver.ArchiveEntryInfo(
+                pathOnHost: url,
+                pathInArchive: URL(fileURLWithPath: relativePath)
+            )
+        }
+
+        try Archiver.uncompress(source: archiveURL, destination: destinationURL)
+
+        let extractedLinkURL = destinationURL.appendingPathComponent("link.txt")
+        let values = try extractedLinkURL.resourceValues(forKeys: [.isSymbolicLinkKey])
+        #expect(values.isSymbolicLink == true)
+        #expect(try fileManager.destinationOfSymbolicLink(atPath: extractedLinkURL.path) == "real/target.txt")
+        #expect(try String(contentsOf: extractedLinkURL, encoding: .utf8) == "hello")
+    }
+
+    @Test
+    func testCompressDigestChangesWhenSymlinkTargetChanges() throws {
+        let fileManager = FileManager.default
+        let tempURL = try fileManager.url(
+            for: .itemReplacementDirectory,
+            in: .userDomainMask,
+            appropriateFor: .temporaryDirectory,
+            create: true
+        )
+        defer { try? fileManager.removeItem(at: tempURL) }
+
+        let sourceURL = tempURL.appendingPathComponent("source")
+        try fileManager.createDirectory(at: sourceURL, withIntermediateDirectories: true)
+
+        let firstTargetURL = sourceURL.appendingPathComponent("first.txt")
+        let secondTargetURL = sourceURL.appendingPathComponent("second.txt")
+        try #require("first".data(using: .utf8)).write(to: firstTargetURL)
+        try #require("second".data(using: .utf8)).write(to: secondTargetURL)
+
+        let linkURL = sourceURL.appendingPathComponent("link.txt")
+        try fileManager.createSymbolicLink(atPath: linkURL.path, withDestinationPath: "first.txt")
+
+        let firstArchiveURL = tempURL.appendingPathComponent("first.tar.gz")
+        let firstDigest = try archiveDigest(sourceURL: sourceURL, destinationURL: firstArchiveURL)
+
+        try fileManager.removeItem(at: linkURL)
+        try fileManager.createSymbolicLink(atPath: linkURL.path, withDestinationPath: "second.txt")
+
+        let secondArchiveURL = tempURL.appendingPathComponent("second.tar.gz")
+        let secondDigest = try archiveDigest(sourceURL: sourceURL, destinationURL: secondArchiveURL)
+
+        #expect(firstDigest != secondDigest)
+    }
+
+    @Test
+    func testCompressDigestChangesWhenPermissionsChange() throws {
+        let fileManager = FileManager.default
+        let tempURL = try fileManager.url(
+            for: .itemReplacementDirectory,
+            in: .userDomainMask,
+            appropriateFor: .temporaryDirectory,
+            create: true
+        )
+        defer { try? fileManager.removeItem(at: tempURL) }
+
+        let sourceURL = tempURL.appendingPathComponent("source")
+        try fileManager.createDirectory(at: sourceURL, withIntermediateDirectories: true)
+
+        let fileURL = sourceURL.appendingPathComponent("file.txt")
+        try #require("hello".data(using: .utf8)).write(to: fileURL)
+
+        try fileManager.setAttributes([.posixPermissions: 0o644], ofItemAtPath: fileURL.path)
+        let firstArchiveURL = tempURL.appendingPathComponent("first.tar.gz")
+        let firstDigest = try archiveDigest(sourceURL: sourceURL, destinationURL: firstArchiveURL)
+
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fileURL.path)
+        let secondArchiveURL = tempURL.appendingPathComponent("second.tar.gz")
+        let secondDigest = try archiveDigest(sourceURL: sourceURL, destinationURL: secondArchiveURL)
+
+        #expect(firstDigest != secondDigest)
+    }
+
+    @Test
+    func testCompressEntriesOnlyArchivesExplicitInputs() throws {
+        let fileManager = FileManager.default
+        let tempURL = try fileManager.url(
+            for: .itemReplacementDirectory,
+            in: .userDomainMask,
+            appropriateFor: .temporaryDirectory,
+            create: true
+        )
+        defer { try? fileManager.removeItem(at: tempURL) }
+
+        let sourceURL = tempURL.appendingPathComponent("source")
+        let archiveURL = tempURL.appendingPathComponent("archive.tar.gz")
+        let destinationURL = tempURL.appendingPathComponent("destination")
+        try fileManager.createDirectory(at: sourceURL, withIntermediateDirectories: true)
+
+        let includeURL = sourceURL.appendingPathComponent("include.txt")
+        let excludeURL = sourceURL.appendingPathComponent("exclude.txt")
+        try #require("keep".data(using: .utf8)).write(to: includeURL)
+        try #require("drop".data(using: .utf8)).write(to: excludeURL)
+
+        _ = try Archiver.compress(
+            entries: [
+                Archiver.ArchiveEntryInfo(
+                    pathOnHost: includeURL,
+                    pathInArchive: URL(fileURLWithPath: "include.txt")
+                )
+            ],
+            destination: archiveURL
+        )
+
+        try Archiver.uncompress(source: archiveURL, destination: destinationURL)
+
+        #expect(fileManager.fileExists(atPath: destinationURL.appendingPathComponent("include.txt").path))
+        #expect(!fileManager.fileExists(atPath: destinationURL.appendingPathComponent("exclude.txt").path))
+    }
+
+    private func archiveDigest(sourceURL: URL, destinationURL: URL) throws -> String {
+        let digest = try Archiver.compress(source: sourceURL, destination: destinationURL) { url in
+            let sourcePath = sourceURL.standardizedFileURL.path
+            let path = url.standardizedFileURL.path
+            let relativePath = String(path.dropFirst(sourcePath.count + 1))
+            return Archiver.ArchiveEntryInfo(
+                pathOnHost: url,
+                pathInArchive: URL(fileURLWithPath: relativePath)
+            )
+        }
+
+        return digest.compactMap { String(format: "%02x", $0) }.joined()
+    }
+}


### PR DESCRIPTION
## Type of Change
- [X] Bug fix


## Motivation and Context
While building out a Docker Compose-style plugin and validating it against our own real development stack, we ran into two classes of problems in the build-context path:

* Correctness issues in archive generation, especially around symlinks 
* Very high client-side overhead while preparing and streaming build contexts.

This PR fixes build-context archiving in `container` so symlinks are preserved correctly, digest calculation reflects symlink target changes, and fssync archives the exact selected file set in the already-computed order.

Before this change, build-context archiving could mis-handle symlinks, archive a broader tree walk than necessary, and produce a digest that did not change when symlink targets changed.

Part of the fix was also more generally related to the Containerization framework.  This PR intentionally stays independently mergeable against the current released `containerization` dependency, so it keeps the local archiver implementation  needed for these fixes today. The Containerization PR is: https://github.com/apple/containerization/pull/652

## Validation

This is an example of the problem the PR actually fixes.

### Build context:
```
ctx="$(mktemp -d /private/tmp/container-retest-rel.XXXXXX)/ctx"
mkdir -p "$ctx"
printf 'hello\n' > "$ctx/target.txt"
ln -s target.txt "$ctx/link.txt"

cat > "$ctx/Dockerfile" <<'EOF'
FROM alpine:3.20
COPY . /ctx
RUN echo "link target: $(readlink /ctx/link.txt)" && \
      test "$(readlink /ctx/link.txt)" = "target.txt" && \
      test "$(cat /ctx/link.txt)" = "hello"
EOF
```

### Build command:
```
  container build -t rel-patch-retest -f Dockerfile .
```

### Observed results:

  - main branch: failed
      - link target: came back empty
      - exit code 1
  - patched branch: passed
      - link target: target.txt
      - Successfully built `rel-patch-retest:latest`
      - exit code 0
  - Before this fix, container build could lose symlink metadata in the archived build context.
  - A relative symlink like link.txt -> target.txt arrived broken inside the build.
  - After this fix, the same build context preserves the symlink correctly and the build succeeds.

## Testing
- [X] Tested locally
- [X] Added/updated tests

