### PR TITLE
Add SMB volume driver via direct guest CIFS mount

### DIFF
--- a/Sources/ContainerCommands/Volume/VolumeCreate.swift
+++ b/Sources/ContainerCommands/Volume/VolumeCreate.swift
@@ -25,6 +25,9 @@ extension Application.VolumeCommand {
             abstract: "Create a new volume"
         )
 
+        @Option(name: .customLong("driver"), help: "Volume driver (default: local)")
+        var driver: String = "local"
+
         @Option(name: .customLong("label"), help: "Set metadata for a volume")
         var labels: [String] = []
 
@@ -53,7 +56,7 @@ extension Application.VolumeCommand {
 
             let volume = try await ClientVolume.create(
                 name: name,
-                driver: "local",
+                driver: driver,
                 driverOpts: parsedDriverOpts,
                 labels: parsedLabels
             )

--- a/Sources/ContainerResource/Container/Filesystem.swift
+++ b/Sources/ContainerResource/Container/Filesystem.swift
@@ -57,6 +57,8 @@ public struct Filesystem: Sendable, Codable {
 
         case block(format: String, cache: CacheMode, sync: SyncMode)
         case volume(name: String, format: String, cache: CacheMode, sync: SyncMode)
+        case smb(share: String, mountOptions: [String: String])
+        case nfs(share: String, mountOptions: [String: String])
         case virtiofs
         case tmpfs
     }
@@ -114,6 +116,26 @@ public struct Filesystem: Sendable, Codable {
         )
     }
 
+    /// An SMB share mounted directly inside the guest via CIFS.
+    public static func smb(share: String, mountOptions: [String: String], destination: String, options: MountOptions) -> Filesystem {
+        .init(
+            type: .smb(share: share, mountOptions: mountOptions),
+            source: share,
+            destination: destination,
+            options: options
+        )
+    }
+
+    /// An NFS share mounted directly inside the guest.
+    public static func nfs(share: String, mountOptions: [String: String], destination: String, options: MountOptions) -> Filesystem {
+        .init(
+            type: .nfs(share: share, mountOptions: mountOptions),
+            source: share,
+            destination: destination,
+            options: options
+        )
+    }
+
     /// A vritiofs backed filesystem providing a directory.
     public static func virtiofs(source: String, destination: String, options: MountOptions) -> Filesystem {
         .init(
@@ -131,6 +153,22 @@ public struct Filesystem: Sendable, Codable {
             destination: destination,
             options: options
         )
+    }
+
+    /// Returns true if the Filesystem is an SMB volume.
+    public var isSMB: Bool {
+        switch type {
+        case .smb(_, _): true
+        default: false
+        }
+    }
+
+    /// Returns true if the Filesystem is an NFS volume.
+    public var isNFS: Bool {
+        switch type {
+        case .nfs(_, _): true
+        default: false
+        }
     }
 
     /// Returns true if the Filesystem is backed by a block device.

--- a/Sources/Services/ContainerAPIService/Client/Utility.swift
+++ b/Sources/Services/ContainerAPIService/Client/Utility.swift
@@ -178,13 +178,30 @@ public struct Utility {
                 resolvedMounts.append(fs)
             case .volume(let parsed):
                 let volume = try await getOrCreateVolume(parsed: parsed, log: log)
-                let volumeMount = Filesystem.volume(
-                    name: parsed.name,
-                    format: volume.format,
-                    source: volume.source,
-                    destination: parsed.destination,
-                    options: parsed.options
-                )
+                let volumeMount: Filesystem
+                if volume.driver == "smb" {
+                    volumeMount = Filesystem.smb(
+                        share: volume.source,
+                        mountOptions: volume.options,
+                        destination: parsed.destination,
+                        options: parsed.options
+                    )
+                } else if volume.driver == "nfs" {
+                    volumeMount = Filesystem.nfs(
+                        share: volume.source,
+                        mountOptions: volume.options,
+                        destination: parsed.destination,
+                        options: parsed.options
+                    )
+                } else {
+                    volumeMount = Filesystem.volume(
+                        name: parsed.name,
+                        format: volume.format,
+                        source: volume.source,
+                        destination: parsed.destination,
+                        options: parsed.options
+                    )
+                }
                 resolvedMounts.append(volumeMount)
             }
         }

