### PR TITLE
Fix "not installing shadowed plugin" startup log noise.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -319,9 +319,6 @@ let package = Package(
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Logging", package: "swift-log"),
-                .product(name: "GRPCCore", package: "grpc-swift-2"),
-                .product(name: "GRPCNIOTransportHTTP2", package: "grpc-swift-nio-transport"),
-                .product(name: "GRPCProtobuf", package: "grpc-swift-protobuf"),
                 .product(name: "Containerization", package: "containerization"),
                 "ContainerLog",
                 "ContainerPlugin",

--- a/Sources/APIServer/APIServer+Start.swift
+++ b/Sources/APIServer/APIServer+Start.swift
@@ -184,9 +184,6 @@ extension APIServer {
             _ = FileManager.default.fileExists(atPath: pluginsURL.path, isDirectory: &directoryExists)
             let userPluginsURL = directoryExists.boolValue ? pluginsURL : nil
 
-            // plugins built into the application installed as a macOS app bundle
-            let appBundlePluginsURL = Bundle.main.resourceURL?.appending(path: "plugins")
-
             // plugins built into the application installed as a Unix-like application
             let installRootPluginsURL =
                 installRoot
@@ -197,7 +194,6 @@ extension APIServer {
 
             let pluginDirectories = [
                 userPluginsURL,
-                appBundlePluginsURL,
                 installRootPluginsURL,
             ].compactMap { $0 }
 

--- a/Sources/ContainerCommands/System/SystemStart.swift
+++ b/Sources/ContainerCommands/System/SystemStart.swift
@@ -72,7 +72,9 @@ extension Application {
         public init() {}
 
         public func run() async throws {
-            // Without the true path to the binary in the plist, `container-apiserver` won't launch properly.
+            // Resolve the symlink to get the true binary path before writing the launchd plist.
+            // Gatekeeper / amfid validates code signatures relative to the enclosing .app bundle
+            // hierarchy; launching via a symlink outside the bundle fails that check.
             // TODO: Can we use the plugin loader to bootstrap the API server?
             let executableUrl = CommandLine.executablePathUrl
                 .deletingLastPathComponent()


### PR DESCRIPTION
- Closes #1450.
- If we require that bundle-packaged installs must populate a Unix-structured `bin` and `libexec`, we don't need the code that searches the app bundle install root. As it stands, we enumerate both the app bundle and the Linux paths, meaning we're looking at the same plugins (in different paths) twice.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Confusing messages in logs.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
