### PR TITLE
ensure-container-stopped.sh: don't fail on launchctl errors

### DIFF
--- a/scripts/ensure-container-stopped.sh
+++ b/scripts/ensure-container-stopped.sh
@@ -44,11 +44,14 @@ done
 if $ALL_DOMAINS; then
     uid=$(id -u)
     for domain in "gui/$uid" "user/$uid" "system"; do
+        if [ "$domain" = "system" ] && [ "$uid" -ne 0 ]; then
+            continue
+        fi
         launchctl print "$domain" 2>/dev/null \
             | grep -oE 'com\.apple\.container\.[^ ]+' \
             | sort -u \
             | while read -r service; do
-                launchctl bootout "$domain/$service"
+                launchctl bootout "$domain/$service" 2>/dev/null || true
             done
     done
 else
@@ -67,5 +70,6 @@ else
         exit 1
     fi
 
-    launchctl list | grep -e 'com\.apple\.container\W' | awk '{print $3}' | xargs -I % launchctl bootout $domain_string/%
+    launchctl list | grep -e 'com\.apple\.container\W' | awk '{print $3}' \
+        | xargs -I % sh -c 'launchctl bootout '"$domain_string"'/% 2>/dev/null || true'
 fi


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Fixes #1281. Supersedes #1306.

When `-a` runs as a regular user (such as via `brew install container`), two launchctl failures bubble up as a non-zero exit and break Homebrew's post-install:

- `bootout` against `system` requires root.
- `launchctl print` lists Mach endpoint names that aren't loaded jobs, so `bootout` returns `No such process` on them.

Skip `system` when not root, and treat individual `bootout` failures as non-fatal. Same fix applied to the non-`-a` `xargs` pipeline.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
