### PR TITLE
swift-configuration decoder

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -44,6 +44,12 @@ Unless required by applicable law or agreed to in writing, software distributed 
 ## Runtime Library Exception to the Apache 2.0 License: ##
 As an exception, if you use this Software to compile your source code and portions of this Software are embedded into the binary product as a result, you may redistribute such product without providing attribution as would otherwise be required by Sections 4(a), 4(b) and 4(d) of the License.
 
+**Apple Inc. and the SwiftConfiguration project authors ( swift-configuration )**
+Copyright © 2025 Apple Inc. and the SwiftConfiguration project authors
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
 **Apple Inc. and the Swift Logging API project authors ( swift-log )**
 Copyright © 2018-2019 Apple Inc. and the Swift Logging API project authors
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.

--- a/Package.resolved
+++ b/Package.resolved
@@ -110,6 +110,15 @@
       }
     },
     {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
+      }
+    },
+    {
       "identity" : "swift-crypto",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",

--- a/Package.swift
+++ b/Package.swift
@@ -50,6 +50,7 @@ let package = Package(
         .package(url: "https://github.com/apple/containerization.git", exact: Version(stringLiteral: scVersion)),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-configuration", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.80.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.36.0"),
@@ -405,6 +406,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Containerization", package: "containerization"),
+                .product(name: "Configuration", package: "swift-configuration"),
                 .product(name: "SystemPackage", package: "swift-system"),
                 .product(name: "TOML", package: "swift-toml"),
                 "CVersion",
@@ -414,6 +416,7 @@ let package = Package(
         .testTarget(
             name: "ContainerPersistenceTests",
             dependencies: [
+                .product(name: "Configuration", package: "swift-configuration"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "SystemPackage", package: "swift-system"),
                 "ContainerPersistence",

--- a/Sources/ContainerPersistence/ConfigCodingStrategy.swift
+++ b/Sources/ContainerPersistence/ConfigCodingStrategy.swift
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// A type that provides custom decoding logic for a specific `Decodable` type
+/// when using `ConfigSnapshotDecoder`. This enables modification of `Decodable` behavior
+/// for types that already conform to `Decodable`, such as `URL` and `Measurement`.
+public protocol ConfigDecodingStrategy: Sendable {
+    associatedtype Value: Decodable
+    func decode(from decoder: Decoder) throws -> Value
+}
+
+/// A type that provides custom encoding logic for a specific `Encodable` type.
+/// This enables modification of `Encodable` behavior for types that already conform
+// to `Encodable`, such as `URL` and `Measurement`.
+public protocol ConfigEncodingStrategy: Sendable {
+    associatedtype Value: Encodable
+    func encode(_ value: Value, to encoder: Encoder) throws
+}
+
+/// A type that provides both custom encoding and decoding for the same type. Similar to `Codable`
+public typealias ConfigCodingStrategy = ConfigDecodingStrategy & ConfigEncodingStrategy
+
+/// Decodes a `URL` from a string value. e.g. "https://www.apple.com"
+public struct URLConfigDecodingStrategy: ConfigDecodingStrategy {
+    public init() {}
+
+    public func decode(from decoder: Decoder) throws -> URL {
+        let container = try decoder.singleValueContainer()
+        let string = try container.decode(String.self)
+        guard let url = URL(string: string) else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Invalid URL string: \"\(string)\"."
+                )
+            )
+        }
+        return url
+    }
+}
+
+// A type erased version of `ConfigDecodingStrategy`
+struct AnyConfigDecodingStrategy: Sendable {
+    let valueTypeID: ObjectIdentifier
+    private let decode: @Sendable (Decoder) throws -> Any
+
+    init<S: ConfigDecodingStrategy>(_ strategy: S) {
+        self.valueTypeID = ObjectIdentifier(S.Value.self)
+        self.decode = { decoder in try strategy.decode(from: decoder) as Any }
+    }
+
+    func decode(from decoder: Decoder) throws -> Any {
+        try decode(decoder)
+    }
+}

--- a/Sources/ContainerPersistence/ConfigSnapshotDecoder.swift
+++ b/Sources/ContainerPersistence/ConfigSnapshotDecoder.swift
@@ -1,0 +1,110 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Configuration
+
+/// A decoder that decodes `Decodable` types from a ``ConfigSnapshotReader``.
+///
+/// `ConfigSnapshotDecoder` bridges Swift's `Decodable` protocol with the configuration
+/// provider system, allowing you to decode structured configuration into typed
+/// Swift values.
+///
+/// ```swift
+/// struct AppConfig: Decodable {
+///     var host: String
+///     var port: Int
+///     var database: DatabaseConfig
+/// }
+///
+/// struct DatabaseConfig: Decodable {
+///     var connectionString: String
+///     var maxConnections: Int
+/// }
+///
+/// let reader = ConfigReader(providers: [envProvider, jsonProvider])
+/// let snapshot = reader.snapshot()
+/// let config = try ConfigSnapshotDecoder().decode(AppConfig.self, from: snapshot)
+/// ```
+///
+/// Nested structs map to dot-separated key paths. In the example above,
+/// `database.connectionString` and `database.maxConnections` are looked up
+/// from the snapshot.
+public struct ConfigSnapshotDecoder: Sendable {
+
+    public var userInfo: [CodingUserInfoKey: any Sendable]
+    private let typeDecodingStrategies: [ObjectIdentifier: AnyConfigDecodingStrategy]
+
+    public init(decodingStrategies: [any ConfigDecodingStrategy] = [URLConfigDecodingStrategy()]) {
+        self.userInfo = [:]
+        var strategies: [ObjectIdentifier: AnyConfigDecodingStrategy] = [:]
+        for strategy in decodingStrategies {
+            let erased = AnyConfigDecodingStrategy(strategy)
+            strategies[erased.valueTypeID] = erased
+        }
+        self.typeDecodingStrategies = strategies
+    }
+
+    public func decode<T: Decodable>(
+        _ type: T.Type,
+        from snapshot: ConfigSnapshotReader
+    ) throws -> T {
+        let decoder = ConfigSnapshotDecoderImpl(
+            snapshot: snapshot,
+            codingPath: [],
+            userInfo: userInfo.mapValues { $0 as Any },
+            typeDecodingStrategies: typeDecodingStrategies
+        )
+        return try T(from: decoder)
+    }
+}
+
+struct ConfigSnapshotDecoderImpl: Decoder {
+    let snapshot: ConfigSnapshotReader
+    let codingPath: [any CodingKey]
+    let userInfo: [CodingUserInfoKey: Any]
+    let typeDecodingStrategies: [ObjectIdentifier: AnyConfigDecodingStrategy]
+
+    func container<Key: CodingKey>(
+        keyedBy type: Key.Type
+    ) throws -> KeyedDecodingContainer<Key> {
+        KeyedDecodingContainer(
+            KeyedContainer<Key>(
+                snapshot: snapshot,
+                codingPath: codingPath,
+                userInfo: userInfo,
+                typeDecodingStrategies: typeDecodingStrategies
+            )
+        )
+    }
+
+    func unkeyedContainer() throws -> any UnkeyedDecodingContainer {
+        UnkeyedContainer(
+            snapshot: snapshot,
+            codingPath: codingPath,
+            userInfo: userInfo,
+            typeDecodingStrategies: typeDecodingStrategies
+        )
+    }
+
+    func singleValueContainer() throws -> any SingleValueDecodingContainer {
+        SingleValueContainer(
+            snapshot: snapshot,
+            codingPath: codingPath,
+            userInfo: userInfo,
+            typeDecodingStrategies: typeDecodingStrategies
+        )
+    }
+}

--- a/Sources/ContainerPersistence/ConfigSnapshotDecoderContainers.swift
+++ b/Sources/ContainerPersistence/ConfigSnapshotDecoderContainers.swift
@@ -1,0 +1,551 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Configuration
+import Foundation
+
+// MARK: - Shared helpers
+
+extension ConfigSnapshotReader {
+    // ConfigSnapshotReader stores typed values — string(forKey:) returns nil for
+    // int/double/bool values. Check all primitive accessors to avoid incorrectly
+    // treating non-string values as nil (e.g. Optional<Int> with an .int value).
+    func hasValue(forKey key: ConfigKey) -> Bool {
+        string(forKey: key) != nil
+            || int(forKey: key) != nil
+            || double(forKey: key) != nil
+            || bool(forKey: key) != nil
+    }
+}
+
+struct KeyedContainer<Key: CodingKey>: KeyedDecodingContainerProtocol {
+    let snapshot: ConfigSnapshotReader
+    let codingPath: [any CodingKey]
+    let userInfo: [CodingUserInfoKey: Any]
+    let typeDecodingStrategies: [ObjectIdentifier: AnyConfigDecodingStrategy]
+
+    // ConfigSnapshotReader has no "key exists" API, so allKeys cannot enumerate
+    // available keys and contains always returns true. This works for structs with
+    // known properties. Types that iterate allKeys for dynamic keys (e.g. dictionaries)
+    // will see an empty collection.
+    var allKeys: [Key] { [] }
+
+    func contains(_ key: Key) -> Bool { true }
+
+    func decodeNil(forKey key: Key) throws -> Bool {
+        !snapshot.hasValue(forKey: configKey(appending: key))
+    }
+
+    func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool {
+        try decodeValue(forKey: key) { try snapshot.requiredBool(forKey: $0) }
+    }
+
+    func decode(_ type: String.Type, forKey key: Key) throws -> String {
+        try decodeValue(forKey: key) { try snapshot.requiredString(forKey: $0) }
+    }
+
+    func decode(_ type: Double.Type, forKey key: Key) throws -> Double {
+        try decodeValue(forKey: key) { try snapshot.requiredDouble(forKey: $0) }
+    }
+
+    func decode(_ type: Float.Type, forKey key: Key) throws -> Float {
+        Float(try decodeValue(forKey: key) { try snapshot.requiredDouble(forKey: $0) })
+    }
+
+    func decode(_ type: Int.Type, forKey key: Key) throws -> Int {
+        try decodeValue(forKey: key) { try snapshot.requiredInt(forKey: $0) }
+    }
+
+    func decode(_ type: Int8.Type, forKey key: Key) throws -> Int8 {
+        try integerValue(forKey: key)
+    }
+
+    func decode(_ type: Int16.Type, forKey key: Key) throws -> Int16 {
+        try integerValue(forKey: key)
+    }
+
+    func decode(_ type: Int32.Type, forKey key: Key) throws -> Int32 {
+        try integerValue(forKey: key)
+    }
+
+    func decode(_ type: Int64.Type, forKey key: Key) throws -> Int64 {
+        try integerValue(forKey: key)
+    }
+
+    func decode(_ type: UInt.Type, forKey key: Key) throws -> UInt {
+        try integerValue(forKey: key)
+    }
+
+    func decode(_ type: UInt8.Type, forKey key: Key) throws -> UInt8 {
+        try integerValue(forKey: key)
+    }
+
+    func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 {
+        try integerValue(forKey: key)
+    }
+
+    func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 {
+        try integerValue(forKey: key)
+    }
+
+    func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 {
+        try integerValue(forKey: key)
+    }
+
+    func decode<T: Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
+        let impl = ConfigSnapshotDecoderImpl(
+            snapshot: snapshot,
+            codingPath: codingPath + [key],
+            userInfo: userInfo,
+            typeDecodingStrategies: typeDecodingStrategies
+        )
+        if let strategy = typeDecodingStrategies[ObjectIdentifier(type)] {
+            guard let typed = try strategy.decode(from: impl) as? T else {
+                throw DecodingError.typeMismatch(
+                    T.self,
+                    DecodingError.Context(
+                        codingPath: codingPath + [key],
+                        debugDescription: "Strategy returned value of unexpected type for \(T.self)."
+                    )
+                )
+            }
+            return typed
+        }
+        return try T(from: impl)
+    }
+
+    func nestedContainer<NestedKey: CodingKey>(
+        keyedBy type: NestedKey.Type,
+        forKey key: Key
+    ) throws -> KeyedDecodingContainer<NestedKey> {
+        KeyedDecodingContainer(
+            KeyedContainer<NestedKey>(
+                snapshot: snapshot,
+                codingPath: codingPath + [key],
+                userInfo: userInfo,
+                typeDecodingStrategies: typeDecodingStrategies
+            )
+        )
+    }
+
+    func nestedUnkeyedContainer(forKey key: Key) throws -> any UnkeyedDecodingContainer {
+        UnkeyedContainer(
+            snapshot: snapshot,
+            codingPath: codingPath + [key],
+            userInfo: userInfo,
+            typeDecodingStrategies: typeDecodingStrategies
+        )
+    }
+
+    func superDecoder() throws -> any Decoder {
+        throw DecodingError.dataCorrupted(
+            DecodingError.Context(
+                codingPath: codingPath,
+                debugDescription: "ConfigSnapshotDecoder does not support superDecoder()."
+            )
+        )
+    }
+
+    func superDecoder(forKey key: Key) throws -> any Decoder {
+        throw DecodingError.dataCorrupted(
+            DecodingError.Context(
+                codingPath: codingPath + [key],
+                debugDescription: "ConfigSnapshotDecoder does not support superDecoder(forKey:)."
+            )
+        )
+    }
+
+    // MARK: - Private helpers
+
+    private func configKey(appending key: Key) -> ConfigKey {
+        ConfigKey(codingPath.map(\.stringValue) + [key.stringValue])
+    }
+
+    private func decodeValue<V>(forKey key: Key, _ body: (ConfigKey) throws -> V) throws -> V {
+        let configKey = configKey(appending: key)
+        do {
+            return try body(configKey)
+        } catch {
+            throw DecodingError.keyNotFound(
+                key,
+                DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "No value found for key \"\(configKey)\"."
+                )
+            )
+        }
+    }
+
+    private func integerValue<T: FixedWidthInteger>(forKey key: Key) throws -> T {
+        let intValue: Int = try decodeValue(forKey: key) { try snapshot.requiredInt(forKey: $0) }
+        guard let converted = T(exactly: intValue) else {
+            throw DecodingError.typeMismatch(
+                T.self,
+                DecodingError.Context(
+                    codingPath: codingPath + [key],
+                    debugDescription: "Value \(intValue) does not fit in \(T.self)."
+                )
+            )
+        }
+        return converted
+    }
+}
+
+struct SingleValueContainer: SingleValueDecodingContainer {
+    let snapshot: ConfigSnapshotReader
+    let codingPath: [any CodingKey]
+    let userInfo: [CodingUserInfoKey: Any]
+    let typeDecodingStrategies: [ObjectIdentifier: AnyConfigDecodingStrategy]
+
+    // ConfigSnapshotReader stores typed values — string(forKey:) returns nil for
+    // int/double/bool values. Check all primitive accessors to avoid incorrectly
+    // treating non-string values as nil (e.g. Optional<Int> with an .int value).
+    func decodeNil() -> Bool {
+        let key = configKey()
+        return snapshot.string(forKey: key) == nil
+            && snapshot.int(forKey: key) == nil
+            && snapshot.double(forKey: key) == nil
+            && snapshot.bool(forKey: key) == nil
+    }
+
+    func decode(_ type: Bool.Type) throws -> Bool {
+        try decodeValue { try snapshot.requiredBool(forKey: $0) }
+    }
+
+    func decode(_ type: String.Type) throws -> String {
+        try decodeValue { try snapshot.requiredString(forKey: $0) }
+    }
+
+    func decode(_ type: Double.Type) throws -> Double {
+        try decodeValue { try snapshot.requiredDouble(forKey: $0) }
+    }
+
+    func decode(_ type: Float.Type) throws -> Float {
+        Float(try decodeValue { try snapshot.requiredDouble(forKey: $0) })
+    }
+
+    func decode(_ type: Int.Type) throws -> Int {
+        try decodeValue { try snapshot.requiredInt(forKey: $0) }
+    }
+
+    func decode(_ type: Int8.Type) throws -> Int8 { try integerValue() }
+    func decode(_ type: Int16.Type) throws -> Int16 { try integerValue() }
+    func decode(_ type: Int32.Type) throws -> Int32 { try integerValue() }
+    func decode(_ type: Int64.Type) throws -> Int64 { try integerValue() }
+    func decode(_ type: UInt.Type) throws -> UInt { try integerValue() }
+    func decode(_ type: UInt8.Type) throws -> UInt8 { try integerValue() }
+    func decode(_ type: UInt16.Type) throws -> UInt16 { try integerValue() }
+    func decode(_ type: UInt32.Type) throws -> UInt32 { try integerValue() }
+    func decode(_ type: UInt64.Type) throws -> UInt64 { try integerValue() }
+
+    func decode<T: Decodable>(_ type: T.Type) throws -> T {
+        let impl = ConfigSnapshotDecoderImpl(
+            snapshot: snapshot,
+            codingPath: codingPath,
+            userInfo: userInfo,
+            typeDecodingStrategies: typeDecodingStrategies
+        )
+        if let strategy = typeDecodingStrategies[ObjectIdentifier(type)] {
+            guard let typed = try strategy.decode(from: impl) as? T else {
+                throw DecodingError.typeMismatch(
+                    T.self,
+                    DecodingError.Context(
+                        codingPath: codingPath,
+                        debugDescription: "Strategy returned value of unexpected type for \(T.self)."
+                    )
+                )
+            }
+            return typed
+        }
+        return try T(from: impl)
+    }
+
+    // MARK: - Private helpers
+
+    private func configKey() -> ConfigKey {
+        ConfigKey(codingPath.map(\.stringValue))
+    }
+
+    private func decodeValue<V>(_ body: (ConfigKey) throws -> V) throws -> V {
+        let configKey = configKey()
+        do {
+            return try body(configKey)
+        } catch {
+            throw DecodingError.valueNotFound(
+                V.self,
+                DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "No value found for key \"\(configKey)\"."
+                )
+            )
+        }
+    }
+
+    private func integerValue<T: FixedWidthInteger>() throws -> T {
+        let intValue: Int = try decodeValue { try snapshot.requiredInt(forKey: $0) }
+        guard let converted = T(exactly: intValue) else {
+            throw DecodingError.typeMismatch(
+                T.self,
+                DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "Value \(intValue) does not fit in \(T.self)."
+                )
+            )
+        }
+        return converted
+    }
+}
+
+struct UnkeyedContainer: UnkeyedDecodingContainer {
+    let snapshot: ConfigSnapshotReader
+    let codingPath: [any CodingKey]
+    let userInfo: [CodingUserInfoKey: Any]
+    let typeDecodingStrategies: [ObjectIdentifier: AnyConfigDecodingStrategy]
+
+    private enum ArrayValue {
+        case strings([String])
+        case ints([Int])
+        case doubles([Double])
+        case bools([Bool])
+        case unsupported
+    }
+
+    private var resolved: ArrayValue = .unsupported
+    private(set) var currentIndex: Int = 0
+
+    var count: Int? {
+        switch resolved {
+        case .strings(let a): a.count
+        case .ints(let a): a.count
+        case .doubles(let a): a.count
+        case .bools(let a): a.count
+        case .unsupported: nil
+        }
+    }
+
+    var isAtEnd: Bool {
+        switch resolved {
+        case .unsupported: false
+        default: currentIndex >= (count ?? 0)
+        }
+    }
+
+    init(
+        snapshot: ConfigSnapshotReader,
+        codingPath: [any CodingKey],
+        userInfo: [CodingUserInfoKey: Any],
+        typeDecodingStrategies: [ObjectIdentifier: AnyConfigDecodingStrategy]
+    ) {
+        self.snapshot = snapshot
+        self.codingPath = codingPath
+        self.userInfo = userInfo
+        self.typeDecodingStrategies = typeDecodingStrategies
+        self.resolved = .unsupported
+    }
+
+    mutating func decodeNil() throws -> Bool { false }
+
+    mutating func decode(_ type: String.Type) throws -> String {
+        let array = try resolveStrings()
+        try checkBounds(array.count)
+        defer { currentIndex += 1 }
+        return array[currentIndex]
+    }
+
+    mutating func decode(_ type: Bool.Type) throws -> Bool {
+        let array = try resolveBools()
+        try checkBounds(array.count)
+        defer { currentIndex += 1 }
+        return array[currentIndex]
+    }
+
+    mutating func decode(_ type: Int.Type) throws -> Int {
+        let array = try resolveInts()
+        try checkBounds(array.count)
+        defer { currentIndex += 1 }
+        return array[currentIndex]
+    }
+
+    mutating func decode(_ type: Double.Type) throws -> Double {
+        let array = try resolveDoubles()
+        try checkBounds(array.count)
+        defer { currentIndex += 1 }
+        return array[currentIndex]
+    }
+
+    mutating func decode(_ type: Float.Type) throws -> Float {
+        Float(try decode(Double.self))
+    }
+
+    mutating func decode(_ type: Int8.Type) throws -> Int8 { try integerElement() }
+    mutating func decode(_ type: Int16.Type) throws -> Int16 { try integerElement() }
+    mutating func decode(_ type: Int32.Type) throws -> Int32 { try integerElement() }
+    mutating func decode(_ type: Int64.Type) throws -> Int64 { try integerElement() }
+    mutating func decode(_ type: UInt.Type) throws -> UInt { try integerElement() }
+    mutating func decode(_ type: UInt8.Type) throws -> UInt8 { try integerElement() }
+    mutating func decode(_ type: UInt16.Type) throws -> UInt16 { try integerElement() }
+    mutating func decode(_ type: UInt32.Type) throws -> UInt32 { try integerElement() }
+    mutating func decode(_ type: UInt64.Type) throws -> UInt64 { try integerElement() }
+
+    mutating func decode<T: Decodable>(_ type: T.Type) throws -> T {
+        if type == String.self { return try decode(String.self) as! T }
+        if type == Int.self { return try decode(Int.self) as! T }
+        if type == Double.self { return try decode(Double.self) as! T }
+        if type == Bool.self { return try decode(Bool.self) as! T }
+        if type == Float.self { return try decode(Float.self) as! T }
+        if type == Int8.self { return try decode(Int8.self) as! T }
+        if type == Int16.self { return try decode(Int16.self) as! T }
+        if type == Int32.self { return try decode(Int32.self) as! T }
+        if type == Int64.self { return try decode(Int64.self) as! T }
+        if type == UInt.self { return try decode(UInt.self) as! T }
+        if type == UInt8.self { return try decode(UInt8.self) as! T }
+        if type == UInt16.self { return try decode(UInt16.self) as! T }
+        if type == UInt32.self { return try decode(UInt32.self) as! T }
+        if type == UInt64.self { return try decode(UInt64.self) as! T }
+        throw DecodingError.dataCorrupted(
+            DecodingError.Context(
+                codingPath: codingPath,
+                debugDescription:
+                    "ConfigSnapshotDecoder does not support decoding arrays of \(T.self). Only arrays of primitive types (String, Int, Double, Bool) are supported."
+            )
+        )
+    }
+
+    mutating func nestedContainer<NestedKey: CodingKey>(
+        keyedBy type: NestedKey.Type
+    ) throws -> KeyedDecodingContainer<NestedKey> {
+        throw DecodingError.dataCorrupted(
+            DecodingError.Context(
+                codingPath: codingPath,
+                debugDescription: "ConfigSnapshotDecoder does not support nested containers inside arrays."
+            )
+        )
+    }
+
+    mutating func nestedUnkeyedContainer() throws -> any UnkeyedDecodingContainer {
+        throw DecodingError.dataCorrupted(
+            DecodingError.Context(
+                codingPath: codingPath,
+                debugDescription: "ConfigSnapshotDecoder does not support nested arrays."
+            )
+        )
+    }
+
+    func superDecoder() throws -> any Decoder {
+        throw DecodingError.dataCorrupted(
+            DecodingError.Context(
+                codingPath: codingPath,
+                debugDescription: "ConfigSnapshotDecoder does not support superDecoder()."
+            )
+        )
+    }
+
+    // MARK: - Private helpers
+
+    private func configKey() -> ConfigKey {
+        ConfigKey(codingPath.map(\.stringValue))
+    }
+
+    private mutating func resolveStrings() throws -> [String] {
+        if case .strings(let a) = resolved { return a }
+        let configKey = configKey()
+        guard let result = snapshot.stringArray(forKey: configKey) else {
+            throw DecodingError.valueNotFound(
+                [String].self,
+                DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "No string array found for key \"\(configKey)\"."
+                )
+            )
+        }
+        resolved = .strings(result)
+        return result
+    }
+
+    private mutating func resolveInts() throws -> [Int] {
+        if case .ints(let a) = resolved { return a }
+        let configKey = configKey()
+        guard let result = snapshot.intArray(forKey: configKey) else {
+            throw DecodingError.valueNotFound(
+                [Int].self,
+                DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "No int array found for key \"\(configKey)\"."
+                )
+            )
+        }
+        resolved = .ints(result)
+        return result
+    }
+
+    private mutating func resolveDoubles() throws -> [Double] {
+        if case .doubles(let a) = resolved { return a }
+        let configKey = configKey()
+        guard let result = snapshot.doubleArray(forKey: configKey) else {
+            throw DecodingError.valueNotFound(
+                [Double].self,
+                DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "No double array found for key \"\(configKey)\"."
+                )
+            )
+        }
+        resolved = .doubles(result)
+        return result
+    }
+
+    private mutating func resolveBools() throws -> [Bool] {
+        if case .bools(let a) = resolved { return a }
+        let configKey = configKey()
+        guard let result = snapshot.boolArray(forKey: configKey) else {
+            throw DecodingError.valueNotFound(
+                [Bool].self,
+                DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "No bool array found for key \"\(configKey)\"."
+                )
+            )
+        }
+        resolved = .bools(result)
+        return result
+    }
+
+    private mutating func integerElement<T: FixedWidthInteger>() throws -> T {
+        let intValue = try decode(Int.self)
+        guard let converted = T(exactly: intValue) else {
+            throw DecodingError.typeMismatch(
+                T.self,
+                DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "Value \(intValue) does not fit in \(T.self)."
+                )
+            )
+        }
+        return converted
+    }
+
+    private func checkBounds(_ count: Int) throws {
+        guard currentIndex < count else {
+            throw DecodingError.valueNotFound(
+                Any.self,
+                DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "Unkeyed container is at end (index \(currentIndex), count \(count))."
+                )
+            )
+        }
+    }
+}