--- a/Sources/Services/ContainerAPIService/Server/Volumes/VolumesService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Volumes/VolumesService.swift
@@ -313,27 +313,59 @@ public actor VolumesService {
             throw VolumeError.volumeAlreadyExists(name)
         }
 
-        try createVolumeDirectory(for: name)
+        let volume: Volume
+        switch driver {
+        case "smb":
+            guard let share = driverOpts["share"] else {
+                throw VolumeError.storageError("smb driver requires --opt share=//server/share")
+            }
+            volume = Volume(
+                name: name,
+                driver: "smb",
+                format: "cifs",
+                source: share,
+                labels: labels,
+                options: driverOpts,
+                sizeInBytes: nil
+            )
+        case "nfs":
+            guard let share = driverOpts["share"] else {
+                throw VolumeError.storageError("nfs driver requires --opt share=server:/export/path")
+            }
+            volume = Volume(
+                name: name,
+                driver: "nfs",
+                format: "nfs",
+                source: share,
+                labels: labels,
+                options: driverOpts,
+                sizeInBytes: nil
+            )
+        case "local":
+            try createVolumeDirectory(for: name)
 
-        // Parse size from driver options (default 512GB)
-        let sizeInBytes: UInt64
-        if let sizeString = driverOpts["size"] {
-            sizeInBytes = try parseSize(sizeString)
-        } else {
-            sizeInBytes = VolumeStorage.defaultVolumeSizeBytes
+            // Parse size from driver options (default 512GB)
+            let sizeInBytes: UInt64
+            if let sizeString = driverOpts["size"] {
+                sizeInBytes = try parseSize(sizeString)
+            } else {
+                sizeInBytes = VolumeStorage.defaultVolumeSizeBytes
+            }
+
+            try createVolumeImage(for: name, sizeInBytes: sizeInBytes)
+
+            volume = Volume(
+                name: name,
+                driver: "local",
+                format: "ext4",
+                source: blockPath(for: name),
+                labels: labels,
+                options: driverOpts,
+                sizeInBytes: sizeInBytes
+            )
+        default:
+            throw VolumeError.driverNotSupported(driver)
         }
-
-        try createVolumeImage(for: name, sizeInBytes: sizeInBytes)
-
-        let volume = Volume(
-            name: name,
-            driver: driver,
-            format: "ext4",
-            source: blockPath(for: name),
-            labels: labels,
-            options: driverOpts,
-            sizeInBytes: sizeInBytes
-        )
 
         try await store.create(volume)
 

--- a/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
+++ b/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
@@ -1250,6 +1250,22 @@ extension Filesystem {
                     "\(Filesystem.SyncMode.vzRuntimeOptionKey)=\(syncMode.asVZRuntimeOption)",
                 ],
             )
+        case .smb(let share, let mountOptions):
+            let opts = mountOptions.filter { $0.key != "share" }.map { $0.value.isEmpty ? $0.key : "\($0.key)=\($0.value)" } + self.options
+            return .any(
+                type: "cifs",
+                source: share,
+                destination: self.destination,
+                options: opts
+            )
+        case .nfs(let share, let mountOptions):
+            let opts = mountOptions.filter { $0.key != "share" }.map { $0.value.isEmpty ? $0.key : "\($0.key)=\($0.value)" } + self.options
+            return .any(
+                type: "nfs",
+                source: share,
+                destination: self.destination,
+                options: opts
+            )
         }
     }
 

