### PR TITLE
Resolve symlinked executable path when detecting install root

### DIFF
--- a/Sources/ContainerPlugin/InstallRoot.swift
+++ b/Sources/ContainerPlugin/InstallRoot.swift
@@ -22,6 +22,7 @@ public struct InstallRoot {
     public static let environmentName = "CONTAINER_INSTALL_ROOT"
 
     public static let defaultURL = CommandLine.executablePathUrl
+        .resolvingSymlinksInPath()
         .deletingLastPathComponent()
         .appendingPathComponent("..")
         .standardized


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
This allows the container binary to be symlinked to alternative locations for packaging purposes, but still be able to resolve plugins properly. As a workaround, packagers can set `CONTAINER_INSTALL_ROOT` to the actual install location but this seems more elegant. 

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
