### PR TITLE
improve error message when image save platform is not available

### DIFF
--- a/Sources/ContainerCommands/Image/ImageSave.swift
+++ b/Sources/ContainerCommands/Image/ImageSave.swift
@@ -84,6 +84,27 @@ extension Application {
                 throw ContainerizationError(.invalidArgument, message: "failed to save image(s)")
             }
 
+            if let p {
+                for (reference, description) in zip(references, images) {
+                    let image = ClientImage(description: description)
+                    do {
+                        _ = try await image.manifest(for: p)
+                    } catch {
+                        var available: [String] = []
+                        if let index = try? await image.index() {
+                            available = index.manifests
+                                .compactMap { $0.platform?.description }
+                                .filter { $0 != "unknown/unknown" }
+                        }
+                        let availableStr = available.isEmpty ? "none" : available.joined(separator: ", ")
+                        throw ContainerizationError(
+                            .invalidArgument,
+                            message: "image \(reference) has no content for platform \(p.description); available platforms: \(availableStr)"
+                        )
+                    }
+                }
+            }
+
             // Write to stdout; otherwise write to the output file
             if output == nil {
                 let tempFile = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).tar")

--- a/Tests/CLITests/Subcommands/Images/TestCLIImagesCommand.swift
+++ b/Tests/CLITests/Subcommands/Images/TestCLIImagesCommand.swift
@@ -296,6 +296,53 @@ class TestCLIImagesCommand: CLITest {
         }
     }
 
+    @Test func testImageSaveMissingPlatform() throws {
+        do {
+            // 1. pull image
+            try doPull(imageName: alpine)
+
+            // 2. tag image so we can safely remove later
+            let alpineRef: Reference = try Reference.parse(alpine)
+            let alpineTagged = "\(alpineRef.name):testImageSaveMissingPlatform"
+            try doImageTag(image: alpine, newName: alpineTagged)
+            let alpineTaggedImagePresent = try isImagePresent(targetImage: alpineTagged)
+            #expect(alpineTaggedImagePresent, "expected to see image \(alpineTagged) tagged")
+
+            defer {
+                try? doRemoveImages(images: [alpineTagged])
+            }
+
+            // 3. attempt to save with a platform that isn't in the image
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer {
+                try? FileManager.default.removeItem(at: tempDir)
+            }
+            let tempFile = tempDir.appendingPathComponent(UUID().uuidString)
+            let saveArgs = [
+                "image",
+                "save",
+                alpineTagged,
+                "--platform",
+                "linux/arm/v5",
+                "--output",
+                tempFile.path(),
+            ]
+            let (_, _, error, status) = try run(arguments: saveArgs)
+
+            #expect(status != 0, "expected save to fail for missing platform")
+            #expect(
+                error.contains("has no content for platform"),
+                "expected error to describe missing platform, got: \(error)")
+            #expect(
+                error.contains("available platforms:"),
+                "expected error to list available platforms, got: \(error)")
+        } catch {
+            Issue.record("failed missing-platform save test \(error)")
+            return
+        }
+    }
+
     @Test func testMaxConcurrentDownloadsValidation() throws {
         // Test that invalid maxConcurrentDownloads value is rejected
         let (_, _, error, status) = try run(arguments: [


### PR DESCRIPTION
## summary
- image save now fails fast with a clear error when the requested platform is not available locally
- the message lists the platforms that ARE available so the user knows what they can save

before:
`Error: notFound: "Content with digest sha256:..."`

after:
`Error: image alpine:latest has no content for platform linux/amd64; available platforms: linux/arm64`

## test plan
- verified locally against a multi-arch image with platforms amd64/arm64/ppc64le/s390x/386/arm-v6/arm-v7:
  - `save --platform linux/arm/v5` (not in image) fails with the new error listing all real platforms (attestation `unknown/unknown` entries are filtered out)
  - `save --platform linux/arm64` (in image) succeeds as before
  - `save` without `--platform` still saves the full multi-arch archive (pre-check is skipped)

fixes #874