--- a/Tests/ContainerAPIClientTests/NFSVolumeTests.swift
+++ b/Tests/ContainerAPIClientTests/NFSVolumeTests.swift
@@ -1,0 +1,111 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerResource
+import ContainerizationError
+import Foundation
+import Testing
+
+@testable import ContainerAPIClient
+
+struct NFSVolumeTests {
+
+    // MARK: - Parser: named volume syntax still works for NFS volumes
+
+    @Test("Named volume syntax resolves as a volume, not a filesystem")
+    func testNamedVolumeIsParsedAsVolume() throws {
+        let result = try Parser.volume("myexport:/data")
+        guard case .volume(let parsed) = result else {
+            Issue.record("Expected .volume, got .filesystem")
+            return
+        }
+        #expect(parsed.name == "myexport")
+        #expect(parsed.destination == "/data")
+        #expect(!parsed.isAnonymous)
+    }
+
+    @Test("Named volume with options is parsed correctly")
+    func testNamedVolumeWithOptions() throws {
+        let result = try Parser.volume("myexport:/data:ro")
+        guard case .volume(let parsed) = result else {
+            Issue.record("Expected .volume")
+            return
+        }
+        #expect(parsed.name == "myexport")
+        #expect(parsed.destination == "/data")
+        #expect(parsed.options == ["ro"])
+    }
+
+    // MARK: - Volume model: NFS driver fields
+
+    @Test("NFS volume stores share path as source")
+    func testNFSVolumeSource() {
+        let volume = Volume(
+            name: "myexport",
+            driver: "nfs",
+            format: "nfs",
+            source: "nas.local:/exports/data",
+            labels: [:],
+            options: ["vers": "4"],
+            sizeInBytes: nil
+        )
+
+        #expect(volume.driver == "nfs")
+        #expect(volume.format == "nfs")
+        #expect(volume.source == "nas.local:/exports/data")
+        #expect(volume.sizeInBytes == nil)
+        #expect(volume.options["vers"] == "4")
+    }
+
+    @Test("NFS volume is not anonymous")
+    func testNFSVolumeIsNotAnonymous() {
+        let volume = Volume(
+            name: "myexport",
+            driver: "nfs",
+            format: "nfs",
+            source: "nas.local:/exports/data",
+            labels: [:]
+        )
+        #expect(!volume.isAnonymous)
+    }
+
+    @Test("Local volume driver defaults remain unchanged")
+    func testLocalVolumeDefaults() {
+        let volume = Volume(
+            name: "mydata",
+            source: "/var/lib/container/volumes/mydata/volume.img"
+        )
+        #expect(volume.driver == "local")
+        #expect(volume.format == "ext4")
+    }
+
+    // MARK: - Utility: parseKeyValuePairs for NFS driver opts
+
+    @Test("NFS driver opts are parsed from --opt flags")
+    func testNFSDriverOptsKeyValueParsing() {
+        let raw = ["share=nas.local:/exports/data", "vers=4"]
+        let parsed = Utility.parseKeyValuePairs(raw)
+
+        #expect(parsed["share"] == "nas.local:/exports/data")
+        #expect(parsed["vers"] == "4")
+    }
+
+    @Test("Missing share opt is detectable")
+    func testMissingNFSShareOpt() {
+        let opts = Utility.parseKeyValuePairs(["vers=4"])
+        #expect(opts["share"] == nil)
+    }
+}

