### PR TITLE
Fix ssh forwarding to use current SSH_AUTH_SOCK value

### DIFF
--- a/Sources/ContainerCommands/Builder/BuilderStart.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStart.swift
@@ -326,7 +326,12 @@ private func startBuildKit(
         )
         defer { try? io.close() }
 
-        let process = try await client.bootstrap(id: id, stdio: io.stdio)
+        var env: [String: String] = [:]
+        if let sshAuthSock = ProcessInfo.processInfo.environment["SSH_AUTH_SOCK"] {
+            env["SSH_AUTH_SOCK"] = sshAuthSock
+        }
+
+        let process = try await client.bootstrap(id: id, stdio: io.stdio, env: env)
         try await process.start()
         await taskManager?.finish()
         try io.closeAfterStart()

--- a/Sources/ContainerCommands/Container/ContainerRun.swift
+++ b/Sources/ContainerCommands/Container/ContainerRun.swift
@@ -123,7 +123,12 @@ extension Application {
                     try? io.close()
                 }
 
-                let process = try await client.bootstrap(id: id, stdio: io.stdio)
+                var env: [String: String] = [:]
+                if let sshAuthSock = ProcessInfo.processInfo.environment["SSH_AUTH_SOCK"] {
+                    env["SSH_AUTH_SOCK"] = sshAuthSock
+                }
+
+                let process = try await client.bootstrap(id: id, stdio: io.stdio, env: env)
                 progress.finish()
 
                 if !self.managementFlags.cidfile.isEmpty {

--- a/Sources/ContainerCommands/Container/ContainerStart.swift
+++ b/Sources/ContainerCommands/Container/ContainerStart.swift
@@ -87,7 +87,12 @@ extension Application {
                     try? io.close()
                 }
 
-                let process = try await client.bootstrap(id: container.id, stdio: io.stdio)
+                var env: [String: String] = [:]
+                if let sshAuthSock = ProcessInfo.processInfo.environment["SSH_AUTH_SOCK"] {
+                    env["SSH_AUTH_SOCK"] = sshAuthSock
+                }
+
+                let process = try await client.bootstrap(id: container.id, stdio: io.stdio, env: env)
                 progress.finish()
 
                 if detach {

--- a/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
+++ b/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
@@ -113,7 +113,7 @@ public struct ContainerClient: Sendable {
     }
 
     /// Bootstrap the container's init process.
-    public func bootstrap(id: String, stdio: [FileHandle?]) async throws -> ClientProcess {
+    public func bootstrap(id: String, stdio: [FileHandle?], env: [String: String]) async throws -> ClientProcess {
         let request = XPCMessage(route: .containerBootstrap)
 
         for (i, h) in stdio.enumerated() {
@@ -133,6 +133,9 @@ public struct ContainerClient: Sendable {
         }
 
         do {
+            let env = try JSONEncoder().encode(env)
+            request.set(key: .env, value: env)
+
             request.set(key: .id, value: id)
             try await xpcClient.send(request)
             return ClientProcessImpl(containerId: id, xpcClient: xpcClient)

--- a/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
+++ b/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
@@ -113,7 +113,7 @@ public struct ContainerClient: Sendable {
     }
 
     /// Bootstrap the container's init process.
-    public func bootstrap(id: String, stdio: [FileHandle?], env: [String: String]) async throws -> ClientProcess {
+    public func bootstrap(id: String, stdio: [FileHandle?], env: [String: String] = [:]) async throws -> ClientProcess {
         let request = XPCMessage(route: .containerBootstrap)
 
         for (i, h) in stdio.enumerated() {

--- a/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
+++ b/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
@@ -113,7 +113,7 @@ public struct ContainerClient: Sendable {
     }
 
     /// Bootstrap the container's init process.
-    public func bootstrap(id: String, stdio: [FileHandle?], env: [String: String] = [:]) async throws -> ClientProcess {
+    public func bootstrap(id: String, stdio: [FileHandle?], env: [String: String]? = nil) async throws -> ClientProcess {
         let request = XPCMessage(route: .containerBootstrap)
 
         for (i, h) in stdio.enumerated() {

--- a/Sources/Services/ContainerAPIService/Client/XPC+.swift
+++ b/Sources/Services/ContainerAPIService/Client/XPC+.swift
@@ -56,6 +56,8 @@ public enum XPCKeys: String {
     case plugin
     /// Archive path to export rootfs
     case archive
+    /// Environment variables passed from terminal
+    case env
 
     /// Health check request.
     case ping

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift
@@ -62,7 +62,7 @@ public struct ContainersHarness: Sendable {
                 message: "env cannot be empty"
             )
         }
-        let env = try JSONDecoder().decode([String: String].self, from: data)
+        let env = try JSONDecoder().decode([String: String]?.self, from: data)
 
         try await service.bootstrap(id: id, stdio: stdio, env: env)
         return message.reply()

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift
@@ -55,7 +55,16 @@ public struct ContainersHarness: Sendable {
             )
         }
         let stdio = message.stdio()
-        try await service.bootstrap(id: id, stdio: stdio)
+
+        guard let data = message.dataNoCopy(key: .env) else {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "env cannot be empty"
+            )
+        }
+        let env = try JSONDecoder().decode([String: String].self, from: data)
+
+        try await service.bootstrap(id: id, stdio: stdio, env: env)
         return message.reply()
     }
 

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -474,7 +474,7 @@ public actor ContainersService {
                     id: id,
                     runtime: runtime
                 )
-                try await sandboxClient.bootstrap(stdio: stdio, allocatedAttachments: allocatedAttachments, env: env ?? [:])
+                try await sandboxClient.bootstrap(stdio: stdio, allocatedAttachments: allocatedAttachments, env: env)
 
                 try await self.exitMonitor.registerProcess(
                     id: id,

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -398,13 +398,13 @@ public actor ContainersService {
     }
 
     /// Bootstrap the init process of the container.
-    public func bootstrap(id: String, stdio: [FileHandle?], env: [String: String] = [:]) async throws {
+    public func bootstrap(id: String, stdio: [FileHandle?], env: [String: String]?) async throws {
         log.debug(
             "ContainersService: enter",
             metadata: [
                 "func": "\(#function)",
                 "id": "\(id)",
-                "env": "\(env)",
+                "env": "\(env ?? [:])",
             ]
         )
         defer {
@@ -474,7 +474,7 @@ public actor ContainersService {
                     id: id,
                     runtime: runtime
                 )
-                try await sandboxClient.bootstrap(stdio: stdio, allocatedAttachments: allocatedAttachments, env: env)
+                try await sandboxClient.bootstrap(stdio: stdio, allocatedAttachments: allocatedAttachments, env: env ?? [:])
 
                 try await self.exitMonitor.registerProcess(
                     id: id,

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -398,12 +398,13 @@ public actor ContainersService {
     }
 
     /// Bootstrap the init process of the container.
-    public func bootstrap(id: String, stdio: [FileHandle?]) async throws {
+    public func bootstrap(id: String, stdio: [FileHandle?], env: [String: String]) async throws {
         log.debug(
             "ContainersService: enter",
             metadata: [
                 "func": "\(#function)",
                 "id": "\(id)",
+                "env": "\(env)",
             ]
         )
         defer {
@@ -473,7 +474,7 @@ public actor ContainersService {
                     id: id,
                     runtime: runtime
                 )
-                try await sandboxClient.bootstrap(stdio: stdio, allocatedAttachments: allocatedAttachments)
+                try await sandboxClient.bootstrap(stdio: stdio, allocatedAttachments: allocatedAttachments, env: env)
 
                 try await self.exitMonitor.registerProcess(
                     id: id,

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -398,7 +398,7 @@ public actor ContainersService {
     }
 
     /// Bootstrap the init process of the container.
-    public func bootstrap(id: String, stdio: [FileHandle?], env: [String: String]) async throws {
+    public func bootstrap(id: String, stdio: [FileHandle?], env: [String: String] = [:]) async throws {
         log.debug(
             "ContainersService: enter",
             metadata: [

--- a/Sources/Services/ContainerSandboxService/Client/SandboxClient.swift
+++ b/Sources/Services/ContainerSandboxService/Client/SandboxClient.swift
@@ -77,7 +77,7 @@ public struct SandboxClient: Sendable {
 
 // Runtime Methods
 extension SandboxClient {
-    public func bootstrap(stdio: [FileHandle?], allocatedAttachments: [AllocatedAttachment]) async throws {
+    public func bootstrap(stdio: [FileHandle?], allocatedAttachments: [AllocatedAttachment], env: [String: String]) async throws {
         let request = XPCMessage(route: SandboxRoutes.bootstrap.rawValue)
 
         for (i, h) in stdio.enumerated() {
@@ -97,6 +97,9 @@ extension SandboxClient {
         }
 
         do {
+            let env = try JSONEncoder().encode(env)
+            request.set(key: SandboxKeys.env.rawValue, value: env)
+
             try request.setAllocatedAttachments(allocatedAttachments)
             try await self.client.send(request)
         } catch {

--- a/Sources/Services/ContainerSandboxService/Client/SandboxClient.swift
+++ b/Sources/Services/ContainerSandboxService/Client/SandboxClient.swift
@@ -77,7 +77,7 @@ public struct SandboxClient: Sendable {
 
 // Runtime Methods
 extension SandboxClient {
-    public func bootstrap(stdio: [FileHandle?], allocatedAttachments: [AllocatedAttachment], env: [String: String] = [:]) async throws {
+    public func bootstrap(stdio: [FileHandle?], allocatedAttachments: [AllocatedAttachment], env: [String: String]? = nil) async throws {
         let request = XPCMessage(route: SandboxRoutes.bootstrap.rawValue)
 
         for (i, h) in stdio.enumerated() {

--- a/Sources/Services/ContainerSandboxService/Client/SandboxClient.swift
+++ b/Sources/Services/ContainerSandboxService/Client/SandboxClient.swift
@@ -77,7 +77,7 @@ public struct SandboxClient: Sendable {
 
 // Runtime Methods
 extension SandboxClient {
-    public func bootstrap(stdio: [FileHandle?], allocatedAttachments: [AllocatedAttachment], env: [String: String]) async throws {
+    public func bootstrap(stdio: [FileHandle?], allocatedAttachments: [AllocatedAttachment], env: [String: String] = [:]) async throws {
         let request = XPCMessage(route: SandboxRoutes.bootstrap.rawValue)
 
         for (i, h) in stdio.enumerated() {

--- a/Sources/Services/ContainerSandboxService/Client/SandboxKeys.swift
+++ b/Sources/Services/ContainerSandboxService/Client/SandboxKeys.swift
@@ -43,6 +43,9 @@ public enum SandboxKeys: String {
     /// Container statistics
     case statistics
 
+    /// Environment variables passed from terminal.
+    case env
+
     /// Network resource keys.
     case allocatedAttachments
     case networkAdditionalData

--- a/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
+++ b/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
@@ -76,12 +76,12 @@ public actor SandboxService {
         }
     }
 
-    private static func sshAuthSocketHostUrl(config: ContainerConfiguration, hostEnv: [String: String], log: Logger? = nil) -> URL? {
+    private static func sshAuthSocketHostUrl(config: ContainerConfiguration, hostEnv: [String: String]?, log: Logger? = nil) -> URL? {
         guard config.ssh else {
             return nil
         }
 
-        guard let sshSocket = hostEnv[Self.sshAuthSocketEnvVar] else {
+        guard let sshSocket = hostEnv?[Self.sshAuthSocketEnvVar] else {
             log?.warning("ssh forwarding requested but no \(Self.sshAuthSocketEnvVar) found")
             return nil
         }
@@ -846,7 +846,7 @@ public actor SandboxService {
     private static func configureContainer(
         czConfig: inout LinuxContainer.Configuration,
         config: ContainerConfiguration,
-        hostEnv: [String: String],
+        hostEnv: [String: String]?,
         log: Logger? = nil,
     ) throws {
         czConfig.cpus = config.resources.cpus
@@ -1165,11 +1165,11 @@ extension XPCMessage {
         return try JSONDecoder().decode(ProcessConfiguration.self, from: data)
     }
 
-    fileprivate func env() throws -> [String: String] {
+    fileprivate func env() throws -> [String: String]? {
         guard let data = self.dataNoCopy(key: SandboxKeys.env.rawValue) else {
             throw ContainerizationError(.invalidArgument, message: "empty env")
         }
-        return try JSONDecoder().decode([String: String].self, from: data)
+        return try JSONDecoder().decode([String: String]?.self, from: data)
     }
 
     fileprivate func getAllocatedAttachments() throws -> [AllocatedAttachment] {

--- a/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
+++ b/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
@@ -76,11 +76,17 @@ public actor SandboxService {
         }
     }
 
-    private static func sshAuthSocketHostUrl(config: ContainerConfiguration) -> URL? {
-        if config.ssh, let sshSocket = Foundation.ProcessInfo.processInfo.environment[Self.sshAuthSocketEnvVar] {
-            return URL(fileURLWithPath: sshSocket)
+    private static func sshAuthSocketHostUrl(config: ContainerConfiguration, hostEnv: [String: String], log: Logger? = nil) -> URL? {
+        guard config.ssh else {
+            return nil
         }
-        return nil
+
+        guard let sshSocket = hostEnv[Self.sshAuthSocketEnvVar] else {
+            log?.warning("ssh forwarding requested but no \(Self.sshAuthSocketEnvVar) found")
+            return nil
+        }
+
+        return URL(fileURLWithPath: sshSocket)
     }
 
     public init(
@@ -140,6 +146,8 @@ public actor SandboxService {
                     message: "container expected to be in created state, got: \(await self.state)"
                 )
             }
+
+            let env = try message.env()
 
             let bundle = ContainerResource.Bundle(path: self.root)
             try bundle.createLogFile()
@@ -216,7 +224,7 @@ public actor SandboxService {
             let id = config.id
             let rootfs = try bundle.containerRootfs.asMount
             let container = try LinuxContainer(id, rootfs: rootfs, vmm: vmm, logger: self.log) { czConfig in
-                try Self.configureContainer(czConfig: &czConfig, config: config)
+                try Self.configureContainer(czConfig: &czConfig, config: config, hostEnv: env, log: self.log)
                 czConfig.interfaces = interfaces
                 czConfig.process.stdout = stdout
                 czConfig.process.stderr = stderr
@@ -710,7 +718,7 @@ public actor SandboxService {
         let czConfig = try self.configureProcessConfig(
             config: processInfo.config,
             stdio: processInfo.io,
-            containerConfig: containerInfo.config
+            containerConfig: containerInfo.config,
         )
 
         let process = try await container.exec(id, configuration: czConfig)
@@ -837,7 +845,9 @@ public actor SandboxService {
 
     private static func configureContainer(
         czConfig: inout LinuxContainer.Configuration,
-        config: ContainerConfiguration
+        config: ContainerConfiguration,
+        hostEnv: [String: String],
+        log: Logger? = nil,
     ) throws {
         czConfig.cpus = config.resources.cpus
         czConfig.memoryInBytes = config.resources.memoryInBytes
@@ -870,7 +880,7 @@ public actor SandboxService {
             czConfig.sockets.append(socketConfig)
         }
 
-        if let socketUrl = Self.sshAuthSocketHostUrl(config: config) {
+        if let socketUrl = Self.sshAuthSocketHostUrl(config: config, hostEnv: hostEnv, log: log) {
             let socketPath = socketUrl.path(percentEncoded: false)
             let attrs = try? FileManager.default.attributesOfItem(atPath: socketPath)
             let permissions = (attrs?[.posixPermissions] as? NSNumber)
@@ -914,14 +924,14 @@ public actor SandboxService {
 
     private static func configureInitialProcess(
         czConfig: inout LinuxContainer.Configuration,
-        config: ContainerConfiguration
+        config: ContainerConfiguration,
     ) throws {
         let process = config.initProcess
 
         czConfig.process.arguments = [process.executable] + process.arguments
         czConfig.process.environmentVariables = process.environment
 
-        if Self.sshAuthSocketHostUrl(config: config) != nil {
+        if config.ssh {
             if !czConfig.process.environmentVariables.contains(where: { $0.starts(with: "\(Self.sshAuthSocketEnvVar)=") }) {
                 czConfig.process.environmentVariables.append("\(Self.sshAuthSocketEnvVar)=\(Self.sshAuthSocketGuestPath)")
             }
@@ -971,7 +981,7 @@ public actor SandboxService {
         proc.arguments = [config.executable] + config.arguments
         proc.environmentVariables = config.environment
 
-        if Self.sshAuthSocketHostUrl(config: containerConfig) != nil {
+        if containerConfig.ssh {
             if !proc.environmentVariables.contains(where: { $0.starts(with: "\(Self.sshAuthSocketEnvVar)=") }) {
                 proc.environmentVariables.append("\(Self.sshAuthSocketEnvVar)=\(Self.sshAuthSocketGuestPath)")
             }
@@ -1153,6 +1163,13 @@ extension XPCMessage {
             throw ContainerizationError(.invalidArgument, message: "empty process configuration")
         }
         return try JSONDecoder().decode(ProcessConfiguration.self, from: data)
+    }
+
+    fileprivate func env() throws -> [String: String] {
+        guard let data = self.dataNoCopy(key: SandboxKeys.env.rawValue) else {
+            throw ContainerizationError(.invalidArgument, message: "empty env")
+        }
+        return try JSONDecoder().decode([String: String].self, from: data)
     }
 
     fileprivate func getAllocatedAttachments() throws -> [AllocatedAttachment] {

--- a/Tests/CLITests/Subcommands/Run/TestCLIRunLifecycle.swift
+++ b/Tests/CLITests/Subcommands/Run/TestCLIRunLifecycle.swift
@@ -183,7 +183,7 @@ class TestCLIRunLifecycle: CLITest {
 
         defer { try? doStop(name: name) }
 
-        try doLongRun(name: name, args: ["--ssh"])  //, env: ["SSH_AUTH_SOCK": socketPath])
+        try doLongRun(name: name, args: ["--ssh"], env: ["SSH_AUTH_SOCK": socketPath])
         try waitForContainerRunning(name)
 
         // Verify SSH_AUTH_SOCK is set to the expected guest path inside the container.

--- a/Tests/CLITests/Subcommands/Run/TestCLIRunLifecycle.swift
+++ b/Tests/CLITests/Subcommands/Run/TestCLIRunLifecycle.swift
@@ -15,6 +15,8 @@
 //===----------------------------------------------------------------------===//
 
 import ContainerizationError
+import Foundation
+import Darwin
 import Testing
 
 class TestCLIRunLifecycle: CLITest {
@@ -137,5 +139,70 @@ class TestCLIRunLifecycle: CLITest {
                 cmd: ["foobarbaz"]
             )
         }
+    }
+
+    @Test func testSSHForwarding() throws {
+        let name = getTestName()
+
+        // Create a temp dir and socket path for the simulated SSH agent.
+        let socketDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: socketDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: socketDir) }
+
+        let socketPath = socketDir.appendingPathComponent("ssh-auth.sock").path
+
+        // Create a listening Unix domain socket to act as a fake SSH agent.
+        let serverFd = socket(AF_UNIX, SOCK_STREAM, 0)
+        precondition(serverFd >= 0, "socket() failed")
+        defer { Darwin.close(serverFd) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        withUnsafeMutableBytes(of: &addr.sun_path) { bytes in
+            socketPath.withCString { cStr in
+                bytes.copyMemory(from: UnsafeRawBufferPointer(start: cStr, count: socketPath.utf8.count + 1))
+            }
+        }
+        let bindResult = withUnsafePointer(to: addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                bind(serverFd, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        precondition(bindResult == 0, "bind() failed: \(errno)")
+        precondition(listen(serverFd, 5) == 0, "listen() failed")
+
+        // Accept and immediately close connections in background to keep the socket alive.
+        let acceptThread = Thread {
+            while true {
+                let clientFd = accept(serverFd, nil, nil)
+                if clientFd < 0 { break }
+                Darwin.close(clientFd)
+            }
+        }
+        acceptThread.start()
+
+        defer { try? doStop(name: name) }
+
+        try doLongRun(name: name, args: ["--ssh"]) //, env: ["SSH_AUTH_SOCK": socketPath])
+        try waitForContainerRunning(name)
+
+        // Verify SSH_AUTH_SOCK is set to the expected guest path inside the container.
+        let sshSockValue = try doExec(name: name, cmd: ["sh", "-c", "echo $SSH_AUTH_SOCK"])
+        #expect(
+            sshSockValue.trimmingCharacters(in: .whitespacesAndNewlines) == "/run/host-services/ssh-auth.sock",
+            "expected SSH_AUTH_SOCK to point to guest socket path"
+        )
+
+        // Verify the forwarded socket file is present and is a socket.
+        let socketCheck = try doExec(
+            name: name,
+            cmd: ["sh", "-c", "[ -S /run/host-services/ssh-auth.sock ] && echo exists || echo missing"]
+        )
+        #expect(
+            socketCheck.trimmingCharacters(in: .whitespacesAndNewlines) == "exists",
+            "expected forwarded SSH socket to exist in container"
+        )
+
+        try doStop(name: name)
     }
 }

--- a/Tests/CLITests/Subcommands/Run/TestCLIRunLifecycle.swift
+++ b/Tests/CLITests/Subcommands/Run/TestCLIRunLifecycle.swift
@@ -15,8 +15,8 @@
 //===----------------------------------------------------------------------===//
 
 import ContainerizationError
-import Foundation
 import Darwin
+import Foundation
 import Testing
 
 class TestCLIRunLifecycle: CLITest {
@@ -183,7 +183,7 @@ class TestCLIRunLifecycle: CLITest {
 
         defer { try? doStop(name: name) }
 
-        try doLongRun(name: name, args: ["--ssh"]) //, env: ["SSH_AUTH_SOCK": socketPath])
+        try doLongRun(name: name, args: ["--ssh"])  //, env: ["SSH_AUTH_SOCK": socketPath])
         try waitForContainerRunning(name)
 
         // Verify SSH_AUTH_SOCK is set to the expected guest path inside the container.

--- a/Tests/CLITests/Utilities/CLITest.swift
+++ b/Tests/CLITests/Utilities/CLITest.swift
@@ -287,7 +287,7 @@ class CLITest {
             runArgs.append(contentsOf: defaultContainerArgs)
         }
 
-        let (_, _, error, status) = try run(arguments: runArgs)
+        let (_, _, error, status) = try run(arguments: runArgs, env: env)
         if status != 0 {
             throw CLIError.executionFailed("command failed: \(error)")
         }

--- a/Tests/CLITests/Utilities/CLITest.swift
+++ b/Tests/CLITests/Utilities/CLITest.swift
@@ -135,7 +135,9 @@ class CLITest {
         }
     }
 
-    func run(arguments: [String], stdin: Data? = nil, currentDirectory: URL? = nil, env: [String: String] = [:]) throws -> (outputData: Data, output: String, error: String, status: Int32) {
+    func run(arguments: [String], stdin: Data? = nil, currentDirectory: URL? = nil, env: [String: String] = [:]) throws -> (
+        outputData: Data, output: String, error: String, status: Int32
+    ) {
         let seq = CLITest.commandSeq.withLock { counter in
             defer { counter += 1 }
             return counter

--- a/Tests/CLITests/Utilities/CLITest.swift
+++ b/Tests/CLITests/Utilities/CLITest.swift
@@ -135,7 +135,7 @@ class CLITest {
         }
     }
 
-    func run(arguments: [String], stdin: Data? = nil, currentDirectory: URL? = nil) throws -> (outputData: Data, output: String, error: String, status: Int32) {
+    func run(arguments: [String], stdin: Data? = nil, currentDirectory: URL? = nil, env: [String: String] = [:]) throws -> (outputData: Data, output: String, error: String, status: Int32) {
         let seq = CLITest.commandSeq.withLock { counter in
             defer { counter += 1 }
             return counter
@@ -153,6 +153,13 @@ class CLITest {
         process.arguments = arguments
         if let directory = currentDirectory {
             process.currentDirectoryURL = directory
+        }
+        if !env.isEmpty {
+            var processEnv = ProcessInfo.processInfo.environment
+            for (key, value) in env {
+                processEnv[key] = value
+            }
+            process.environment = processEnv
         }
 
         let inputPipe = Pipe()
@@ -246,7 +253,8 @@ class CLITest {
         image: String? = nil,
         args: [String]? = nil,
         containerArgs: [String]? = nil,
-        autoRemove: Bool = true
+        autoRemove: Bool = true,
+        env: [String: String] = [:]
     ) throws {
         var runArgs = [
             "run"


### PR DESCRIPTION
This PR fixes #357, passing `SSH_AUTH_SOCK` env variable from current terminal to the `SandboxService` so that the container can mount the correct ssh auth socket. For that, it introduces `env` parameters to `bootstrap` RPC of both `ContainersService` and `SandboxService`. This parameter is used only for passing `SSH_AUTH_SOCK` now, but can be extended to pass more runtime env variables.

This PR is a follow up PR of #1214.

## Type of Change
- [X] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Container run `--ssh` was inheriting `SSH_AUTH_SOCK` env variable from launchd, not from current terminal.

## Testing
- [X] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
