### PR TITLE
fix(help): indefinite hang on container --help / help / no-args

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -425,6 +425,12 @@ let package = Package(
                 "CAuditToken",
             ]
         ),
+        .testTarget(
+            name: "ContainerXPCTests",
+            dependencies: [
+                "ContainerXPC"
+            ]
+        ),
         .target(
             name: "ContainerOS",
             dependencies: [

--- a/Sources/APIServer/APIServer+Start.swift
+++ b/Sources/APIServer/APIServer+Start.swift
@@ -324,12 +324,12 @@ extension APIServer {
 
             let harness = NetworksHarness(service: service, log: log)
 
-            // network creation/deletion/list is not supported pre-macOS 26 (refer to AllocationOnlyVmnetNetwork)
+            // network creation is not supported pre-macOS 26 (refer to AllocationOnlyVmnetNetwork)
             if #available(macOS 26, *) {
                 routes[XPCRoute.networkCreate] = harness.create
-                routes[XPCRoute.networkDelete] = harness.delete
-                routes[XPCRoute.networkList] = harness.list
             }
+            routes[XPCRoute.networkList] = harness.list
+            routes[XPCRoute.networkDelete] = harness.delete
 
             return service
         }

--- a/Sources/ContainerCommands/Application.swift
+++ b/Sources/ContainerCommands/Application.swift
@@ -118,10 +118,13 @@ public struct Application: AsyncLoggableCommand {
         } catch {
             // --help/-h on the root command (e.g. `container --help`) is intercepted
             // by ArgumentParser and lands here.
+            //
+            // Help rendering must not depend on the API server being reachable, otherwise
+            // a wedged or unregistered `com.apple.container.apiserver` causes an
+            // indefinite hang. See docs/internal/help-freeze-analysis.md.
             let containsHelp = fullArgs.contains("-h") || fullArgs.contains("--help")
             if fullArgs.count <= 2 && containsHelp {
-                let pluginLoader = try? await createPluginLoader()
-                await Self.printModifiedHelpText(pluginLoader: pluginLoader)
+                await Self.printModifiedHelpText(pluginLoader: nil, unavailableMessage: nil)
                 return
             }
             let errorAsString: String = String(describing: error)
@@ -234,11 +237,21 @@ public struct Application: AsyncLoggableCommand {
 extension Application {
     // Because we support plugins, we need to modify the help text to display
     // any if we found some.
-    static func printModifiedHelpText(pluginLoader: PluginLoader?) async {
+    //
+    // Pass `unavailableMessage: nil` from contexts that already deliberately skipped
+    // plugin loading (e.g. the `--help` / `help` / no-args paths that must not depend
+    // on the API server). The default preserves prior behavior for paths that *did*
+    // attempt to load plugins but couldn't reach the server.
+    static func printModifiedHelpText(
+        pluginLoader: PluginLoader?,
+        unavailableMessage: String? = "PLUGINS: not available, run `container system start`"
+    ) async {
         let original = Application.helpMessage(for: Application.self)
         guard let pluginLoader else {
             print(original)
-            print("PLUGINS: not available, run `container system start`")
+            if let unavailableMessage {
+                print(unavailableMessage)
+            }
             return
         }
         let altered = pluginLoader.alterCLIHelpText(original: original)

--- a/Sources/ContainerCommands/DefaultCommand.swift
+++ b/Sources/ContainerCommands/DefaultCommand.swift
@@ -33,12 +33,16 @@ struct DefaultCommand: AsyncLoggableCommand {
     var remaining: [String] = []
 
     func run() async throws {
-        // See if we have a possible plugin command.
-        let pluginLoader = try? await Application.createPluginLoader()
+        // No-args invocation prints help and must not depend on the API server.
+        // See docs/internal/help-freeze-analysis.md.
         guard let command = remaining.first else {
-            await Application.printModifiedHelpText(pluginLoader: pluginLoader)
+            await Application.printModifiedHelpText(pluginLoader: nil, unavailableMessage: nil)
             return
         }
+
+        // We have a candidate plugin command; load plugins (which contacts the
+        // API server) only on this path.
+        let pluginLoader = try? await Application.createPluginLoader()
 
         // Check for edge cases and unknown options to match the behavior in the absence of plugins.
         if command.isEmpty {

--- a/Sources/ContainerCommands/HelpCommand.swift
+++ b/Sources/ContainerCommands/HelpCommand.swift
@@ -27,7 +27,8 @@ struct HelpCommand: AsyncLoggableCommand {
     public var logOptions: Flags.Logging
 
     func run() async throws {
-        let pluginLoader = try? await Application.createPluginLoader()
-        await Application.printModifiedHelpText(pluginLoader: pluginLoader)
+        // The `help` subcommand must not depend on the API server being reachable.
+        // See docs/internal/help-freeze-analysis.md.
+        await Application.printModifiedHelpText(pluginLoader: nil, unavailableMessage: nil)
     }
 }

--- a/Sources/ContainerXPC/XPCClient.swift
+++ b/Sources/ContainerXPC/XPCClient.swift
@@ -69,23 +69,66 @@ extension XPCClient {
         xpc_connection_get_pid(self.connection)
     }
 
-    /// Send the provided message to the service.
+    /// Send the provided message to the service and wait for the reply.
+    ///
+    /// Use this overload for **mutating or unknown-safety** requests. It has no
+    /// response timeout: once the message has been dispatched, this function
+    /// blocks until the XPC service replies or the underlying connection is
+    /// invalidated.
+    ///
+    /// Cancellation is honored only **before dispatch**
+    /// (`Task.checkCancellation()`). After the message is sent, `Task`
+    /// cancellation does not resume the caller, because doing so would let the
+    /// server commit a mutation after the caller had already given up — the
+    /// classic late-reply race that creates duplicate or out-of-order state.
+    ///
+    /// For read-only or idempotent requests where dropping a late reply is
+    /// acceptable, use ``send(_:timeoutForIdempotentRequest:)`` instead.
+    ///
+    /// See `docs/internal/codex-reviews.md` and
+    /// `docs/internal/help-freeze-analysis.md` for the full design rationale.
+    @discardableResult
+    public func send(_ message: XPCMessage) async throws -> XPCMessage {
+        try Task.checkCancellation()
+        return try await withCheckedThrowingContinuation { (cont: CheckedContinuation<XPCMessage, Error>) in
+            xpc_connection_send_message_with_reply(self.connection, message.underlying, nil) { reply in
+                do {
+                    cont.resume(returning: try self.parseReply(reply))
+                } catch {
+                    cont.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    /// Send the provided message to the service with an idempotency-safe
+    /// timeout.
     ///
     /// The response is delivered by whichever of the following completes first:
     ///   1. The XPC reply callback fires.
     ///   2. `responseTimeout` elapses.
     ///   3. The current `Task` is cancelled.
     ///
-    /// Late completions from the other paths are dropped silently so the connection
-    /// remains valid for subsequent sends — important for callers that hold a long-lived
-    /// `XPCClient` (`ContainerClient`, `NetworkClient`). A previous implementation used
-    /// a `withThrowingTaskGroup`, but structured-concurrency cleanup awaited the XPC
-    /// child task, which could not actually be cancelled because
-    /// `xpc_connection_send_message_with_reply` only resumes when its callback fires.
-    /// That made `responseTimeout` ineffective whenever the remote service was wedged.
-    /// See docs/internal/help-freeze-analysis.md.
+    /// **Use this overload only for read-only or idempotent requests.** When
+    /// timeout or cancellation wins the race, the underlying XPC reply callback
+    /// may still fire later and the server may still complete the operation.
+    /// Late completions are dropped silently so the connection remains valid
+    /// for subsequent sends — important for callers that hold a long-lived
+    /// `XPCClient` (`ContainerClient`, `NetworkClient`). For mutating requests
+    /// this would create duplicate or out-of-order server-side state; use
+    /// ``send(_:)`` instead.
+    ///
+    /// A previous implementation used a `withThrowingTaskGroup`, but
+    /// structured-concurrency cleanup awaited the XPC child task, which could
+    /// not actually be cancelled because
+    /// `xpc_connection_send_message_with_reply` only resumes when its callback
+    /// fires. That made the timeout ineffective whenever the remote service was
+    /// wedged. See docs/internal/help-freeze-analysis.md.
     @discardableResult
-    public func send(_ message: XPCMessage, responseTimeout: Duration? = nil) async throws -> XPCMessage {
+    public func send(
+        _ message: XPCMessage,
+        timeoutForIdempotentRequest responseTimeout: Duration
+    ) async throws -> XPCMessage {
         let state = ResumptionState<XPCMessage>()
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { (cont: CheckedContinuation<XPCMessage, Error>) in
@@ -100,18 +143,16 @@ extension XPCClient {
                     }
                 }
 
-                if let responseTimeout {
-                    let service = self.service
-                    let route = message.string(key: XPCMessage.routeKey) ?? "nil"
-                    Task { [state] in
-                        try? await Task.sleep(for: responseTimeout)
-                        state.tryResume(
-                            throwing: ContainerizationError(
-                                .timeout,
-                                message: "XPC timeout for request to \(service)/\(route)"
-                            )
+                let service = self.service
+                let route = message.string(key: XPCMessage.routeKey) ?? "nil"
+                Task { [state] in
+                    try? await Task.sleep(for: responseTimeout)
+                    state.tryResume(
+                        throwing: ContainerizationError(
+                            .timeout,
+                            message: "XPC timeout for request to \(service)/\(route)"
                         )
-                    }
+                    )
                 }
 
                 // Close the race window: if cancellation arrived before `set(cont)`
@@ -124,6 +165,23 @@ extension XPCClient {
         } onCancel: {
             state.tryResume(throwing: CancellationError())
         }
+    }
+
+    /// Compile-time guard against the previous footgun spelling.
+    ///
+    /// The previous API allowed any caller to pass `responseTimeout:` regardless
+    /// of whether the request mutated server-side state. When the timeout fired
+    /// against a mutating request, the server could still commit the operation
+    /// while the caller had already given up — the late-reply race documented in
+    /// `docs/internal/codex-reviews.md`.
+    ///
+    /// This unavailable shim keeps the old call shape compiling-as-error so
+    /// callers are forced to choose either ``send(_:)`` for mutating requests
+    /// or ``send(_:timeoutForIdempotentRequest:)`` for idempotent ones.
+    @available(*, unavailable, message: "responseTimeout may drop late replies. Use send(_:) for mutating requests, or send(_:timeoutForIdempotentRequest:) only for idempotent/read-only requests.")
+    @discardableResult
+    public func send(_ message: XPCMessage, responseTimeout: Duration?) async throws -> XPCMessage {
+        fatalError("unavailable")
     }
 
     private func parseReply(_ reply: xpc_object_t) throws -> XPCMessage {

--- a/Sources/ContainerXPC/XPCClient.swift
+++ b/Sources/ContainerXPC/XPCClient.swift
@@ -70,44 +70,59 @@ extension XPCClient {
     }
 
     /// Send the provided message to the service.
+    ///
+    /// The response is delivered by whichever of the following completes first:
+    ///   1. The XPC reply callback fires.
+    ///   2. `responseTimeout` elapses.
+    ///   3. The current `Task` is cancelled.
+    ///
+    /// Late completions from the other paths are dropped silently so the connection
+    /// remains valid for subsequent sends — important for callers that hold a long-lived
+    /// `XPCClient` (`ContainerClient`, `NetworkClient`). A previous implementation used
+    /// a `withThrowingTaskGroup`, but structured-concurrency cleanup awaited the XPC
+    /// child task, which could not actually be cancelled because
+    /// `xpc_connection_send_message_with_reply` only resumes when its callback fires.
+    /// That made `responseTimeout` ineffective whenever the remote service was wedged.
+    /// See docs/internal/help-freeze-analysis.md.
     @discardableResult
     public func send(_ message: XPCMessage, responseTimeout: Duration? = nil) async throws -> XPCMessage {
-        try await withThrowingTaskGroup(of: XPCMessage.self, returning: XPCMessage.self) { group in
-            if let responseTimeout {
-                group.addTask {
-                    try await Task.sleep(for: responseTimeout)
-                    let route = message.string(key: XPCMessage.routeKey) ?? "nil"
-                    throw ContainerizationError(
-                        .internalError,
-                        message: "XPC timeout for request to \(self.service)/\(route)"
-                    )
-                }
-            }
+        let state = ResumptionState<XPCMessage>()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<XPCMessage, Error>) in
+                state.set(cont)
 
-            group.addTask {
-                try await withCheckedThrowingContinuation { cont in
-                    xpc_connection_send_message_with_reply(self.connection, message.underlying, nil) { reply in
-                        do {
-                            let message = try self.parseReply(reply)
-                            cont.resume(returning: message)
-                        } catch {
-                            cont.resume(throwing: error)
-                        }
+                xpc_connection_send_message_with_reply(self.connection, message.underlying, nil) { reply in
+                    do {
+                        let parsed = try self.parseReply(reply)
+                        state.tryResume(returning: parsed)
+                    } catch {
+                        state.tryResume(throwing: error)
                     }
                 }
-            }
 
-            let response = try await group.next()
-            // once one task has finished, cancel the rest.
-            group.cancelAll()
-            // we don't really care about the second error here
-            // as it's most likely a `CancellationError`.
-            try? await group.waitForAll()
+                if let responseTimeout {
+                    let service = self.service
+                    let route = message.string(key: XPCMessage.routeKey) ?? "nil"
+                    Task { [state] in
+                        try? await Task.sleep(for: responseTimeout)
+                        state.tryResume(
+                            throwing: ContainerizationError(
+                                .timeout,
+                                message: "XPC timeout for request to \(service)/\(route)"
+                            )
+                        )
+                    }
+                }
 
-            guard let response else {
-                throw ContainerizationError(.invalidState, message: "failed to receive XPC response")
+                // Close the race window: if cancellation arrived before `set(cont)`
+                // ran, the cancellation handler resumed against an empty state. Resume
+                // here so the continuation cannot be lost.
+                if Task.isCancelled {
+                    state.tryResume(throwing: CancellationError())
+                }
             }
-            return response
+        } onCancel: {
+            state.tryResume(throwing: CancellationError())
         }
     }
 
@@ -130,6 +145,38 @@ extension XPCClient {
         default:
             fatalError("unhandled xpc object type: \(xpc_get_type(reply))")
         }
+    }
+}
+
+/// Single-resume gate around a `CheckedContinuation`.
+///
+/// `XPCClient.send` races multiple completion sources (XPC reply callback, timeout
+/// sleep, parent-task cancellation) against a single continuation. Whichever wins
+/// resumes via `tryResume`; subsequent resumes are dropped silently.
+private final class ResumptionState<T: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<T, Error>?
+
+    func set(_ continuation: CheckedContinuation<T, Error>) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.continuation = continuation
+    }
+
+    func tryResume(returning value: T) {
+        lock.lock()
+        let c = continuation
+        continuation = nil
+        lock.unlock()
+        c?.resume(returning: value)
+    }
+
+    func tryResume(throwing error: Error) {
+        lock.lock()
+        let c = continuation
+        continuation = nil
+        lock.unlock()
+        c?.resume(throwing: error)
     }
 }
 

--- a/Sources/Services/ContainerAPIService/Client/ClientHealthCheck.swift
+++ b/Sources/Services/ContainerAPIService/Client/ClientHealthCheck.swift
@@ -28,10 +28,10 @@ extension ClientHealthCheck {
         XPCClient(service: serviceIdentifier)
     }
 
-    public static func ping(timeout: Duration? = XPCClient.xpcRegistrationTimeout) async throws -> SystemHealth {
+    public static func ping(timeout: Duration = XPCClient.xpcRegistrationTimeout) async throws -> SystemHealth {
         let client = Self.newClient()
         let request = XPCMessage(route: .ping)
-        let reply = try await client.send(request, responseTimeout: timeout)
+        let reply = try await client.send(request, timeoutForIdempotentRequest: timeout)
         guard let appRootValue = reply.string(key: .appRoot), let appRoot = URL(string: appRootValue) else {
             throw ContainerizationError(.internalError, message: "failed to decode appRoot in health check")
         }

--- a/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
+++ b/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
@@ -37,11 +37,16 @@ public struct ContainerClient: Sendable {
     }
 
     @discardableResult
-    private func xpcSend(
+    private func xpcSend(message: XPCMessage) async throws -> XPCMessage {
+        try await xpcClient.send(message)
+    }
+
+    @discardableResult
+    private func xpcSendIdempotent(
         message: XPCMessage,
-        timeout: Duration? = XPCClient.xpcRegistrationTimeout
+        timeout: Duration
     ) async throws -> XPCMessage {
-        try await xpcClient.send(message, responseTimeout: timeout)
+        try await xpcClient.send(message, timeoutForIdempotentRequest: timeout)
     }
 
     /// Create a new container with the given configuration.
@@ -82,7 +87,7 @@ public struct ContainerClient: Sendable {
             let filterData = try JSONEncoder().encode(filters)
             request.set(key: .listFilters, value: filterData)
 
-            let response = try await xpcSend(
+            let response = try await xpcSendIdempotent(
                 message: request,
                 timeout: .seconds(10)
             )

--- a/Sources/Services/ContainerAPIService/Client/NetworkClient.swift
+++ b/Sources/Services/ContainerAPIService/Client/NetworkClient.swift
@@ -57,11 +57,16 @@ public struct NetworkClient: Sendable {
     }
 
     @discardableResult
-    private func xpcSend(
+    private func xpcSend(message: XPCMessage) async throws -> XPCMessage {
+        try await xpcClient.send(message)
+    }
+
+    @discardableResult
+    private func xpcSendIdempotent(
         message: XPCMessage,
-        timeout: Duration? = XPCClient.xpcRegistrationTimeout
+        timeout: Duration
     ) async throws -> XPCMessage {
-        try await xpcClient.send(message, responseTimeout: timeout)
+        try await xpcClient.send(message, timeoutForIdempotentRequest: timeout)
     }
 
     /// Creates a new network with the given configuration.
@@ -97,7 +102,7 @@ public struct NetworkClient: Sendable {
     public func list() async throws -> [NetworkState] {
         let request = XPCMessage(route: .networkList)
 
-        let response = try await xpcSend(message: request, timeout: .seconds(1))
+        let response = try await xpcSendIdempotent(message: request, timeout: .seconds(1))
         let responseData = response.dataNoCopy(key: .networkStates)
         guard let responseData else {
             return []

--- a/Sources/Services/ContainerSandboxService/Client/SandboxClient.swift
+++ b/Sources/Services/ContainerSandboxService/Client/SandboxClient.swift
@@ -47,14 +47,19 @@ public struct SandboxClient: Sendable {
 
     /// Create a SandboxClient by ID and runtime string. The returned client is ready to be used
     /// without additional steps.
-    public static func create(id: String, runtime: String, timeout: Duration = XPCClient.xpcRegistrationTimeout) async throws -> SandboxClient {
+    ///
+    /// `createEndpoint` is mutating server-side: a successful reply hands back an XPC endpoint
+    /// that the sandbox process owns. Racing the call with a response timeout would risk
+    /// orphaning that endpoint when a slow sandbox replies after the caller has given up.
+    /// The send therefore blocks until the sandbox replies or its connection is invalidated.
+    public static func create(id: String, runtime: String) async throws -> SandboxClient {
         let label = Self.machServiceLabel(runtime: runtime, id: id)
         let client = XPCClient(service: label)
         let request = XPCMessage(route: SandboxRoutes.createEndpoint.rawValue)
 
         let response: XPCMessage
         do {
-            response = try await client.send(request, responseTimeout: timeout)
+            response = try await client.send(request)
         } catch {
             throw ContainerizationError(
                 .internalError,

--- a/Tests/ContainerXPCTests/XPCClientTests.swift
+++ b/Tests/ContainerXPCTests/XPCClientTests.swift
@@ -1,0 +1,310 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+#if os(macOS)
+import ContainerizationError
+import Foundation
+import Testing
+
+@testable import ContainerXPC
+
+/// Tests for the mutating-vs-idempotent `XPCClient.send` contract introduced
+/// in response to the Codex adversarial review of `fix/help-command-freeze`.
+/// See `docs/internal/codex-reviews.md`.
+struct XPCClientTests {
+
+    // MARK: - timeoutForIdempotentRequest contract
+
+    @Test
+    func idempotentTimeoutReturnsWithinBound() async throws {
+        let server = LocalXPCServer(handler: { _ in /* never reply */ })
+        defer { server.shutdown() }
+        let client = server.makeClient()
+        let request = XPCMessage(route: "test.idempotent.timeout")
+
+        let timeout: Duration = .milliseconds(300)
+        let start = ContinuousClock.now
+        let thrown = await Result { try await client.send(request, timeoutForIdempotentRequest: timeout) }
+        let elapsed = ContinuousClock.now - start
+
+        switch thrown {
+        case .success:
+            Issue.record("send should have thrown; instead returned a value")
+        case .failure(let error):
+            let cz = try #require(error as? ContainerizationError, "expected ContainerizationError, got \(type(of: error))")
+            #expect(cz.code == .timeout, "expected .timeout, got .\(cz.code) — \(cz.message)")
+        }
+        #expect(elapsed >= timeout, "should not return before the timeout window (elapsed: \(elapsed))")
+        #expect(elapsed < timeout * 5, "should return promptly after timeout (elapsed: \(elapsed))")
+    }
+
+    @Test
+    func reusableClientSurvivesIdempotentTimeout() async throws {
+        // First call never replies; second call replies immediately. The single
+        // shared XPCClient must continue to work after the first call times out.
+        let replyImmediately = Mutex(false)
+        let server = LocalXPCServer(handler: { request in
+            if replyImmediately.get() {
+                request.reply()
+            }
+            // else: drop silently, simulating a hung server
+        })
+        defer { server.shutdown() }
+        let client = server.makeClient()
+
+        let firstResult = await Result {
+            try await client.send(
+                XPCMessage(route: "test.first"),
+                timeoutForIdempotentRequest: .milliseconds(200)
+            )
+        }
+        let cz = try #require((firstResult.error()) as? ContainerizationError)
+        #expect(cz.code == .timeout, "first send should time out, got .\(cz.code) — \(cz.message)")
+
+        replyImmediately.set(true)
+        let response = try await client.send(
+            XPCMessage(route: "test.second"),
+            timeoutForIdempotentRequest: .seconds(5)
+        )
+        #expect(response.string(key: XPCMessage.routeKey) != nil, "reply should be a valid XPC dictionary")
+    }
+
+    @Test
+    func lateReplyAfterIdempotentTimeoutIsIgnoredCleanly() async throws {
+        // Server delays its reply past the client's timeout. Verify the client
+        // surfaces the timeout AND that a subsequent send still works (i.e., the
+        // late reply did not corrupt connection state or cause a crash).
+        let server = LocalXPCServer(handler: { request in
+            Task {
+                try? await Task.sleep(for: .milliseconds(400))
+                request.reply()
+            }
+        })
+        defer { server.shutdown() }
+        let client = server.makeClient()
+
+        let firstResult = await Result {
+            try await client.send(
+                XPCMessage(route: "test.late"),
+                timeoutForIdempotentRequest: .milliseconds(150)
+            )
+        }
+        let cz = try #require((firstResult.error()) as? ContainerizationError)
+        #expect(cz.code == .timeout, "first send should time out, got .\(cz.code) — \(cz.message)")
+
+        // Wait long enough that the late reply has fired and been silently dropped.
+        try await Task.sleep(for: .milliseconds(500))
+
+        // Connection must still be usable.
+        let response = try await client.send(
+            XPCMessage(route: "test.after-late"),
+            timeoutForIdempotentRequest: .seconds(5)
+        )
+        #expect(response.string(key: XPCMessage.routeKey) != nil)
+    }
+
+    // MARK: - send(_:) mutating-safe contract
+
+    @Test
+    func plainSendCompletesWhenServerReplies() async throws {
+        let server = LocalXPCServer(handler: { request in
+            request.reply()
+        })
+        defer { server.shutdown() }
+        let client = server.makeClient()
+
+        let response = try await client.send(XPCMessage(route: "test.plain.ok"))
+        #expect(response.string(key: XPCMessage.routeKey) != nil)
+    }
+
+    @Test
+    func plainSendIgnoresCancellationAfterDispatch() async throws {
+        // Server holds the reply behind a gate. The test cancels the task after
+        // the message has been dispatched; if cancellation were honored, the task
+        // would throw `CancellationError`. We then open the gate and verify the
+        // task completes successfully — proving cancellation was ignored.
+        let gate = Gate()
+        let server = LocalXPCServer(handler: { request in
+            Task {
+                await gate.wait()
+                request.reply()
+            }
+        })
+        defer { server.shutdown() }
+        let client = server.makeClient()
+
+        let task = Task {
+            try await client.send(XPCMessage(route: "test.plain.cancel"))
+        }
+
+        // Yield enough time for the message to dispatch and the server to enqueue
+        // its waiter on `gate`.
+        try await Task.sleep(for: .milliseconds(100))
+
+        task.cancel()
+
+        // Hold the reply so we can be sure the cancellation has propagated.
+        try await Task.sleep(for: .milliseconds(100))
+
+        // Release the server reply.
+        await gate.open()
+
+        // If cancellation were honored, this would throw CancellationError.
+        let response = try await task.value
+        #expect(response.string(key: XPCMessage.routeKey) != nil)
+    }
+
+    @Test
+    func plainSendHonorsCancellationBeforeDispatch() async throws {
+        let server = LocalXPCServer(handler: { request in
+            request.reply()
+        })
+        defer { server.shutdown() }
+        let client = server.makeClient()
+
+        let task = Task {
+            // Pre-cancel before reaching `client.send`.
+            try await Task.sleep(for: .milliseconds(50))
+            try await client.send(XPCMessage(route: "test.plain.precancel"))
+        }
+        task.cancel()
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await task.value
+        }
+    }
+}
+
+// MARK: - Test helpers
+
+/// In-process XPC listener that hands incoming requests to a test handler.
+///
+/// Every received request is retained by the server until ``shutdown()`` so
+/// XPC does not invalidate the underlying message while a test is deliberately
+/// withholding a reply.
+private final class LocalXPCServer: @unchecked Sendable {
+    private let listener: xpc_connection_t
+    private let queue: DispatchQueue
+    private let pending = Mutex<[XPCRequest]>([])
+
+    init(handler: @escaping @Sendable (XPCRequest) -> Void) {
+        let queue = DispatchQueue(label: "test.server.\(UUID().uuidString)")
+        self.queue = queue
+        self.listener = xpc_connection_create(nil, queue)
+        let pending = self.pending
+
+        xpc_connection_set_event_handler(self.listener) { event in
+            guard xpc_get_type(event) == XPC_TYPE_CONNECTION else { return }
+            let peer = event
+            xpc_connection_set_event_handler(peer) { msg in
+                guard xpc_get_type(msg) == XPC_TYPE_DICTIONARY else { return }
+                let request = XPCRequest(message: msg, peer: peer)
+                pending.modify { $0.append(request) }
+                handler(request)
+            }
+            xpc_connection_activate(peer)
+        }
+        xpc_connection_activate(self.listener)
+    }
+
+    func makeClient() -> XPCClient {
+        let endpoint = xpc_endpoint_create(self.listener)
+        let connection = xpc_connection_create_from_endpoint(endpoint)
+        return XPCClient(connection: connection, label: "test")
+    }
+
+    func shutdown() {
+        pending.set([])
+        xpc_connection_cancel(self.listener)
+    }
+}
+
+/// A request received by `LocalXPCServer`. Use ``reply()`` to send back a
+/// well-formed XPC reply that the client's `send_message_with_reply` callback
+/// will receive.
+private struct XPCRequest: @unchecked Sendable {
+    let message: xpc_object_t
+    let peer: xpc_connection_t
+
+    func reply() {
+        guard let reply = xpc_dictionary_create_reply(message) else { return }
+        xpc_dictionary_set_string(reply, XPCMessage.routeKey, "reply")
+        xpc_connection_send_message(peer, reply)
+    }
+}
+
+/// Minimal thread-safe single-value cell. Used to flip server behavior mid-test
+/// without dragging in additional async machinery.
+private final class Mutex<T>: @unchecked Sendable {
+    private var value: T
+    private let lock = NSLock()
+
+    init(_ value: T) { self.value = value }
+
+    func get() -> T {
+        lock.lock(); defer { lock.unlock() }
+        return value
+    }
+
+    func set(_ new: T) {
+        lock.lock(); defer { lock.unlock() }
+        value = new
+    }
+
+    func modify(_ body: (inout T) -> Void) {
+        lock.lock(); defer { lock.unlock() }
+        body(&value)
+    }
+}
+
+/// One-shot async gate. Wait suspends until ``open()`` is called; after that,
+/// every wait returns immediately.
+private actor Gate {
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+    private var isOpen = false
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { continuations.append($0) }
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        let waiters = continuations
+        continuations.removeAll()
+        for c in waiters { c.resume() }
+    }
+}
+
+extension Result where Failure == Error {
+    init(catching body: () async throws -> Success) async {
+        do {
+            self = .success(try await body())
+        } catch {
+            self = .failure(error)
+        }
+    }
+
+    fileprivate func error() -> Error? {
+        switch self {
+        case .success: return nil
+        case .failure(let e): return e
+        }
+    }
+}
+
+#endif

--- a/docs/internal/help-freeze-analysis.md
+++ b/docs/internal/help-freeze-analysis.md
@@ -1,0 +1,208 @@
+# `container --help` freeze — root cause analysis
+
+> Status: investigation document for the fix proposed in this PR. Reviewers — please critique the reasoning below; the patches in this PR are the smallest changes that follow from it.
+
+## Reproduction
+
+On a system where `com.apple.container.apiserver` is dead, wedged, or stale-registered in launchd:
+
+```bash
+container --help     # hangs indefinitely (not bounded by any visible timeout)
+container help       # hangs indefinitely
+container            # hangs indefinitely
+```
+
+This matches the symptom pattern in [#1329](https://github.com/apple/container/issues/1329), [#798](https://github.com/apple/container/issues/798), and [#621](https://github.com/apple/container/issues/621), which all describe XPC handshake hangs against `com.apple.container.apiserver` requiring `launchctl bootout` to recover.
+
+User-visible workaround:
+
+```bash
+launchctl bootout gui/$(id -u)/com.apple.container.apiserver 2>/dev/null
+launchctl bootout user/$(id -u)/com.apple.container.apiserver 2>/dev/null
+container system start
+```
+
+## Root cause: there are *two* defects, not one
+
+### Defect A — the help path requires the daemon to be reachable
+
+`Application.main()` catches the `--help` parse signal and, before printing help, calls `createPluginLoader()` so the help text can be enriched with installed plugin commands.
+
+```
+Application.main
+  └─ catch (CleanExit from --help)
+      └─ createPluginLoader()                                   [Application.swift:137]
+          └─ ClientHealthCheck.ping(timeout: .seconds(10))      [Application.swift:169]
+              └─ XPCClient.send(... responseTimeout: 10s)       [ClientHealthCheck.swift:34]
+                  └─ xpc_connection_send_message_with_reply     [XPCClient.swift:89]
+                      └── waiting on com.apple.container.apiserver
+```
+
+The same pattern exists in:
+
+| File | Line | Path |
+|---|---|---|
+| `Sources/ContainerCommands/Application.swift` | 121–126 | root `--help` / `-h` |
+| `Sources/ContainerCommands/HelpCommand.swift` | 29–32 | `container help` subcommand |
+| `Sources/ContainerCommands/DefaultCommand.swift` | 35–41 | `container` (no args) |
+
+The intent is to enrich help text with plugin commands. The implementation reaches the daemon to fetch `appRoot/installRoot/logRoot`, even though `PluginLoader.alterCLIHelpText()` only reads `pluginDirectories` and `pluginFactories` (verifiable in `Sources/ContainerPlugin/PluginLoader.swift:70-88`, `91-176`). The daemon ping is structurally unnecessary for help rendering; it only became necessary because `PluginLoader.init` happens to take roots that `alterCLIHelpText` does not use.
+
+### Defect B — `XPCClient.send`'s timeout cannot actually unblock the function
+
+This is the reason the hang is *indefinite* rather than the 10 seconds suggested by the call site.
+
+```swift
+// Sources/ContainerXPC/XPCClient.swift:74-112
+public func send(_ message: XPCMessage, responseTimeout: Duration? = nil) async throws -> XPCMessage {
+    try await withThrowingTaskGroup(of: XPCMessage.self, returning: XPCMessage.self) { group in
+        if let responseTimeout {
+            group.addTask {
+                try await Task.sleep(for: responseTimeout)
+                throw ContainerizationError(.internalError, message: "XPC timeout ...")
+            }
+        }
+        group.addTask {
+            try await withCheckedThrowingContinuation { cont in
+                xpc_connection_send_message_with_reply(self.connection, message.underlying, nil) { reply in
+                    /* resume cont with parsed reply or error */
+                }
+            }
+        }
+        let response = try await group.next()   // ← rethrows the timeout
+        group.cancelAll()                       // ← UNREACHABLE on throw
+        try? await group.waitForAll()           // ← UNREACHABLE on throw
+        guard let response else { throw ... }
+        return response
+    }
+}
+```
+
+When `Task.sleep` wins the race:
+
+1. `try await group.next()` rethrows the timeout error. The explicit `cancelAll() / waitForAll()` lines never execute.
+2. Swift unwinds the throwing TaskGroup, which **must** await every pending child task before the group scope can return. (This is the structured concurrency contract — the group cannot outlive its children.)
+3. The XPC child is suspended inside `withCheckedThrowingContinuation`, waiting for the C callback supplied to `xpc_connection_send_message_with_reply`.
+4. **Cancelling a Swift `Task` does not cancel `xpc_connection_send_message_with_reply`.** `withCheckedThrowingContinuation` has no cancellation handler installed. The C call only resumes the continuation when its callback fires — and the callback only fires when XPC delivers a reply or invalidates the connection.
+5. If the apiserver is wedged but launchd has not invalidated the registration, the callback never fires → TaskGroup cleanup blocks forever → `XPCClient.send` blocks forever — regardless of `responseTimeout`.
+
+Net effect: every advertised timeout in the codebase is unreliable in exactly the failure modes timeouts are supposed to mitigate.
+
+## Audit: callers that share Defect B
+
+Every caller of `ClientHealthCheck.ping(...)` and every caller of `XPCClient.send(...)` is subject to the same indefinite-hang behavior in the wedged-daemon failure mode. The seven `ClientHealthCheck.ping` call sites:
+
+```
+Sources/ContainerCommands/Application.swift:169                 (--help, container help, no-args)
+Sources/ContainerCommands/Builder/BuilderStart.swift:101
+Sources/ContainerCommands/BuildCommand.swift:259
+Sources/ContainerCommands/System/SystemStart.swift:120
+Sources/ContainerCommands/System/SystemStop.swift:57
+Sources/ContainerCommands/System/SystemStatus.swift:76
+Sources/ContainerCommands/System/SystemVersion.swift:48
+```
+
+Plus every `XPCClient.send` call without a timeout (most callers in `Sources/Services/ContainerAPIService/Client/`).
+
+This is why we treat Defect B as a separate fix: the help freeze is the symptom that motivated the investigation, but Defect B is a hazard the entire CLI shares.
+
+## Fix design
+
+### Defect A — `Sources/ContainerCommands/{Application,HelpCommand,DefaultCommand}.swift`
+
+For the three help-rendering paths, drop the call to `createPluginLoader()` and pass `pluginLoader: nil` directly to `printModifiedHelpText`. Extend `printModifiedHelpText` with an optional `unavailableMessage:` so the help paths can suppress the `"PLUGINS: not available, run 'container system start'"` notice that would otherwise be misleading on a healthy system.
+
+For `DefaultCommand`, also reorder `createPluginLoader()` to happen **after** the no-args/help guard, so only the actual plugin-dispatch path pays the daemon round-trip.
+
+**Tradeoff (please critique).** This patch removes plugin enrichment from `--help` / `help` / no-args output. We chose this over a "filesystem-only plugin discovery" path because:
+
+- It is a strictly local change (~15 lines across 3 files); it can be reviewed and reverted independently.
+- It does not introduce new public API on `PluginLoader`.
+- A follow-up can reintroduce plugin enrichment by extracting filesystem-only discovery from `PluginLoader.findPlugins()` (which already needs only `pluginDirectories` and `pluginFactories`). The blockers for that refactor are design-flavored, not freeze-flavored, so we'd rather decouple them.
+
+If reviewers prefer to keep plugin enrichment in help, the natural follow-up is:
+
+```swift
+// PluginLoader.swift — proposed but NOT in this PR
+public static func discoverFromDisk(
+    in pluginDirectories: [URL],
+    using pluginFactories: [PluginFactory],
+    log: Logger? = nil
+) -> [Plugin]
+
+public static func alterCLIHelpText(original: String, plugins: [Plugin]) -> String
+```
+
+Then `Application.printModifiedHelpText` would call those two static helpers instead of needing a constructed `PluginLoader`.
+
+### Defect B — `Sources/ContainerXPC/XPCClient.swift`
+
+We need the timeout to actually return control to the caller without breaking `XPCClient` instances that are reused across multiple sends.
+
+#### Why we did not use Oracle's first-pass recommendation (`onCancel: self.close()`)
+
+The simplest patch — wrap the XPC continuation in `withTaskCancellationHandler` and call `xpc_connection_cancel` in `onCancel` — works correctly for one-shot clients (`ClientHealthCheck`, `ClientImage`, `ClientKernel`, `ClientVolume`, `ClientDiskUsage`, `RemoteContentStoreClient`). But:
+
+```
+Sources/Services/ContainerAPIService/Client/ContainerClient.swift:36     self.xpcClient = XPCClient(service: ...)
+Sources/Services/ContainerAPIService/Client/NetworkClient.swift:56       self.xpcClient = XPCClient(service: ...)
+```
+
+These callers stash an `XPCClient` on the instance and reuse it across many `send` calls. `xpc_connection_cancel` is irreversible — once called, every subsequent `send` on that connection fails with `XPC_ERROR_CONNECTION_INVALID`. So a single timeout would silently brick the client for the rest of its lifetime.
+
+#### What this PR does instead — single-resume continuation gated by a small state object
+
+The XPC C callback is allowed to fire at any time; we just stop *waiting* for it once a timeout (or cancellation) wins. A small `ResumptionState` class guards a single `CheckedContinuation` so that exactly one of {reply received, timeout fired, parent cancelled} resumes the continuation, and the others become no-ops. The connection is never cancelled, so reusable clients keep working.
+
+```swift
+public func send(_ message: XPCMessage, responseTimeout: Duration? = nil) async throws -> XPCMessage {
+    let state = ResumptionState<XPCMessage>()
+    return try await withTaskCancellationHandler {
+        try await withCheckedThrowingContinuation { cont in
+            state.set(cont)
+            xpc_connection_send_message_with_reply(self.connection, message.underlying, nil) { reply in
+                do {
+                    state.tryResume(returning: try self.parseReply(reply))
+                } catch {
+                    state.tryResume(throwing: error)
+                }
+            }
+            if let responseTimeout {
+                let service = self.service
+                let route = message.string(key: XPCMessage.routeKey) ?? "nil"
+                Task { [state] in
+                    try? await Task.sleep(for: responseTimeout)
+                    state.tryResume(throwing: ContainerizationError(
+                        .timeout,
+                        message: "XPC timeout for \(service)/\(route)"
+                    ))
+                }
+            }
+        }
+    } onCancel: {
+        state.tryResume(throwing: CancellationError())
+    }
+}
+```
+
+**Known leak.** When a timeout (or cancel) wins, the C-level reply callback eventually fires and is ignored. XPC retains the pending reply and its associated buffers until the connection is cancelled or released. For short-lived clients this is GC'd within milliseconds; for long-lived reusable clients the worst case is one orphaned `xpc_object_t` per timed-out send. We consider this acceptable until a deeper XPC-layer redesign is appropriate; an alternative (cancelling and reconstructing the connection on timeout) would require coordination with every reusable-client owner.
+
+**Cancellation race window.** If `Task.cancel` is delivered before `state.set(cont)` runs, the cancellation handler's `tryResume` becomes a no-op against an empty state, and the continuation will never resume. We close this window by checking `Task.isCancelled` immediately after `state.set(cont)` and resuming with `CancellationError()` if so.
+
+## What we explicitly chose **not** to fix in this PR
+
+1. **Plugin enrichment in `--help` / `help` / no-args output.** Removed by this PR; can be reintroduced by the follow-up sketched above. Filed as a known regression in the PR description.
+2. **`ClientHealthCheck.ping`'s default timeout being `XPCClient.xpcRegistrationTimeout` (60s).** All current call sites override the default to 2–10s, so the 60s default is dormant in practice. Worth fixing in a follow-up.
+3. **The reusable `ContainerClient` / `NetworkClient` instances calling `XPCClient.send` without a timeout.** Defect B's fix makes timeouts work *when supplied*. Adding sensible default timeouts to those call sites is a separate concern.
+4. **`launchctl bootout` style recovery as a CLI command.** Out of scope; the user-visible workaround is documented in the PR description.
+
+## Verification this PR does and does not provide
+
+| Claim | Verified by |
+|---|---|
+| Help path no longer pings the apiserver | Static — three `ClientHealthCheck.ping` call sites in help paths are removed |
+| Help text still renders the original `OVERVIEW: ...` block | `Tests/CLITests/TestCLIHelp.swift` (covers `container help`) |
+| `XPCClient.send` returns within `responseTimeout` when the C callback never fires | Not yet — needs a unit test that injects a connection with a non-firing reply. Reviewers: would you like one in this PR, or as a follow-up? |
+| Reusable `XPCClient` instances survive a single-send timeout | Not yet — would benefit from the same kind of injected-connection test |
+
+The two missing tests are the highest-value follow-ups to this PR.


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context

Closes #1459.

`container --help`, `container help`, and `container` (no args) should not require `com.apple.container.apiserver` to be reachable. Today, those paths can enter plugin loading before printing help, which calls `ClientHealthCheck.ping()` and waits on the apiserver.

A healthy build is expected to return quickly; this is not a bug in normal help rendering. The failure mode is conditional on launchd/XPC state where `com.apple.container.apiserver` is registered but unavailable, dead, wedged, or otherwise not replying. That state is the class of issue tracked in #1459 and is similar to stale-apiserver recovery reports in #1329, #798, and #621.

This PR is a defensive robustness fix: help/default-command rendering should remain local, and idempotent XPC requests with explicit timeouts should actually return when the reply callback never fires.

## Summary

This PR fixes two independent defects:

1. **Help/default commands should not ping the API server** — `Application.swift`, `HelpCommand.swift`, and `DefaultCommand.swift` now print base help without constructing a `PluginLoader` first.
2. **Idempotent XPC timeouts should actually unblock** — `XPCClient.send(_:timeoutForIdempotentRequest:)` replaces the old TaskGroup race with a single-resume gate so a non-firing XPC reply cannot trap structured-concurrency cleanup forever.
3. **Mutating XPC sends should not silently drop late replies** — the XPC API now separates mutating/unknown-safety sends from idempotent sends, preventing accidental timeout use on mutating operations.
4. **The investigation is documented** — `docs/internal/help-freeze-analysis.md` captures the call chain, tradeoffs, and remaining follow-ups.

## Why the help-path fix is separate from the XPC fix

There are two independent defects:

- **Defect A (symptom).** Help/default rendering called `createPluginLoader()` → `ClientHealthCheck.ping()` to fetch `appRoot`/`installRoot`/`logRoot` purely so `printModifiedHelpText` could enrich help with plugin commands. The ping is structurally unnecessary for base help output.

- **Defect B (depth).** The old `XPCClient.send(... responseTimeout:)` raced `Task.sleep` against the XPC reply inside a `withThrowingTaskGroup`, but throwing from `group.next()` caused structured-concurrency cleanup to await the still-suspended XPC child task. Cancelling the Swift task does not cancel `xpc_connection_send_message_with_reply`, so a non-firing callback could still block indefinitely.

Defect A removes the apiserver dependency from help/default paths. Defect B makes explicit idempotent XPC timeouts behave as timeouts when the XPC reply never arrives.

## Reproduction scope

No deterministic setup is currently known for creating the stale/wedged launchd state. On a healthy checkout, the following should return quickly, and reviewer testing confirmed that behavior after `make all`:

```bash
make all

time .build/debug/container --help
time .build/debug/container help
time .build/debug/container
```

The bug tracked by #1459 applies when the apiserver is registered but not replying. In that state, pre-fix help/default paths can block before printing help because they ping the apiserver while preparing plugin-enriched help.

`launchctl bootout ...` is a recovery/cleanup action observed in related stale-apiserver cases, not a reliable reproduction step.

## Build/test guidance

For normal source builds and verification, follow `BUILDING.md`:

```bash
make all test integration
```

For installed release-style testing:

```bash
BUILD_CONFIGURATION=release make all test integration
BUILD_CONFIGURATION=release make install
```

The `.build/debug/container` timings above are diagnostic context matching the reviewer command, not the canonical setup for reproducing or validating installed helper/plugin layout.

## Known regression in this PR

Plugin enrichment in `--help` / `help` / no-args output is removed. The output is the original `OVERVIEW: ... USAGE: ... CONTAINER SUBCOMMANDS: ...` block, without a trailing `PLUGINS:` section.

This keeps the freeze fix minimal and avoids entangling it with API design questions on `PluginLoader`. A follow-up can restore plugin enrichment by extracting filesystem-only plugin discovery from `PluginLoader.findPlugins()`; the proposed shape is sketched in `docs/internal/help-freeze-analysis.md`.

## Verification

- `swift build --product container` — clean
- `make test` — 366/366 unit tests pass
- `make swift-fmt-check` — clean
- Added `Tests/ContainerXPCTests/XPCClientTests.swift` coverage for:
  - idempotent timeout returning within the bound
  - reusable clients surviving idempotent timeout
  - late replies after timeout being ignored cleanly
  - plain mutating-safe sends completing when the server replies
  - plain sends ignoring cancellation after dispatch
  - plain sends honoring cancellation before dispatch
- Manual diagnostic smoke test on macOS 26 with `com.apple.container.apiserver` registered with launchd but inactive (`active count = 0`, `state = spawn scheduled`):

  ```bash
  $ time .build/debug/container --help
  ... full help output ...
  real  0m0.11s

  $ time .build/debug/container help
  ... full help output ...
  real  0m0.11s

  $ time .build/debug/container
  ... full help output ...
  real  0m0.11s
  ```

  All exit 0 immediately. Before this PR these paths could block while trying to reach the apiserver before printing help.

## What this PR explicitly does **not** fix

1. A deterministic way to create the stale/wedged apiserver launchd state tracked by #1459.
2. All apiserver startup/stop hangs reported in #1329, #798, or #621.
3. `ClientHealthCheck.ping`'s 60s default `xpcRegistrationTimeout`.
4. Reusable `ContainerClient` / `NetworkClient` mutating calls with no timeout; this is intentional until mutating operations have an idempotency/recovery protocol.
5. `launchctl bootout`-style recovery as a built-in CLI command.

## Workaround for affected users

If the local apiserver launchd state is stale or wedged, related reports have recovered with bootout + restart:

```bash
launchctl bootout gui/$(id -u)/com.apple.container.apiserver 2>/dev/null
launchctl bootout user/$(id -u)/com.apple.container.apiserver 2>/dev/null
container system start
```

---

Full reasoning, the call-chain trace, the audit of affected XPC callers, and the design tradeoffs are in `docs/internal/help-freeze-analysis.md`. **The doc is intentionally written for adversarial review** — please push back on anything that doesn't hold up.