### PR TITLE
Fall back to simple text output when stdout is not a TTY

### DIFF
--- a/Sources/ContainerCommands/Flags+ProgressConfig.swift
+++ b/Sources/ContainerCommands/Flags+ProgressConfig.swift
@@ -19,16 +19,11 @@ import Foundation
 import TerminalProgress
 
 extension Flags.Progress {
-    /// Resolves `.auto` into `.ansi` or `.plain` based on the terminal.
-    ///
-    /// When the progress type is `.auto`, the terminal file handle is checked
-    /// with `isatty`. If the output is a TTY, `.ansi` is used; otherwise
-    /// `.plain` is selected so that piped or redirected output still shows
-    /// simple line-by-line status text.
-    private func resolvedProgress(terminal: FileHandle = .standardError) -> ProgressType {
+    /// Resolves `.auto` into `.ansi` or `.plain` based on whether stderr is a TTY.
+    private func resolvedProgress() -> ProgressType {
         switch progress {
         case .auto:
-            return isatty(terminal.fileDescriptor) == 1 ? .ansi : .plain
+            return isatty(FileHandle.standardError.fileDescriptor) == 1 ? .ansi : .plain
         case .none, .ansi, .plain, .color:
             return progress
         }

--- a/Sources/ContainerCommands/Flags+ProgressConfig.swift
+++ b/Sources/ContainerCommands/Flags+ProgressConfig.swift
@@ -15,15 +15,32 @@
 //===----------------------------------------------------------------------===//
 
 import ContainerAPIClient
+import Foundation
 import TerminalProgress
 
 extension Flags.Progress {
+    /// Resolves `.auto` into `.ansi` or `.plain` based on the terminal.
+    ///
+    /// When the progress type is `.auto`, the terminal file handle is checked
+    /// with `isatty`. If the output is a TTY, `.ansi` is used; otherwise
+    /// `.plain` is selected so that piped or redirected output still shows
+    /// simple line-by-line status text.
+    private func resolvedProgress(terminal: FileHandle = .standardError) -> ProgressType {
+        switch progress {
+        case .auto:
+            return isatty(terminal.fileDescriptor) == 1 ? .ansi : .plain
+        case .none, .ansi, .plain, .color:
+            return progress
+        }
+    }
+
     /// Creates a `ProgressConfig` based on the selected progress type.
     ///
     /// For `.none`, progress updates are disabled. For `.ansi`, the given parameters
     /// are used as-is. For `.plain`, ANSI-incompatible features (spinner, clear on finish)
     /// are disabled and the output mode is set to `.plain`. For `.color`, behavior matches
     /// `.ansi` but the output mode is set to `.color` to enable color-coded output.
+    /// For `.auto`, the type is resolved by checking whether stderr is a TTY.
     func makeConfig(
         description: String = "",
         itemsName: String = "it",
@@ -33,13 +50,14 @@ extension Flags.Progress {
         ignoreSmallSize: Bool = false,
         totalTasks: Int? = nil
     ) throws -> ProgressConfig {
-        switch progress {
+        let resolved = resolvedProgress()
+        switch resolved {
         case .none:
             return try ProgressConfig(disableProgressUpdates: true)
         case .ansi, .plain, .color:
-            let isPlain = progress == .plain
+            let isPlain = resolved == .plain
             let outputMode: ProgressConfig.OutputMode
-            switch progress {
+            switch resolved {
             case .plain: outputMode = .plain
             case .color: outputMode = .color
             default: outputMode = .ansi
@@ -56,6 +74,8 @@ extension Flags.Progress {
                 clearOnFinish: !isPlain,
                 outputMode: outputMode
             )
+        case .auto:
+            fatalError("unreachable: .auto should have been resolved")
         }
     }
 }

--- a/Sources/Services/ContainerAPIService/Client/Flags.swift
+++ b/Sources/Services/ContainerAPIService/Client/Flags.swift
@@ -351,14 +351,15 @@ public struct Flags {
         }
 
         public enum ProgressType: String, ExpressibleByArgument {
+            case auto
             case none
             case ansi
             case plain
             case color
         }
 
-        @Option(name: .long, help: ArgumentHelp("Progress type (format: none|ansi|plain|color)", valueName: "type"))
-        public var progress: ProgressType = .ansi
+        @Option(name: .long, help: ArgumentHelp("Progress type (format: auto|none|ansi|plain|color)", valueName: "type"))
+        public var progress: ProgressType = .auto
     }
 
     public struct ImageFetch: ParsableArguments {

--- a/Tests/CLITests/Subcommands/Images/TestCLIProgressAuto.swift
+++ b/Tests/CLITests/Subcommands/Images/TestCLIProgressAuto.swift
@@ -19,55 +19,52 @@ import Testing
 
 class TestCLIProgressAuto: CLITest {
     @Test func testAutoProgressFallsBackToPlainWhenPiped() throws {
-        do {
-            let (_, _, error, status) = try run(arguments: [
-                "image", "pull",
-                "--progress", "auto",
-                alpine,
-            ])
-            #expect(status == 0, "image pull should succeed, stderr: \(error)")
-            let lines = error.components(separatedBy: .newlines)
-                .filter { !$0.contains("Warning! Running debug build") && !$0.isEmpty }
-            #expect(!lines.isEmpty, "expected plain progress output on stderr when piped")
-            #expect(!error.contains("\u{1B}["), "expected no ANSI escapes in piped output")
-        } catch {
-            Issue.record("failed to test auto progress: \(error)")
-            return
-        }
+        let (_, _, error, status) = try run(arguments: [
+            "image", "pull",
+            "--progress", "auto",
+            alpine,
+        ])
+        #expect(status == 0, "image pull should succeed, stderr: \(error)")
+        let lines = error.components(separatedBy: .newlines)
+            .filter { !$0.contains("Warning! Running debug build") && !$0.isEmpty }
+        #expect(!lines.isEmpty, "expected plain progress output on stderr when piped")
+        #expect(!error.contains("\u{1B}["), "expected no ANSI escapes in piped output")
     }
 
     @Test func testExplicitPlainProgress() throws {
-        do {
-            let (_, _, error, status) = try run(arguments: [
-                "image", "pull",
-                "--progress", "plain",
-                alpine,
-            ])
-            #expect(status == 0, "image pull --progress plain should succeed, stderr: \(error)")
-            let lines = error.components(separatedBy: .newlines)
-                .filter { !$0.contains("Warning! Running debug build") && !$0.isEmpty }
-            #expect(!lines.isEmpty, "expected plain progress output on stderr")
-            #expect(!error.contains("\u{1B}["), "expected no ANSI escapes with --progress plain")
-        } catch {
-            Issue.record("failed to test plain progress: \(error)")
-            return
-        }
+        let (_, _, error, status) = try run(arguments: [
+            "image", "pull",
+            "--progress", "plain",
+            alpine,
+        ])
+        #expect(status == 0, "image pull --progress plain should succeed, stderr: \(error)")
+        let lines = error.components(separatedBy: .newlines)
+            .filter { !$0.contains("Warning! Running debug build") && !$0.isEmpty }
+        #expect(!lines.isEmpty, "expected plain progress output on stderr")
+        #expect(!error.contains("\u{1B}["), "expected no ANSI escapes with --progress plain")
+    }
+
+    @Test func testExplicitAnsiProgress() throws {
+        let (_, _, error, status) = try run(arguments: [
+            "image", "pull",
+            "--progress", "ansi",
+            alpine,
+        ])
+        #expect(status == 0, "image pull --progress ansi should succeed, stderr: \(error)")
+        let lines = error.components(separatedBy: .newlines)
+            .filter { !$0.contains("Warning! Running debug build") && !$0.isEmpty }
+        #expect(!lines.isEmpty, "expected ansi progress output on stderr")
     }
 
     @Test func testNoneProgressSuppressesOutput() throws {
-        do {
-            let (_, _, error, status) = try run(arguments: [
-                "image", "pull",
-                "--progress", "none",
-                alpine,
-            ])
-            #expect(status == 0, "image pull --progress none should succeed, stderr: \(error)")
-            let lines = error.components(separatedBy: .newlines)
-                .filter { !$0.contains("Warning! Running debug build") && !$0.isEmpty }
-            #expect(lines.isEmpty, "expected no progress output on stderr with --progress none")
-        } catch {
-            Issue.record("failed to test none progress: \(error)")
-            return
-        }
+        let (_, _, error, status) = try run(arguments: [
+            "image", "pull",
+            "--progress", "none",
+            alpine,
+        ])
+        #expect(status == 0, "image pull --progress none should succeed, stderr: \(error)")
+        let lines = error.components(separatedBy: .newlines)
+            .filter { !$0.contains("Warning! Running debug build") && !$0.isEmpty }
+        #expect(lines.isEmpty, "expected no progress output on stderr with --progress none")
     }
 }

--- a/Tests/CLITests/Subcommands/Images/TestCLIProgressAuto.swift
+++ b/Tests/CLITests/Subcommands/Images/TestCLIProgressAuto.swift
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+class TestCLIProgressAuto: CLITest {
+    @Test func testAutoProgressFallsBackToPlainWhenPiped() throws {
+        do {
+            let (_, _, error, status) = try run(arguments: [
+                "image", "pull",
+                "--progress", "auto",
+                alpine,
+            ])
+            #expect(status == 0, "image pull should succeed, stderr: \(error)")
+            let lines = error.components(separatedBy: .newlines)
+                .filter { !$0.contains("Warning! Running debug build") && !$0.isEmpty }
+            #expect(!lines.isEmpty, "expected plain progress output on stderr when piped")
+            #expect(!error.contains("\u{1B}["), "expected no ANSI escapes in piped output")
+        } catch {
+            Issue.record("failed to test auto progress: \(error)")
+            return
+        }
+    }
+
+    @Test func testExplicitPlainProgress() throws {
+        do {
+            let (_, _, error, status) = try run(arguments: [
+                "image", "pull",
+                "--progress", "plain",
+                alpine,
+            ])
+            #expect(status == 0, "image pull --progress plain should succeed, stderr: \(error)")
+            let lines = error.components(separatedBy: .newlines)
+                .filter { !$0.contains("Warning! Running debug build") && !$0.isEmpty }
+            #expect(!lines.isEmpty, "expected plain progress output on stderr")
+            #expect(!error.contains("\u{1B}["), "expected no ANSI escapes with --progress plain")
+        } catch {
+            Issue.record("failed to test plain progress: \(error)")
+            return
+        }
+    }
+
+    @Test func testNoneProgressSuppressesOutput() throws {
+        do {
+            let (_, _, error, status) = try run(arguments: [
+                "image", "pull",
+                "--progress", "none",
+                alpine,
+            ])
+            #expect(status == 0, "image pull --progress none should succeed, stderr: \(error)")
+            let lines = error.components(separatedBy: .newlines)
+                .filter { !$0.contains("Warning! Running debug build") && !$0.isEmpty }
+            #expect(lines.isEmpty, "expected no progress output on stderr with --progress none")
+        } catch {
+            Issue.record("failed to test none progress: \(error)")
+            return
+        }
+    }
+}


### PR DESCRIPTION
## summary
- detect when stdout is not a tty and fall back to simple line-by-line status output
- fixes silent commands when piping to a file

fixes #113

## test plan

**before (main):**
```
$ container image pull ghcr.io/linuxcontainers/alpine:3.20 2>stderr.txt
$ cat stderr.txt
(empty - progress lost when stderr is not a tty)
```

**after:**
```
$ container image pull ghcr.io/linuxcontainers/alpine:3.20 2>stderr.txt
$ cat stderr.txt
[1/2] Fetching image [0s]
[1/2] Fetching image (7 of 15 blobs) [2s]
[1/2] Fetching image 42% (23 of 50 blobs, 10.0/23.7 MB, 6.9 MB/s) [5s]
[2/2] Unpacking image for platform linux/arm64 [11s]
...
```

also added `TestCLIProgressAuto` integration test covering auto/plain/none modes