--- a/Tests/ContainerPersistenceTests/ConfigSnapshotDecoderTests.swift
+++ b/Tests/ContainerPersistenceTests/ConfigSnapshotDecoderTests.swift
@@ -1,0 +1,542 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Configuration
+import ContainerPersistence
+import Foundation
+import Testing
+
+struct ConfigSnapshotDecoderTests {
+
+    struct FlatConfig: Decodable, Equatable {
+        var host: String
+        var port: Int
+        var debug: Bool
+        var rate: Double
+    }
+
+    @Test func decodeFlatStruct() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "host": ConfigValue(.string("localhost"), isSecret: false),
+                "port": ConfigValue(.int(8080), isSecret: false),
+                "debug": ConfigValue(.bool(true), isSecret: false),
+                "rate": ConfigValue(.double(0.5), isSecret: false),
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        let config = try ConfigSnapshotDecoder().decode(FlatConfig.self, from: snapshot)
+        #expect(config.host == "localhost")
+        #expect(config.port == 8080)
+        #expect(config.debug == true)
+        #expect(config.rate == 0.5)
+    }
+
+    // MARK: - Nested structs
+
+    struct NestedConfig: Decodable, Equatable {
+        var database: DatabaseConfig
+    }
+
+    struct DatabaseConfig: Decodable, Equatable {
+        var host: String
+        var port: Int
+    }
+
+    @Test func decodeNestedStruct() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "database.host": ConfigValue(.string("db.example.com"), isSecret: false),
+                "database.port": ConfigValue(.int(5432), isSecret: false),
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        let config = try ConfigSnapshotDecoder().decode(NestedConfig.self, from: snapshot)
+        #expect(config.database.host == "db.example.com")
+        #expect(config.database.port == 5432)
+    }
+
+    // MARK: - Optional properties
+
+    struct OptionalConfig: Decodable, Equatable {
+        var name: String
+        var nickname: String?
+    }
+
+    @Test func decodeOptionalPresent() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "name": ConfigValue(.string("Alice"), isSecret: false),
+                "nickname": ConfigValue(.string("Ali"), isSecret: false),
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        let config = try ConfigSnapshotDecoder().decode(OptionalConfig.self, from: snapshot)
+        #expect(config.name == "Alice")
+        #expect(config.nickname == "Ali")
+    }
+
+    @Test func decodeOptionalMissing() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "name": ConfigValue(.string("Alice"), isSecret: false)
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        let config = try ConfigSnapshotDecoder().decode(OptionalConfig.self, from: snapshot)
+        #expect(config.name == "Alice")
+        #expect(config.nickname == nil)
+    }
+
+    // MARK: - Arrays
+
+    struct ArrayConfig: Decodable, Equatable {
+        var tags: [String]
+        var counts: [Int]
+    }
+
+    @Test func decodeArrays() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "tags": ConfigValue(.stringArray(["swift", "config"]), isSecret: false),
+                "counts": ConfigValue(.intArray([1, 2, 3]), isSecret: false),
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        let config = try ConfigSnapshotDecoder().decode(ArrayConfig.self, from: snapshot)
+        #expect(config.tags == ["swift", "config"])
+        #expect(config.counts == [1, 2, 3])
+    }
+
+    struct MoreArraysConfig: Decodable, Equatable {
+        var rates: [Double]
+        var flags: [Bool]
+    }
+
+    @Test func decodeDoubleAndBoolArrays() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "rates": ConfigValue(.doubleArray([1.5, 2.5, 3.5]), isSecret: false),
+                "flags": ConfigValue(.boolArray([true, false, true]), isSecret: false),
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        let config = try ConfigSnapshotDecoder().decode(MoreArraysConfig.self, from: snapshot)
+        #expect(config.rates == [1.5, 2.5, 3.5])
+        #expect(config.flags == [true, false, true])
+    }
+
+    // MARK: - Error cases
+
+    struct RequiredConfig: Decodable {
+        var name: String
+        var age: Int
+    }
+
+    @Test func decodeMissingRequiredKeyThrows() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "name": ConfigValue(.string("Alice"), isSecret: false)
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        #expect(throws: DecodingError.self) {
+            try ConfigSnapshotDecoder().decode(RequiredConfig.self, from: snapshot)
+        }
+    }
+
+    struct IntConfig: Decodable {
+        var count: Int
+    }
+
+    @Test func decodeTypeMismatchThrows() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "count": ConfigValue(.string("not-a-number"), isSecret: false)
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        #expect(throws: DecodingError.self) {
+            try ConfigSnapshotDecoder().decode(IntConfig.self, from: snapshot)
+        }
+    }
+
+    struct ArrayOfStructsConfig: Decodable {
+        var items: [DatabaseConfig]
+    }
+
+    @Test func decodeArrayOfStructsThrows() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [:]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        #expect(throws: DecodingError.self) {
+            try ConfigSnapshotDecoder().decode(ArrayOfStructsConfig.self, from: snapshot)
+        }
+    }
+
+    // MARK: - Scoped snapshot
+
+    @Test func decodeScopedSnapshot() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "app.host": ConfigValue(.string("localhost"), isSecret: false),
+                "app.port": ConfigValue(.int(3000), isSecret: false),
+                "app.debug": ConfigValue(.bool(false), isSecret: false),
+                "app.rate": ConfigValue(.double(1.0), isSecret: false),
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot().scoped(to: "app")
+        let config = try ConfigSnapshotDecoder().decode(FlatConfig.self, from: snapshot)
+        #expect(config.host == "localhost")
+        #expect(config.port == 3000)
+    }
+
+    // MARK: - Custom CodingKeys
+
+    struct CustomKeysConfig: Decodable, Equatable {
+        var serverHost: String
+        var serverPort: Int
+
+        enum CodingKeys: String, CodingKey {
+            case serverHost = "server-host"
+            case serverPort = "server-port"
+        }
+    }
+
+    @Test func decodeCustomCodingKeys() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "server-host": ConfigValue(.string("example.com"), isSecret: false),
+                "server-port": ConfigValue(.int(443), isSecret: false),
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        let config = try ConfigSnapshotDecoder().decode(CustomKeysConfig.self, from: snapshot)
+        #expect(config.serverHost == "example.com")
+        #expect(config.serverPort == 443)
+    }
+
+    // MARK: - Enum with raw value
+
+    enum Environment: String, Decodable {
+        case development
+        case staging
+        case production
+    }
+
+    struct EnumConfig: Decodable, Equatable {
+        var env: Environment
+    }
+
+    @Test func decodeEnum() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "env": ConfigValue(.string("production"), isSecret: false)
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        let config = try ConfigSnapshotDecoder().decode(EnumConfig.self, from: snapshot)
+        #expect(config.env == .production)
+    }
+
+    // MARK: - URL string fallback
+
+    struct URLConfig: Decodable {
+        var endpoint: URL
+    }
+
+    @Test func decodeURL() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "endpoint": ConfigValue(.string("https://example.com/api"), isSecret: false)
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        let config = try ConfigSnapshotDecoder().decode(URLConfig.self, from: snapshot)
+        #expect(config.endpoint == URL(string: "https://example.com/api")!)
+    }
+
+    // MARK: - Custom decoding strategies
+
+    struct PrefixURLStrategy: ConfigDecodingStrategy {
+        let base: String
+
+        func decode(from decoder: Decoder) throws -> URL {
+            let container = try decoder.singleValueContainer()
+            let path = try container.decode(String.self)
+            guard let url = URL(string: base + path) else {
+                throw DecodingError.dataCorrupted(
+                    DecodingError.Context(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "Invalid URL."
+                    )
+                )
+            }
+            return url
+        }
+    }
+
+    @Test func customStrategyOverridesURL() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "endpoint": ConfigValue(.string("/api/v1"), isSecret: false)
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        let decoder = ConfigSnapshotDecoder(
+            decodingStrategies: [PrefixURLStrategy(base: "https://example.com")]
+        )
+        let config = try decoder.decode(URLConfig.self, from: snapshot)
+        #expect(config.endpoint == URL(string: "https://example.com/api/v1")!)
+    }
+
+    // MARK: - Narrow integer types
+
+    struct NarrowIntConfig: Decodable, Equatable {
+        var small: Int16
+        var unsigned: UInt8
+    }
+
+    @Test func decodeNarrowIntegers() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "small": ConfigValue(.int(42), isSecret: false),
+                "unsigned": ConfigValue(.int(200), isSecret: false),
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        let config = try ConfigSnapshotDecoder().decode(NarrowIntConfig.self, from: snapshot)
+        #expect(config.small == 42)
+        #expect(config.unsigned == 200)
+    }
+
+    @Test func decodeIntegerOverflowThrows() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "small": ConfigValue(.int(42), isSecret: false),
+                "unsigned": ConfigValue(.int(300), isSecret: false),
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        #expect(throws: DecodingError.self) {
+            try ConfigSnapshotDecoder().decode(NarrowIntConfig.self, from: snapshot)
+        }
+    }
+
+    @Test func removeStrategyRevertsToDecodable() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "endpoint": ConfigValue(.string("https://example.com/api"), isSecret: false)
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        let decoder = ConfigSnapshotDecoder(decodingStrategies: [])
+        // Without the URL strategy, URL.init(from:) is used. URL's default
+        // Decodable expects a keyed container with "relative" and optional
+        // "base" keys, so decoding a plain string should fail.
+        #expect(throws: DecodingError.self) {
+            try decoder.decode(URLConfig.self, from: snapshot)
+        }
+    }
+
+    struct Seconds: Decodable {
+        var value: Int
+    }
+
+    struct SecondsStrategy: ConfigDecodingStrategy {
+        func decode(from decoder: Decoder) throws -> Seconds {
+            let container = try decoder.singleValueContainer()
+            let raw = try container.decode(Int.self)
+            return Seconds(value: raw)
+        }
+    }
+
+    struct TimerConfig: Decodable {
+        var timeout: Seconds
+    }
+
+    @Test func customStrategyForUserType() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "timeout": ConfigValue(.int(30), isSecret: false)
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        let decoder = ConfigSnapshotDecoder(decodingStrategies: [
+            URLConfigDecodingStrategy(),
+            SecondsStrategy(),
+        ])
+        let config = try decoder.decode(TimerConfig.self, from: snapshot)
+        #expect(config.timeout.value == 30)
+    }
+
+    struct NestedURLConfig: Decodable {
+        var service: ServiceConfig
+    }
+
+    struct ServiceConfig: Decodable {
+        var endpoint: URL
+        var name: String
+    }
+
+    @Test func strategyWorksInNestedStruct() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "service.endpoint": ConfigValue(.string("https://nested.example.com"), isSecret: false),
+                "service.name": ConfigValue(.string("api"), isSecret: false),
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        let config = try ConfigSnapshotDecoder().decode(NestedURLConfig.self, from: snapshot)
+        #expect(config.service.endpoint == URL(string: "https://nested.example.com")!)
+        #expect(config.service.name == "api")
+    }
+
+    // MARK: - Float decoding
+
+    struct FloatConfig: Decodable, Equatable {
+        var temperature: Float
+        var ratio: Float
+    }
+
+    @Test func decodeFloat() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "temperature": ConfigValue(.double(98.6), isSecret: false),
+                "ratio": ConfigValue(.double(0.333), isSecret: false),
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        let config = try ConfigSnapshotDecoder().decode(FloatConfig.self, from: snapshot)
+        #expect(config.temperature == Float(98.6))
+        #expect(config.ratio == Float(0.333))
+    }
+
+    // MARK: - Deeply nested structs (3+ levels)
+
+    struct AppConfig: Decodable, Equatable {
+        var cluster: ClusterConfig
+    }
+
+    struct ClusterConfig: Decodable, Equatable {
+        var primary: NodeConfig
+    }
+
+    struct NodeConfig: Decodable, Equatable {
+        var host: String
+        var port: Int
+    }
+
+    @Test func decodeDeeplyNestedStruct() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "cluster.primary.host": ConfigValue(.string("node1.example.com"), isSecret: false),
+                "cluster.primary.port": ConfigValue(.int(9090), isSecret: false),
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        let config = try ConfigSnapshotDecoder().decode(AppConfig.self, from: snapshot)
+        #expect(config.cluster.primary.host == "node1.example.com")
+        #expect(config.cluster.primary.port == 9090)
+    }
+
+    // MARK: - Optional non-string types
+
+    struct OptionalIntConfig: Decodable, Equatable {
+        var name: String
+        var retries: Int?
+        var verbose: Bool?
+        var rate: Double?
+    }
+
+    @Test func decodeOptionalNonStringPresent() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "name": ConfigValue(.string("test"), isSecret: false),
+                "retries": ConfigValue(.int(3), isSecret: false),
+                "verbose": ConfigValue(.bool(true), isSecret: false),
+                "rate": ConfigValue(.double(0.75), isSecret: false),
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        let config = try ConfigSnapshotDecoder().decode(OptionalIntConfig.self, from: snapshot)
+        #expect(config.name == "test")
+        #expect(config.retries == 3)
+        #expect(config.verbose == true)
+        #expect(config.rate == 0.75)
+    }
+
+    @Test func decodeOptionalNonStringMissing() throws {
+        let provider = InMemoryProvider(
+            name: "test",
+            values: [
+                "name": ConfigValue(.string("test"), isSecret: false)
+            ]
+        )
+        let reader = ConfigReader(provider: provider)
+        let snapshot = reader.snapshot()
+        let config = try ConfigSnapshotDecoder().decode(OptionalIntConfig.self, from: snapshot)
+        #expect(config.name == "test")
+        #expect(config.retries == nil)
+        #expect(config.verbose == nil)
+        #expect(config.rate == nil)
+    }
+}


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [X] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
This adds a swift Decoder that decodes from a swift-configuration
ConfigSnapshot, and adds the ability to modify how select types are decoded within the
ConfigSnapshotDecoder. This is something that JSONEncoder already does
with URLs specifically, however this enables users to configure this
behavior for any arbitrary type regardless of existing Codable
conformance.

The decoder will help us expand on top of (pr: https://github.com/apple/container/pull/1425), which switches user configuration to TOML. With this PR we will be able to provide a multi layered TOML if desired, allowing container to ship a default TOML instead of encoding them in code constants.

## Testing
- [X] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
