### PR TITLE
Fix ContainerResource build failure

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -350,6 +350,7 @@ let package = Package(
         .target(
             name: "ContainerResource",
             dependencies: [
+                .product(name: "Collections", package: "swift-collections"),
                 .product(name: "Containerization", package: "containerization"),
                 "ContainerXPC",
                 "CAuditToken",

--- a/Sources/ContainerResource/Common/ApplicationError.swift
+++ b/Sources/ContainerResource/Common/ApplicationError.swift
@@ -17,7 +17,7 @@
 /// Protocol for errors with a stable code and structured metadata.
 /// This allows the client to present the error as it chooses.
 
-import Collections
+import OrderedCollections
 
 public protocol AppError: Error {
     var code: AppErrorCode { get }

--- a/Sources/ContainerResource/Common/ResourceLabels.swift
+++ b/Sources/ContainerResource/Common/ResourceLabels.swift
@@ -14,7 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import Collections
+import OrderedCollections
 
 /// Metadata for a managed resource.
 public struct ResourceLabels: Sendable, Equatable {


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

The `ContainerResource` target uses `OrderedDictionary` (added in #1360) but doesn't declare a dependency on `swift-collections` in `Package.swift`, and the source files import the `Collections` umbrella module instead of `OrderedCollections`. This causes build failures when `OrderedDictionary` is used in public declarations, since the compiler requires the specific submodule to be imported in that context.

- Add `swift-collections` dependency to the `ContainerResource` target in `Package.swift`
- Change `import Collections` to `import OrderedCollections` in `ApplicationError.swift` and `ResourceLabels.swift`

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