--- a/Tests/ContainerAPIClientTests/SMBVolumeTests.swift
+++ b/Tests/ContainerAPIClientTests/SMBVolumeTests.swift
@@ -1,0 +1,114 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerResource
+import ContainerizationError
+import Foundation
+import Testing
+
+@testable import ContainerAPIClient
+
+struct SMBVolumeTests {
+
+    // MARK: - Parser: named volume syntax still works for SMB volumes
+
+    @Test("Named volume syntax resolves as a volume, not a filesystem")
+    func testNamedVolumeIsParsedAsVolume() throws {
+        let result = try Parser.volume("myshare:/data")
+        guard case .volume(let parsed) = result else {
+            Issue.record("Expected .volume, got .filesystem")
+            return
+        }
+        #expect(parsed.name == "myshare")
+        #expect(parsed.destination == "/data")
+        #expect(!parsed.isAnonymous)
+    }
+
+    @Test("Named volume with options is parsed correctly")
+    func testNamedVolumeWithOptions() throws {
+        let result = try Parser.volume("myshare:/data:ro")
+        guard case .volume(let parsed) = result else {
+            Issue.record("Expected .volume")
+            return
+        }
+        #expect(parsed.name == "myshare")
+        #expect(parsed.destination == "/data")
+        #expect(parsed.options == ["ro"])
+    }
+
+    // MARK: - Volume model: SMB driver fields
+
+    @Test("SMB volume stores share path as source")
+    func testSMBVolumeSource() {
+        let volume = Volume(
+            name: "myshare",
+            driver: "smb",
+            format: "cifs",
+            source: "//server/share",
+            labels: [:],
+            options: ["username": "user", "password": "secret"],
+            sizeInBytes: nil
+        )
+
+        #expect(volume.driver == "smb")
+        #expect(volume.format == "cifs")
+        #expect(volume.source == "//server/share")
+        #expect(volume.sizeInBytes == nil)
+        #expect(volume.options["username"] == "user")
+        #expect(volume.options["password"] == "secret")
+    }
+
+    @Test("SMB volume is not anonymous")
+    func testSMBVolumeIsNotAnonymous() {
+        let volume = Volume(
+            name: "myshare",
+            driver: "smb",
+            format: "cifs",
+            source: "//server/share",
+            labels: [:]
+        )
+        #expect(!volume.isAnonymous)
+    }
+
+    @Test("Local volume driver defaults remain unchanged")
+    func testLocalVolumeDefaults() {
+        let volume = Volume(
+            name: "mydata",
+            source: "/var/lib/container/volumes/mydata/volume.img"
+        )
+        #expect(volume.driver == "local")
+        #expect(volume.format == "ext4")
+    }
+
+    // MARK: - Utility: parseKeyValuePairs for SMB driver opts
+
+    @Test("SMB driver opts are parsed from --opt flags")
+    func testSMBDriverOptsKeyValueParsing() {
+        let raw = ["share=//server/share", "username=user", "password=secret", "domain=corp"]
+        let parsed = Utility.parseKeyValuePairs(raw)
+
+        #expect(parsed["share"] == "//server/share")
+        #expect(parsed["username"] == "user")
+        #expect(parsed["password"] == "secret")
+        #expect(parsed["domain"] == "corp")
+    }
+
+    @Test("Missing share opt is detectable")
+    func testMissingSMBShareOpt() {
+        let opts = Utility.parseKeyValuePairs(["username=user"])
+        #expect(opts["share"] == nil)
+    }
+}

