### PR TITLE
add -f flag to prune commands for docker compat

### DIFF
--- a/Sources/ContainerCommands/Container/ContainerPrune.swift
+++ b/Sources/ContainerCommands/Container/ContainerPrune.swift
@@ -31,7 +31,15 @@ extension Application {
         @OptionGroup
         public var logOptions: Flags.Logging
 
+        @Flag(name: .shortAndLong, help: "Accepted for Docker compatibility; has no effect.")
+        var force: Bool = false
+
         public func run() async throws {
+            if force {
+                let warning = "Warning: '-f' has no effect; prune does not prompt for confirmation.\n"
+                FileHandle.standardError.write(Data(warning.utf8))
+            }
+
             let client = ContainerClient()
             let containersToPrune = try await client.list().filter { $0.status == .stopped }
 

--- a/Sources/ContainerCommands/Image/ImagePrune.swift
+++ b/Sources/ContainerCommands/Image/ImagePrune.swift
@@ -32,7 +32,15 @@ extension Application {
         @Flag(name: .shortAndLong, help: "Remove all unused images, not just dangling ones")
         var all: Bool = false
 
+        @Flag(name: .shortAndLong, help: "Accepted for Docker compatibility; has no effect.")
+        var force: Bool = false
+
         public func run() async throws {
+            if force {
+                let warning = "Warning: '-f' has no effect; prune does not prompt for confirmation.\n"
+                FileHandle.standardError.write(Data(warning.utf8))
+            }
+
             let allImages = try await ClientImage.list()
 
             let imagesToPrune: [ClientImage]

--- a/Sources/ContainerCommands/Network/NetworkPrune.swift
+++ b/Sources/ContainerCommands/Network/NetworkPrune.swift
@@ -29,7 +29,15 @@ extension Application.NetworkCommand {
         @OptionGroup
         public var logOptions: Flags.Logging
 
+        @Flag(name: .shortAndLong, help: "Accepted for Docker compatibility; has no effect.")
+        var force: Bool = false
+
         public func run() async throws {
+            if force {
+                let warning = "Warning: '-f' has no effect; prune does not prompt for confirmation.\n"
+                FileHandle.standardError.write(Data(warning.utf8))
+            }
+
             let networkClient = NetworkClient()
             let client = ContainerClient()
             let allContainers = try await client.list()

--- a/Sources/ContainerCommands/Volume/VolumePrune.swift
+++ b/Sources/ContainerCommands/Volume/VolumePrune.swift
@@ -28,7 +28,15 @@ extension Application.VolumeCommand {
         @OptionGroup
         public var logOptions: Flags.Logging
 
+        @Flag(name: .shortAndLong, help: "Accepted for Docker compatibility; has no effect.")
+        var force: Bool = false
+
         public func run() async throws {
+            if force {
+                let warning = "Warning: '-f' has no effect; prune does not prompt for confirmation.\n"
+                FileHandle.standardError.write(Data(warning.utf8))
+            }
+
             let allVolumes = try await ClientVolume.list()
 
             // Find all volumes not used by any container

--- a/Tests/CLITests/Subcommands/Containers/TestCLIPrune.swift
+++ b/Tests/CLITests/Subcommands/Containers/TestCLIPrune.swift
@@ -32,6 +32,16 @@ class TestCLIPruneCommand: CLITest {
         #expect(output.contains("Reclaimed Zero KB in disk space"), "should show no containers message")
     }
 
+    @Test func testContainerPruneForceFlagIsNoOp() throws {
+        let (_, output, error, status) = try run(arguments: ["prune", "-f"])
+        if status != 0 {
+            throw CLIError.executionFailed("container prune -f failed: \(error)")
+        }
+
+        #expect(error.contains("has no effect"), "should print a warning about -f being a no-op")
+        #expect(output.contains("Reclaimed"), "should still perform prune normally")
+    }
+
     @Test func testContainerPruneStoppedContainers() throws {
         let testName = getTestName()
         let npcName = "\(testName)_wont_be_pruned"


### PR DESCRIPTION
## summary
- adds -f/--force to image/container/volume/network prune as a no-op
- prints a warning to stderr when used, so the flag is not silently ignored
- unblocks docker automation scripts calling `prune -f`

## test plan
- added CLI test: `container prune -f` succeeds, prints warning on stderr, normal output on stdout
- did all four prune variants since docker scripts typically call each; happy to narrow to just image prune if preferred

fixes #938