### PR TITLE
Explicitly pass default subnets into network creation

### DIFF
--- a/Sources/APIServer/APIServer+Start.swift
+++ b/Sources/APIServer/APIServer+Start.swift
@@ -19,9 +19,11 @@ import ContainerAPIClient
 import ContainerAPIService
 import ContainerLog
 import ContainerNetworkService
+import ContainerPersistence
 import ContainerPlugin
 import ContainerResource
 import ContainerXPC
+import ContainerizationExtras
 import DNSServer
 import Foundation
 import Logging
@@ -316,6 +318,8 @@ extension APIServer {
                 let config = try NetworkConfiguration(
                     id: NetworkClient.defaultNetworkName,
                     mode: .nat,
+                    ipv4Subnet: try? DefaultsStore.getOptional(key: .defaultSubnet).map { try CIDRv4($0) },
+                    ipv6Subnet: try? DefaultsStore.getOptional(key: .defaultIPv6Subnet).map { try CIDRv6($0) },
                     labels: try .init([ResourceLabelKeys.role: ResourceRoleValues.builtin]),
                     pluginInfo: NetworkPluginInfo(plugin: "container-network-vmnet")
                 )
@@ -324,9 +328,13 @@ extension APIServer {
 
             let harness = NetworksHarness(service: service, log: log)
 
-            routes[XPCRoute.networkCreate] = harness.create
-            routes[XPCRoute.networkDelete] = harness.delete
-            routes[XPCRoute.networkList] = harness.list
+            // network creation/deletion/list is not supported pre-macOS 26 (refer to AllocationOnlyVmnetNetwork)
+            if #available(macOS 26, *) {
+                routes[XPCRoute.networkCreate] = harness.create
+                routes[XPCRoute.networkDelete] = harness.delete
+                routes[XPCRoute.networkList] = harness.list
+            }
+
             return service
         }
 

--- a/Sources/Services/ContainerNetworkService/Server/AllocationOnlyVmnetNetwork.swift
+++ b/Sources/Services/ContainerNetworkService/Server/AllocationOnlyVmnetNetwork.swift
@@ -14,7 +14,6 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import ContainerPersistence
 import ContainerResource
 import ContainerXPC
 import ContainerizationError
@@ -23,6 +22,9 @@ import Foundation
 import Logging
 
 public actor AllocationOnlyVmnetNetwork: Network {
+    // The IPv4 subnet to be used if none explicitly passed in the `NetworkConfiguration`
+    private static let defaultIPv4Subnet = try! CIDRv4("192.168.64.1/24")
+
     private let log: Logger
     private var _state: NetworkState
 
@@ -36,8 +38,8 @@ public actor AllocationOnlyVmnetNetwork: Network {
             throw ContainerizationError(.unsupported, message: "invalid network mode \(configuration.mode)")
         }
 
-        guard configuration.ipv4Subnet == nil else {
-            throw ContainerizationError(.unsupported, message: "IPv4 subnet assignment is not yet implemented")
+        guard configuration.ipv6Subnet == nil else {
+            throw ContainerizationError(.unsupported, message: "IPv6 subnet assignment is not yet implemented")
         }
 
         self.log = log
@@ -65,8 +67,8 @@ public actor AllocationOnlyVmnetNetwork: Network {
             ]
         )
 
-        let defaultIPv4Subnet = try CIDRv4(DefaultsStore.get(key: .defaultSubnet))
-        let ipv4Subnet = configuration.ipv4Subnet ?? defaultIPv4Subnet
+        let ipv4Subnet = configuration.ipv4Subnet ?? Self.defaultIPv4Subnet
+
         let gateway = IPv4Address(ipv4Subnet.lower.value + 1)
         let status = NetworkStatus(
             ipv4Subnet: ipv4Subnet,

--- a/Sources/Services/ContainerNetworkService/Server/ReservedVmnetNetwork.swift
+++ b/Sources/Services/ContainerNetworkService/Server/ReservedVmnetNetwork.swift
@@ -14,7 +14,6 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import ContainerPersistence
 import ContainerResource
 import ContainerXPC
 import Containerization
@@ -117,11 +116,8 @@ public final class ReservedVmnetNetwork: Network {
 
         vmnet_network_configuration_disable_dhcp(vmnetConfiguration)
 
-        // subnet priority is CLI argument, UserDefault, auto
-        let defaultIpv4Subnet = try DefaultsStore.getOptional(key: .defaultSubnet).map { try CIDRv4($0) }
-        let ipv4Subnet = configuration.ipv4Subnet ?? defaultIpv4Subnet
-        let defaultIpv6Subnet = try DefaultsStore.getOptional(key: .defaultIPv6Subnet).map { try CIDRv6($0) }
-        let ipv6Subnet = configuration.ipv6Subnet ?? defaultIpv6Subnet
+        let ipv4Subnet = configuration.ipv4Subnet
+        let ipv6Subnet = configuration.ipv6Subnet
 
         // set the IPv4 subnet if the caller provided one
         if let ipv4Subnet {


### PR DESCRIPTION
This changes the semantics around `ReservedVmnetNetwork` and `AllocationOnlyVmnetNetwork` to only create ipv4/6 subnets for networks when the values are explicitly passed in the `NetworkConfiguration`. Previously if the values in the `NetworkConfiguration` were not present it would attempt to source them via `DefaultsStore`.


## Type of Change
- [X] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

The change solves an issue that caused `container network create <name>` to fail when `UserDefaults` was set to a value that is identical to the hard coded default ("192.168.64.1/24"/"fd00::/64"). It would fail because a network with these parameters would already exist, and thus could not be reserved.

## Testing
- [X] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