--- a/Tests/ContainerResourceTests/FilesystemNFSTests.swift
+++ b/Tests/ContainerResourceTests/FilesystemNFSTests.swift
@@ -1,0 +1,112 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import ContainerResource
+
+struct FilesystemNFSTests {
+
+    @Test("NFS factory produces correct FSType")
+    func testNFSFactory() {
+        let fs = Filesystem.nfs(
+            share: "nas.local:/exports/data",
+            mountOptions: ["vers": "4"],
+            destination: "/data",
+            options: []
+        )
+
+        guard case .nfs(let share, let opts) = fs.type else {
+            Issue.record("Expected .nfs FSType")
+            return
+        }
+        #expect(share == "nas.local:/exports/data")
+        #expect(opts["vers"] == "4")
+        #expect(fs.source == "nas.local:/exports/data")
+        #expect(fs.destination == "/data")
+    }
+
+    @Test("isNFS returns true only for NFS filesystems")
+    func testIsNFS() {
+        let nfs = Filesystem.nfs(
+            share: "nas.local:/exports/data",
+            mountOptions: [:],
+            destination: "/data",
+            options: []
+        )
+        let virtiofs = Filesystem.virtiofs(source: "/host/path", destination: "/data", options: [])
+        let tmpfs = Filesystem.tmpfs(destination: "/tmp", options: [])
+
+        #expect(nfs.isNFS)
+        #expect(!virtiofs.isNFS)
+        #expect(!tmpfs.isNFS)
+    }
+
+    @Test("NFS filesystem is not a block device")
+    func testNFSIsNotBlock() {
+        let fs = Filesystem.nfs(
+            share: "nas.local:/exports/data",
+            mountOptions: [:],
+            destination: "/data",
+            options: []
+        )
+        #expect(!fs.isBlock)
+        #expect(!fs.isVolume)
+        #expect(!fs.isTmpfs)
+        #expect(!fs.isVirtiofs)
+        #expect(!fs.isSMB)
+    }
+
+    @Test("NFS FSType round-trips through Codable")
+    func testNFSCodable() throws {
+        let original = Filesystem.nfs(
+            share: "nas.local:/exports/data",
+            mountOptions: ["vers": "4"],
+            destination: "/mnt/data",
+            options: ["ro"]
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(Filesystem.self, from: data)
+
+        guard case .nfs(let share, let opts) = decoded.type else {
+            Issue.record("Expected .nfs after decoding")
+            return
+        }
+        #expect(share == "nas.local:/exports/data")
+        #expect(opts["vers"] == "4")
+        #expect(decoded.destination == "/mnt/data")
+        #expect(decoded.options == ["ro"])
+    }
+
+    @Test("NFS mount options are preserved with extra options")
+    func testNFSWithExtraOptions() {
+        let fs = Filesystem.nfs(
+            share: "nas.local:/exports/backup",
+            mountOptions: ["vers": "3", "timeo": "600"],
+            destination: "/backup",
+            options: ["ro", "noatime"]
+        )
+
+        guard case .nfs(_, let opts) = fs.type else {
+            Issue.record("Expected .nfs FSType")
+            return
+        }
+        #expect(opts.count == 2)
+        #expect(fs.options == ["ro", "noatime"])
+    }
+}

--- a/Tests/ContainerResourceTests/FilesystemSMBTests.swift
+++ b/Tests/ContainerResourceTests/FilesystemSMBTests.swift
@@ -1,0 +1,113 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import ContainerResource
+
+struct FilesystemSMBTests {
+
+    @Test("SMB factory produces correct FSType")
+    func testSMBFactory() {
+        let fs = Filesystem.smb(
+            share: "//server/share",
+            mountOptions: ["username": "user", "password": "secret"],
+            destination: "/data",
+            options: []
+        )
+
+        guard case .smb(let share, let opts) = fs.type else {
+            Issue.record("Expected .smb FSType")
+            return
+        }
+        #expect(share == "//server/share")
+        #expect(opts["username"] == "user")
+        #expect(opts["password"] == "secret")
+        #expect(fs.source == "//server/share")
+        #expect(fs.destination == "/data")
+    }
+
+    @Test("isSMB returns true only for SMB filesystems")
+    func testIsSMB() {
+        let smb = Filesystem.smb(
+            share: "//server/share",
+            mountOptions: [:],
+            destination: "/data",
+            options: []
+        )
+        let virtiofs = Filesystem.virtiofs(source: "/host/path", destination: "/data", options: [])
+        let tmpfs = Filesystem.tmpfs(destination: "/tmp", options: [])
+
+        #expect(smb.isSMB)
+        #expect(!virtiofs.isSMB)
+        #expect(!tmpfs.isSMB)
+    }
+
+    @Test("SMB filesystem is not a block device")
+    func testSMBIsNotBlock() {
+        let fs = Filesystem.smb(
+            share: "//server/share",
+            mountOptions: [:],
+            destination: "/data",
+            options: []
+        )
+        #expect(!fs.isBlock)
+        #expect(!fs.isVolume)
+        #expect(!fs.isTmpfs)
+        #expect(!fs.isVirtiofs)
+    }
+
+    @Test("SMB FSType round-trips through Codable")
+    func testSMBCodable() throws {
+        let original = Filesystem.smb(
+            share: "//server/share",
+            mountOptions: ["username": "user", "domain": "corp"],
+            destination: "/mnt/data",
+            options: ["ro"]
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(Filesystem.self, from: data)
+
+        guard case .smb(let share, let opts) = decoded.type else {
+            Issue.record("Expected .smb after decoding")
+            return
+        }
+        #expect(share == "//server/share")
+        #expect(opts["username"] == "user")
+        #expect(opts["domain"] == "corp")
+        #expect(decoded.destination == "/mnt/data")
+        #expect(decoded.options == ["ro"])
+    }
+
+    @Test("SMB mount options are preserved with extra options")
+    func testSMBWithExtraOptions() {
+        let fs = Filesystem.smb(
+            share: "//nas/backup",
+            mountOptions: ["username": "admin", "password": "pass", "domain": "corp"],
+            destination: "/backup",
+            options: ["ro", "noatime"]
+        )
+
+        guard case .smb(_, let opts) = fs.type else {
+            Issue.record("Expected .smb FSType")
+            return
+        }
+        #expect(opts.count == 3)
+        #expect(fs.options == ["ro", "noatime"])
+    }
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -809,7 +809,7 @@ Creates a new named volume with an optional size and driver-specific options.
 **Usage**
 
 ```bash
-container volume create [--label <label> ...] [--opt <opt> ...] [-s <s>] [--debug] <name>
+container volume create [--driver <driver>] [--label <label> ...] [--opt <opt> ...] [-s <s>] [--debug] <name>
 ```
 
 **Arguments**
@@ -818,9 +818,51 @@ container volume create [--label <label> ...] [--opt <opt> ...] [-s <s>] [--debu
 
 **Options**
 
+*   `--driver <driver>`: Volume driver to use (default: `local`)
 *   `--label <label>`: Set metadata for a volume
-*   `--opt <opt>`: Set driver specific options
-*   `-s <s>`: Size of the volume in bytes, with optional K, M, G, T, or P suffix
+*   `--opt <opt>`: Set driver specific options (format: key=value)
+*   `-s <s>`: Size of the volume in bytes, with optional K, M, G, T, or P suffix (local driver only)
+
+**Drivers**
+
+*   `local` (default): Creates a block-backed ext4 volume on the host. Supports `--opt size=<size>` and `-s`.
+*   `smb`: Mounts an SMB/CIFS network share directly inside the guest. No block image is created. Requires `--opt share=//server/share`. Supported options:
+    *   `share=//server/share` *(required)*: UNC path to the SMB share
+    *   `username=<user>`: SMB username
+    *   `password=<pass>`: SMB password
+    *   `domain=<domain>`: SMB domain or workgroup
+*   `nfs`: Mounts an NFS export directly inside the guest. No block image is created. Requires `--opt share=server:/export/path`. Supported options:
+    *   `share=server:/export/path` *(required)*: NFS server and export path
+    *   `addr=<server-ip>` *(recommended)*: Explicit server IP address — required by the kernel's NFS client when mounting without a userspace helper
+    *   `vers=<version>`: NFS protocol version (e.g. `4`, `3`; default negotiated)
+    *   `proto=tcp` *(recommended)*: Force TCP transport — required if the guest kernel was built with `CONFIG_NFS_DISABLE_UDP_SUPPORT`
+    *   `nolock`: Disable NLM file locking — use if the server does not support the lock manager
+    *   Any additional options are passed as mount options (e.g. `timeo=600`, `retrans=2`)
+
+**Examples**
+
+```bash
+# Create a local volume
+container volume create mydata
+
+# Create a local volume with a specific size
+container volume create -s 10G mydata
+
+# Create an SMB volume
+container volume create --driver smb \
+  --opt share=//fileserver/share \
+  --opt username=user \
+  --opt password=secret \
+  myshare
+
+# Create an NFS volume
+container volume create --driver nfs \
+  --opt share=nas.local:/exports/data \
+  --opt addr=nas.local \
+  --opt vers=3 \
+  --opt proto=tcp \
+  myexport
+```
 
 **Anonymous Volumes**
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -60,6 +60,80 @@ total 4
 %
 </pre>
 
+## Mount an SMB share in a container
+
+You can mount an SMB/CIFS network share directly inside a container using the `smb` volume driver. The share is mounted natively by the Linux guest via CIFS — no host-side mount is required.
+
+First, create a named volume pointing at your SMB share:
+
+```bash
+container volume create --driver smb \
+  --opt share=//fileserver/share \
+  --opt username=alice \
+  --opt password=secret \
+  myshare
+```
+
+Then use it with `-v` exactly like a local volume:
+
+```bash
+container run -v myshare:/data alpine ls /data
+```
+
+The volume persists as a named resource. Any container can reference it by name:
+
+```bash
+container run -v myshare:/mnt/share --rm alpine sh -c "cp /mnt/share/report.csv /tmp/"
+```
+
+To remove the volume when it is no longer needed:
+
+```bash
+container volume delete myshare
+```
+
+> [!NOTE]
+> The Linux guest kernel must have CIFS support to mount SMB volumes. Verify that your kernel configuration includes `CONFIG_CIFS`.
+
+## Mount an NFS export in a container
+
+You can mount an NFS export directly inside a container using the `nfs` volume driver. The share is mounted natively by the Linux guest — no host-side mount is required.
+
+First, create a named volume pointing at your NFS export:
+
+```bash
+container volume create --driver nfs \
+  --opt share=nas.local:/exports/data \
+  --opt addr=nas.local \
+  --opt vers=3 \
+  --opt proto=tcp \
+  myexport
+```
+
+> [!NOTE]
+> `addr` must match the server hostname or IP in `share`. The guest kernel's NFS client requires it explicitly when mounting without a userspace helper. Use `proto=tcp` if your kernel was built with `CONFIG_NFS_DISABLE_UDP_SUPPORT=y` (the default container kernel config).
+
+Then use it with `-v` exactly like a local volume:
+
+```bash
+container run -v myexport:/data alpine ls /data
+```
+
+The volume persists as a named resource. Any container can reference it by name:
+
+```bash
+container run -v myexport:/mnt/data --rm alpine sh -c "cp /mnt/data/report.csv /tmp/"
+```
+
+To remove the volume when it is no longer needed:
+
+```bash
+container volume delete myexport
+```
+
+> [!NOTE]
+> The Linux guest kernel must have NFS client support to mount NFS volumes. Verify that your kernel configuration includes `CONFIG_NFS_FS`.
+
 ## Build and run a multiplatform image
 
 Using the [project from the tutorial example](tutorial.md#set-up-a-simple-project), you can create an image to use both on Apple silicon Macs and on x86-64 servers.


### PR DESCRIPTION
Add NFS and SMB volume drivers via direct guest mounts

Adds `--driver nfs` and `--driver smb` to `container volume create`. Both drivers mount network shares directly inside the Linux guest rather than going through `virtiofs`, eliminating the host-side mount hop.

When a volume is created with `--driver smb` or `--driver nfs`, no block image is created. The share path and options are stored as volume metadata. At container start, `Utility.swift` resolves the volume into a `Filesystem.smb` or `Filesystem.nfs` mount, which `SandboxService.swift` translates into a `.any` guest mount with type `cifs` or `nfs` respectively.

Usage:

## SMB

```
container volume create --driver smb \
  --opt share=//192.168.1.1/Media \
  --opt username=user \
  --opt password=secret \
  --opt vers=3.0 \
  myshare
```

## NFS

```
container volume create --driver nfs \
  --opt share=nas.local:/exports/data \
  --opt addr=nas.local \
  --opt vers=3 \
  --opt proto=tcp \
  myexport
```

```
container run -v myshare:/media alpine ls /media
```

Boolean mount flags (e.g. `nolock`, `mfsymlinks`) can be passed as `--opt nolock=` with an empty value and are serialized as bare flags in the mount data string.

## Kernel requirement

This depends on a pending change to apple/containerization. The default guest kernel ships with `CONFIG_CIFS=y` disabled. A PR to that repo is needed to enable it in `kernel/config-arm64` — without it, SMB mounts fail at runtime with `errno 19 (ENODEV)`. NFS (`CONFIG_NFS_FS`) is already enabled in the current kernel config but is not compiled into the shipped kernel binary, so a rebuild is required for both drivers to work end-to-end.

The required containerization change is a single line in `kernel/config-arm64`:

```
# Before
# CONFIG_CIFS is not set
```

```
# After
CONFIG_CIFS=y
# CONFIG_CIFS_STATS2 is not set
CONFIG_CIFS_ALLOW_INSECURE_LEGACY=y
CONFIG_CIFS_UPCALL=y
CONFIG_CIFS_XATTR=y
CONFIG_CIFS_POSIX=y
# CONFIG_CIFS_DEBUG is not set
CONFIG_CIFS_DFS_UPCALL=y
# CONFIG_CIFS_SMB_DIRECT is not set
```

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

#1413 

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [x] Added/updated docs