### PR TITLE
Add Environment Variable for Progress Mode

### DIFF
--- a/Sources/ContainerCommands/Flags+ProgressConfig.swift
+++ b/Sources/ContainerCommands/Flags+ProgressConfig.swift
@@ -20,12 +20,12 @@ import TerminalProgress
 
 extension Flags.Progress {
     /// Resolves `.auto` into `.ansi` or `.plain` based on whether stderr is a TTY.
-    private func resolvedProgress() -> ProgressType {
-        switch progress {
+    private func resolveAutoProgress(_ type: ProgressType) -> ProgressType {
+        switch type {
         case .auto:
             return isatty(FileHandle.standardError.fileDescriptor) == 1 ? .ansi : .plain
         case .none, .ansi, .plain, .color:
-            return progress
+            return type
         }
     }
 
@@ -45,7 +45,7 @@ extension Flags.Progress {
         ignoreSmallSize: Bool = false,
         totalTasks: Int? = nil
     ) throws -> ProgressConfig {
-        let resolved = resolvedProgress()
+        let resolved = resolveAutoProgress(resolvedProgress)
         switch resolved {
         case .none:
             return try ProgressConfig(disableProgressUpdates: true)

--- a/Sources/ContainerCommands/Flags+ProgressConfig.swift
+++ b/Sources/ContainerCommands/Flags+ProgressConfig.swift
@@ -20,7 +20,7 @@ import TerminalProgress
 
 extension Flags.Progress {
     /// Resolves `.auto` into `.ansi` or `.plain` based on whether stderr is a TTY.
-    private func resolveAutoProgress(_ type: ProgressType) -> ProgressType {
+    private static func resolveAutoProgress(_ type: ProgressType) -> ProgressType {
         switch type {
         case .auto:
             return isatty(FileHandle.standardError.fileDescriptor) == 1 ? .ansi : .plain
@@ -45,7 +45,7 @@ extension Flags.Progress {
         ignoreSmallSize: Bool = false,
         totalTasks: Int? = nil
     ) throws -> ProgressConfig {
-        let resolved = resolveAutoProgress(resolvedProgress)
+        let resolved = Self.resolveAutoProgress(resolvedProgress)
         switch resolved {
         case .none:
             return try ProgressConfig(disableProgressUpdates: true)

--- a/Sources/Services/ContainerAPIService/Client/Flags.swift
+++ b/Sources/Services/ContainerAPIService/Client/Flags.swift
@@ -358,10 +358,10 @@ public struct Flags {
             case color
         }
 
+        static let environmentVariable = "CONTAINER_CLI_PROGRESS"
+
         @Option(name: .long, help: ArgumentHelp("Progress type (format: auto|none|ansi|plain|color) [environment: CONTAINER_CLI_PROGRESS]", valueName: "type"))
         public var progress: ProgressType?
-
-        static let environmentVariable = "CONTAINER_CLI_PROGRESS"
 
         public var resolvedProgress: ProgressType {
             resolveProgress()

--- a/Sources/Services/ContainerAPIService/Client/Flags.swift
+++ b/Sources/Services/ContainerAPIService/Client/Flags.swift
@@ -358,8 +358,28 @@ public struct Flags {
             case color
         }
 
-        @Option(name: .long, help: ArgumentHelp("Progress type (format: auto|none|ansi|plain|color)", valueName: "type"))
-        public var progress: ProgressType = .auto
+        @Option(name: .long, help: ArgumentHelp("Progress type (format: auto|none|ansi|plain|color) [environment: CONTAINER_CLI_PROGRESS]", valueName: "type"))
+        public var progress: ProgressType?
+
+        static let environmentVariable = "CONTAINER_CLI_PROGRESS"
+
+        public var resolvedProgress: ProgressType {
+            resolveProgress()
+        }
+
+        func resolveProgress(
+            environment: [String: String] = ProcessInfo.processInfo.environment
+        ) -> ProgressType {
+            if let progress {
+                return progress
+            }
+            if let envValue = environment[Self.environmentVariable],
+                let envProgress = ProgressType(rawValue: envValue)
+            {
+                return envProgress
+            }
+            return .auto
+        }
     }
 
     public struct ImageFetch: ParsableArguments {

--- a/Tests/ContainerAPIClientTests/ProgressFlagsTests.swift
+++ b/Tests/ContainerAPIClientTests/ProgressFlagsTests.swift
@@ -1,0 +1,151 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import ContainerAPIClient
+
+struct ProgressFlagsTests {
+
+    // MARK: - Default behavior
+
+    @Test
+    func testDefaultWithNoFlagOrEnvVar() throws {
+        let flags = try Flags.Progress.parse([])
+        let result = flags.resolveProgress(environment: [:])
+        #expect(result == .auto)
+    }
+
+    // MARK: - Explicit flag
+
+    @Test
+    func testExplicitFlagPlain() {
+        let flags = Flags.Progress(progress: .plain)
+        let result = flags.resolveProgress(environment: [:])
+        #expect(result == .plain)
+    }
+
+    @Test
+    func testExplicitFlagNone() {
+        let flags = Flags.Progress(progress: .none)
+        let result = flags.resolveProgress(environment: [:])
+        #expect(result == .none)
+    }
+
+    @Test
+    func testExplicitFlagAnsi() {
+        let flags = Flags.Progress(progress: .ansi)
+        let result = flags.resolveProgress(environment: [:])
+        #expect(result == .ansi)
+    }
+
+    @Test
+    func testExplicitFlagColor() {
+        let flags = Flags.Progress(progress: .color)
+        let result = flags.resolveProgress(environment: [:])
+        #expect(result == .color)
+    }
+
+    @Test
+    func testExplicitFlagAuto() {
+        let flags = Flags.Progress(progress: .auto)
+        let result = flags.resolveProgress(environment: [:])
+        #expect(result == .auto)
+    }
+
+    // MARK: - Environment variable
+
+    @Test
+    func testEnvVarPlain() throws {
+        let flags = try Flags.Progress.parse([])
+        let result = flags.resolveProgress(environment: ["CONTAINER_CLI_PROGRESS": "plain"])
+        #expect(result == .plain)
+    }
+
+    @Test
+    func testEnvVarNone() throws {
+        let flags = try Flags.Progress.parse([])
+        let result = flags.resolveProgress(environment: ["CONTAINER_CLI_PROGRESS": "none"])
+        #expect(result == .none)
+    }
+
+    @Test
+    func testEnvVarAnsi() throws {
+        let flags = try Flags.Progress.parse([])
+        let result = flags.resolveProgress(environment: ["CONTAINER_CLI_PROGRESS": "ansi"])
+        #expect(result == .ansi)
+    }
+
+    @Test
+    func testEnvVarColor() throws {
+        let flags = try Flags.Progress.parse([])
+        let result = flags.resolveProgress(environment: ["CONTAINER_CLI_PROGRESS": "color"])
+        #expect(result == .color)
+    }
+
+    @Test
+    func testEnvVarAuto() throws {
+        let flags = try Flags.Progress.parse([])
+        let result = flags.resolveProgress(environment: ["CONTAINER_CLI_PROGRESS": "auto"])
+        #expect(result == .auto)
+    }
+
+    // MARK: - Flag takes precedence over environment variable
+
+    @Test
+    func testFlagOverridesEnvVar() {
+        let flags = Flags.Progress(progress: .ansi)
+        let result = flags.resolveProgress(environment: ["CONTAINER_CLI_PROGRESS": "plain"])
+        #expect(result == .ansi)
+    }
+
+    @Test
+    func testFlagNoneOverridesEnvVar() {
+        let flags = Flags.Progress(progress: .none)
+        let result = flags.resolveProgress(environment: ["CONTAINER_CLI_PROGRESS": "ansi"])
+        #expect(result == .none)
+    }
+
+    @Test
+    func testFlagColorOverridesEnvVar() {
+        let flags = Flags.Progress(progress: .color)
+        let result = flags.resolveProgress(environment: ["CONTAINER_CLI_PROGRESS": "plain"])
+        #expect(result == .color)
+    }
+
+    // MARK: - Invalid environment variable
+
+    @Test
+    func testInvalidEnvVarFallsBackToDefault() throws {
+        let flags = try Flags.Progress.parse([])
+        let result = flags.resolveProgress(environment: ["CONTAINER_CLI_PROGRESS": "bogus"])
+        #expect(result == .auto)
+    }
+
+    @Test
+    func testEmptyEnvVarFallsBackToDefault() throws {
+        let flags = try Flags.Progress.parse([])
+        let result = flags.resolveProgress(environment: ["CONTAINER_CLI_PROGRESS": ""])
+        #expect(result == .auto)
+    }
+
+    // MARK: - Environment variable name
+
+    @Test
+    func testEnvironmentVariableName() {
+        #expect(Flags.Progress.environmentVariable == "CONTAINER_CLI_PROGRESS")
+    }
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -91,7 +91,7 @@ container run [<options>] <image> [<arguments> ...]
 
 **Progress Options**
 
-*   `--progress <type>`: Progress type (format: none|ansi|plain|color) [environment: CONTAINER_CLI_PROGRESS] (default: ansi)
+*   `--progress <type>`: Progress type (format: none|ansi|plain|color) (default: ansi) [environment: CONTAINER_CLI_PROGRESS]
 
 **Examples**
 
@@ -514,7 +514,7 @@ container image pull [--debug] [--scheme <scheme>] [--progress <type>] [--arch <
 **Options**
 
 *   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https, auto) (default: auto)
-*   `--progress <type>`: Progress type (format: none|ansi|plain|color) [environment: CONTAINER_CLI_PROGRESS] (default: ansi)
+*   `--progress <type>`: Progress type (format: none|ansi|plain|color) (default: ansi) [environment: CONTAINER_CLI_PROGRESS]
 *   `-a, --arch <arch>`: Limit the pull to the specified architecture
 *   `--os <os>`: Limit the pull to the specified OS
 *   `--platform <platform>`: Limit the pull to the specified platform (format: os/arch[/variant], takes precedence over --os and --arch)
@@ -536,7 +536,7 @@ container image push [--scheme <scheme>] [--progress <type>] [--arch <arch>] [--
 **Options**
 
 *   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https, auto) (default: auto)
-*   `--progress <type>`: Progress type (format: none|ansi|plain|color) [environment: CONTAINER_CLI_PROGRESS] (default: ansi)
+*   `--progress <type>`: Progress type (format: none|ansi|plain|color) (default: ansi) [environment: CONTAINER_CLI_PROGRESS]
 *   `-a, --arch <arch>`: Limit the push to the specified architecture
 *   `--os <os>`: Limit the push to the specified OS
 *   `--platform <platform>`: Limit the push to the specified platform (format: os/arch[/variant], takes precedence over --os and --arch)

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -91,7 +91,7 @@ container run [<options>] <image> [<arguments> ...]
 
 **Progress Options**
 
-*   `--progress <type>`: Progress type (format: none|ansi|plain|color) (default: ansi)
+*   `--progress <type>`: Progress type (format: none|ansi|plain|color) [environment: CONTAINER_CLI_PROGRESS] (default: ansi)
 
 **Examples**
 
@@ -514,7 +514,7 @@ container image pull [--debug] [--scheme <scheme>] [--progress <type>] [--arch <
 **Options**
 
 *   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https, auto) (default: auto)
-*   `--progress <type>`: Progress type (format: none|ansi|plain|color) (default: ansi)
+*   `--progress <type>`: Progress type (format: none|ansi|plain|color) [environment: CONTAINER_CLI_PROGRESS] (default: ansi)
 *   `-a, --arch <arch>`: Limit the pull to the specified architecture
 *   `--os <os>`: Limit the pull to the specified OS
 *   `--platform <platform>`: Limit the pull to the specified platform (format: os/arch[/variant], takes precedence over --os and --arch)
@@ -536,7 +536,7 @@ container image push [--scheme <scheme>] [--progress <type>] [--arch <arch>] [--
 **Options**
 
 *   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https, auto) (default: auto)
-*   `--progress <type>`: Progress type (format: none|ansi|plain|color) (default: ansi)
+*   `--progress <type>`: Progress type (format: none|ansi|plain|color) [environment: CONTAINER_CLI_PROGRESS] (default: ansi)
 *   `-a, --arch <arch>`: Limit the push to the specified architecture
 *   `--os <os>`: Limit the push to the specified OS
 *   `--platform <platform>`: Limit the push to the specified platform (format: os/arch[/variant], takes precedence over --os and --arch)


### PR DESCRIPTION
## Type of Change
  - [ ] Bug fix
  - [x] New feature
  - [ ] Breaking change
  - [x] Documentation update

  ## Motivation and Context
  ### Environment Variable for Progress Mode

  Adds support for a `CONTAINER_CLI_PROGRESS` environment variable that allows users to set their preferred default progress mode (`none`, `ansi`, `plain`) without passing `--progress`
   on every command.

  This follows the same pattern as `BUILDKIT_PROGRESS` and aligns with the project's transition from macOS user defaults to environment variables for configuration.

  **Precedence:** `--progress` flag → `CONTAINER_CLI_PROGRESS` env var → default (`ansi`)

  **Affected commands:** `container image pull`, `container image push`, `container run`

  > **Note:** ~`color` mode support is commented out, pending merge of #1384. Once merged, uncommenting `case color` in the enum and updating the help text is all that's needed.~

  Closes #1406

  ## Testing
  - [x] Tested locally
  - [x] Added/updated tests
  - [x] Added/updated docs

  ## Test Instructions

  ```bash
  # Default (ansi) — no flag, no env var
  container image pull alpine

  # Env var sets mode
  CONTAINER_CLI_PROGRESS=plain container image pull alpine

  # Flag overrides env var
  CONTAINER_CLI_PROGRESS=plain container --progress ansi image pull alpine

  # Env var disables progress
  CONTAINER_CLI_PROGRESS=none container image pull alpine

  # Invalid env var falls back to default (ansi)
  CONTAINER_CLI_PROGRESS=bogus container image pull alpine