### PR TITLE
Change guest ssh socket path

### DIFF
--- a/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
+++ b/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
@@ -51,7 +51,7 @@ public actor SandboxService {
     private var processes: [String: ProcessInfo] = [:]
     private var socketForwarders: [SocketForwarderResult] = []
 
-    private static let sshAuthSocketGuestPath = "/run/host-services/ssh-auth.sock"
+    private static let sshAuthSocketGuestPath = "/var/host-services/ssh-auth.sock"
     private static let sshAuthSocketEnvVar = "SSH_AUTH_SOCK"
 
     class ExitWaiter {

--- a/Tests/CLITests/Subcommands/Run/TestCLIRunLifecycle.swift
+++ b/Tests/CLITests/Subcommands/Run/TestCLIRunLifecycle.swift
@@ -189,14 +189,14 @@ class TestCLIRunLifecycle: CLITest {
         // Verify SSH_AUTH_SOCK is set to the expected guest path inside the container.
         let sshSockValue = try doExec(name: name, cmd: ["sh", "-c", "echo $SSH_AUTH_SOCK"])
         #expect(
-            sshSockValue.trimmingCharacters(in: .whitespacesAndNewlines) == "/run/host-services/ssh-auth.sock",
+            sshSockValue.trimmingCharacters(in: .whitespacesAndNewlines) == "/var/host-services/ssh-auth.sock",
             "expected SSH_AUTH_SOCK to point to guest socket path"
         )
 
         // Verify the forwarded socket file is present and is a socket.
         let socketCheck = try doExec(
             name: name,
-            cmd: ["sh", "-c", "[ -S /run/host-services/ssh-auth.sock ] && echo exists || echo missing"]
+            cmd: ["sh", "-c", "[ -S /var/host-services/ssh-auth.sock ] && echo exists || echo missing"]
         )
         #expect(
             socketCheck.trimmingCharacters(in: .whitespacesAndNewlines) == "exists",


### PR DESCRIPTION
Changes ssh socket path in container to `/var/host-services/ssh-auth.sock` as the path `/run` (where the ssh socket is mounted initially) is often mounted again by init systems, and the ssh socket is hidden.

## Type of Change
- [X] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Makes ssh socket forwarding reliable.

## Testing
- [X] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
