### PR TITLE
Add bridge mode networking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,12 @@ PKG_PATH := bin/$(BUILD_CONFIGURATION)/container-installer-unsigned.pkg
 DSYM_DIR := bin/$(BUILD_CONFIGURATION)/bundle/container-dSYM
 DSYM_PATH := bin/$(BUILD_CONFIGURATION)/bundle/container-dSYM.zip
 CODESIGN_OPTS ?= --force --sign - --timestamp=none
+ENABLE_BRIDGE_NETWORKING ?= 0
+ifeq ($(ENABLE_BRIDGE_NETWORKING),1)
+	RUNTIME_LINUX_ENTITLEMENTS := signing/container-runtime-linux.bridge-mode.entitlements
+else
+	RUNTIME_LINUX_ENTITLEMENTS := signing/container-runtime-linux.entitlements
+endif
 
 
 # Conditionally use a temporary data directory for integration tests
@@ -121,7 +127,7 @@ installer-pkg: $(STAGING_DIR)
 	@codesign $(CODESIGN_OPTS) --identifier com.apple.container.cli "$(join $(STAGING_DIR), bin/container)"
 	@codesign $(CODESIGN_OPTS) --identifier com.apple.container.apiserver "$(join $(STAGING_DIR), bin/container-apiserver)"
 	@codesign $(CODESIGN_OPTS) --prefix=com.apple.container. "$(join $(STAGING_DIR), libexec/container/plugins/container-core-images/bin/container-core-images)"
-	@codesign $(CODESIGN_OPTS) --prefix=com.apple.container. --entitlements=signing/container-runtime-linux.entitlements "$(join $(STAGING_DIR), libexec/container/plugins/container-runtime-linux/bin/container-runtime-linux)"
+	@codesign $(CODESIGN_OPTS) --prefix=com.apple.container. --entitlements=$(RUNTIME_LINUX_ENTITLEMENTS) "$(join $(STAGING_DIR), libexec/container/plugins/container-runtime-linux/bin/container-runtime-linux)"
 	@codesign $(CODESIGN_OPTS) --prefix=com.apple.container. --entitlements=signing/container-network-vmnet.entitlements "$(join $(STAGING_DIR), libexec/container/plugins/container-network-vmnet/bin/container-network-vmnet)"
 
 	@echo Creating application installer

--- a/Package.swift
+++ b/Package.swift
@@ -332,6 +332,7 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Containerization", package: "containerization"),
                 "ContainerLog",
+                "ContainerNetworkServiceClient",
                 "ContainerPlugin",
                 "ContainerResource",
                 "ContainerSandboxService",

--- a/Sources/APIServer/ContainerDNSHandler.swift
+++ b/Sources/APIServer/ContainerDNSHandler.swift
@@ -76,10 +76,12 @@ struct ContainerDNSHandler: DNSHandler {
     }
 
     private func answerHost(question: Question) async throws -> ResourceRecord? {
-        guard let ipAllocation = try await networkService.lookup(hostname: question.name) else {
+        guard let ipAllocation = try await networkService.lookup(hostname: question.name),
+            let ipv4Address = ipAllocation.ipv4Address
+        else {
             return nil
         }
-        let ipv4 = ipAllocation.ipv4Address.address.description
+        let ipv4 = ipv4Address.address.description
         guard let ip = try? IPv4Address(ipv4) else {
             throw DNSResolverError.serverError("failed to parse IP address: \(ipv4)")
         }

--- a/Sources/ContainerCommands/Builder/BuilderStatus.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStatus.swift
@@ -85,7 +85,7 @@ private struct PrintableBuilder: ListDisplayable {
             snapshot.id,
             snapshot.configuration.image.reference,
             snapshot.status.rawValue,
-            snapshot.networks.map { $0.ipv4Address.description }.joined(separator: ","),
+            snapshot.networks.map { $0.ipv4Address?.description ?? "" }.joined(separator: ","),
             "\(snapshot.configuration.resources.cpus)",
             "\(snapshot.configuration.resources.memoryInBytes / (1024 * 1024)) MB",
         ]

--- a/Sources/ContainerCommands/Container/ContainerList.swift
+++ b/Sources/ContainerCommands/Container/ContainerList.swift
@@ -64,7 +64,7 @@ extension PrintableContainer: ListDisplayable {
             self.configuration.platform.os,
             self.configuration.platform.architecture,
             self.status.rawValue,
-            self.networks.map { $0.ipv4Address.description }.joined(separator: ","),
+            self.networks.map { $0.ipv4Address?.description ?? "" }.joined(separator: ","),
             "\(self.configuration.resources.cpus)",
             "\(self.configuration.resources.memoryInBytes / (1024 * 1024)) MB",
             self.startedDate?.ISO8601Format() ?? "",

--- a/Sources/ContainerCommands/Network/NetworkCreate.swift
+++ b/Sources/ContainerCommands/Network/NetworkCreate.swift
@@ -21,6 +21,7 @@ import ContainerizationError
 import ContainerizationExtras
 import Foundation
 import TerminalProgress
+import Virtualization
 
 extension Application {
     public struct NetworkCreate: AsyncLoggableCommand {
@@ -33,6 +34,9 @@ extension Application {
 
         @Flag(name: .customLong("internal"), help: "Restrict to host-only network")
         var hostOnly: Bool = false
+
+        @Option(name: .long, help: "Host network interface to bridge to")
+        var bridge: String? = nil
 
         @Option(
             name: .customLong("subnet"), help: "Set subnet for a network",
@@ -64,14 +68,34 @@ extension Application {
 
         public func run() async throws {
             let parsedLabels = try ResourceLabels(Utility.parseKeyValuePairs(labels))
-            let mode: NetworkMode = hostOnly ? .hostOnly : .nat
+            let mode: NetworkMode
+            var hostInterfaceName: String? = nil
+            var effectiveVariant = pluginVariant
+            if let bridge = bridge {
+                guard ipv4Subnet == nil, ipv6Subnet == nil else {
+                    throw ValidationError("--subnet and --subnet-v6 cannot be used with --bridge")
+                }
+                let available = VZBridgedNetworkInterface.networkInterfaces.map { $0.identifier }
+                guard available.contains(bridge) else {
+                    let list = available.isEmpty ? "none available" : available.joined(separator: ", ")
+                    throw ValidationError("no bridged interface '\(bridge)'; available: \(list)")
+                }
+                mode = .bridge
+                hostInterfaceName = bridge
+                effectiveVariant = "bridged"
+            } else if hostOnly {
+                mode = .hostOnly
+            } else {
+                mode = .nat
+            }
             let config = try NetworkConfiguration(
                 id: self.name,
                 mode: mode,
                 ipv4Subnet: ipv4Subnet,
                 ipv6Subnet: ipv6Subnet,
                 labels: parsedLabels,
-                pluginInfo: NetworkPluginInfo(plugin: self.plugin, variant: self.pluginVariant)
+                pluginInfo: NetworkPluginInfo(plugin: self.plugin, variant: effectiveVariant),
+                hostInterface: hostInterfaceName
             )
             let networkClient = NetworkClient()
             let network = try await networkClient.create(configuration: config)

--- a/Sources/ContainerResource/Network/Attachment.swift
+++ b/Sources/ContainerResource/Network/Attachment.swift
@@ -23,9 +23,11 @@ public struct Attachment: Codable, Sendable {
     /// The hostname associated with the attachment.
     public let hostname: String
     /// The CIDR address describing the interface IPv4 address, with the prefix length of the subnet.
-    public let ipv4Address: CIDRv4
+    /// Nil for bridge-mode attachments where the address is assigned by DHCP at runtime.
+    public let ipv4Address: CIDRv4?
     /// The IPv4 gateway address.
-    public let ipv4Gateway: IPv4Address
+    /// Nil for bridge-mode attachments where the gateway is discovered via DHCP at runtime.
+    public let ipv4Gateway: IPv4Address?
     /// The CIDR address describing the interface IPv6 address, with the prefix length of the subnet.
     /// The address is nil if the IPv6 subnet could not be determined at network creation time.
     public let ipv6Address: CIDRv6?
@@ -37,8 +39,8 @@ public struct Attachment: Codable, Sendable {
     public init(
         network: String,
         hostname: String,
-        ipv4Address: CIDRv4,
-        ipv4Gateway: IPv4Address,
+        ipv4Address: CIDRv4?,
+        ipv4Gateway: IPv4Address?,
         ipv6Address: CIDRv6?,
         macAddress: MACAddress?,
         mtu: UInt32? = nil
@@ -72,16 +74,12 @@ public struct Attachment: Codable, Sendable {
 
         network = try container.decode(String.self, forKey: .network)
         hostname = try container.decode(String.self, forKey: .hostname)
-        if let address = try? container.decode(CIDRv4.self, forKey: .ipv4Address) {
-            ipv4Address = address
-        } else {
-            ipv4Address = try container.decode(CIDRv4.self, forKey: .address)
-        }
-        if let gateway = try? container.decode(IPv4Address.self, forKey: .ipv4Gateway) {
-            ipv4Gateway = gateway
-        } else {
-            ipv4Gateway = try container.decode(IPv4Address.self, forKey: .gateway)
-        }
+        ipv4Address =
+            try container.decodeIfPresent(CIDRv4.self, forKey: .ipv4Address)
+            ?? container.decodeIfPresent(CIDRv4.self, forKey: .address)
+        ipv4Gateway =
+            try container.decodeIfPresent(IPv4Address.self, forKey: .ipv4Gateway)
+            ?? container.decodeIfPresent(IPv4Address.self, forKey: .gateway)
         ipv6Address = try container.decodeIfPresent(CIDRv6.self, forKey: .ipv6Address)
         macAddress = try container.decodeIfPresent(MACAddress.self, forKey: .macAddress)
         mtu = try container.decodeIfPresent(UInt32.self, forKey: .mtu)
@@ -93,8 +91,8 @@ public struct Attachment: Codable, Sendable {
 
         try container.encode(network, forKey: .network)
         try container.encode(hostname, forKey: .hostname)
-        try container.encode(ipv4Address, forKey: .ipv4Address)
-        try container.encode(ipv4Gateway, forKey: .ipv4Gateway)
+        try container.encodeIfPresent(ipv4Address, forKey: .ipv4Address)
+        try container.encodeIfPresent(ipv4Gateway, forKey: .ipv4Gateway)
         try container.encodeIfPresent(ipv6Address, forKey: .ipv6Address)
         try container.encodeIfPresent(macAddress, forKey: .macAddress)
         try container.encodeIfPresent(mtu, forKey: .mtu)

--- a/Sources/ContainerResource/Network/NetworkConfiguration.swift
+++ b/Sources/ContainerResource/Network/NetworkConfiguration.swift
@@ -54,6 +54,9 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
     /// to be proliferated to most users when they update container.
     public let pluginInfo: NetworkPluginInfo?
 
+    /// The host network interface to bridge to. Only set when mode == .bridge.
+    public let hostInterface: String?
+
     /// Creates a network configuration
     public init(
         id: String,
@@ -61,7 +64,8 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
         ipv4Subnet: CIDRv4? = nil,
         ipv6Subnet: CIDRv6? = nil,
         labels: ResourceLabels = .init(),
-        pluginInfo: NetworkPluginInfo?
+        pluginInfo: NetworkPluginInfo?,
+        hostInterface: String? = nil
     ) throws {
         self.id = id
         self.creationDate = Date()
@@ -70,6 +74,7 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
         self.ipv6Subnet = ipv6Subnet
         self.labels = labels
         self.pluginInfo = pluginInfo
+        self.hostInterface = hostInterface
         try validate()
     }
 
@@ -81,6 +86,7 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
         case ipv6Subnet
         case labels
         case pluginInfo
+        case hostInterface
         // TODO: retain for deserialization compatibility for now, remove later
         case subnet
     }
@@ -102,6 +108,7 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
         let decodedLabels = try container.decodeIfPresent([String: String].self, forKey: .labels) ?? [:]
         labels = try .init(decodedLabels)
         pluginInfo = try container.decodeIfPresent(NetworkPluginInfo.self, forKey: .pluginInfo)
+        hostInterface = try container.decodeIfPresent(String.self, forKey: .hostInterface)
         try validate()
     }
 
@@ -116,6 +123,7 @@ public struct NetworkConfiguration: Codable, Sendable, Identifiable {
         try container.encodeIfPresent(ipv6Subnet, forKey: .ipv6Subnet)
         try container.encode(labels, forKey: .labels)
         try container.encodeIfPresent(pluginInfo, forKey: .pluginInfo)
+        try container.encodeIfPresent(hostInterface, forKey: .hostInterface)
     }
 
     private func validate() throws {

--- a/Sources/ContainerResource/Network/NetworkMode.swift
+++ b/Sources/ContainerResource/Network/NetworkMode.swift
@@ -24,6 +24,11 @@ public enum NetworkMode: String, Codable, Sendable {
     /// Host only networking mode
     /// Containers can talk with each other in the same subnet only.
     case hostOnly = "hostOnly"
+
+    /// Bridge networking mode.
+    /// Containers attach directly to a host physical interface and receive IPs
+    /// from the upstream DHCP server on that network.
+    case bridge = "bridge"
 }
 
 extension NetworkMode {
@@ -35,6 +40,7 @@ extension NetworkMode {
         switch value.lowercased() {
         case "nat": self = .nat
         case "hostOnly": self = .hostOnly
+        case "bridge": self = .bridge
         default: return nil
         }
     }

--- a/Sources/Plugins/NetworkVmnet/NetworkVmnetHelper+Start.swift
+++ b/Sources/Plugins/NetworkVmnet/NetworkVmnetHelper+Start.swift
@@ -29,6 +29,7 @@ import Logging
 enum Variant: String, ExpressibleByArgument {
     case reserved
     case allocationOnly
+    case bridged
 }
 
 extension NetworkMode: ExpressibleByArgument {}
@@ -66,6 +67,9 @@ extension NetworkVmnetHelper {
             return .reserved
         }()
 
+        @Option(name: .long, help: "Host network interface to bridge to (bridged variant only)")
+        var hostInterface: String?
+
         var logRoot = LogRoot.path
 
         func run() async throws {
@@ -91,7 +95,8 @@ extension NetworkVmnetHelper {
                     mode: mode,
                     ipv4Subnet: ipv4Subnet,
                     ipv6Subnet: ipv6Subnet,
-                    pluginInfo: pluginInfo
+                    pluginInfo: pluginInfo,
+                    hostInterface: hostInterface
                 )
                 let network = try Self.createNetwork(
                     configuration: configuration,
@@ -137,6 +142,8 @@ extension NetworkVmnetHelper {
                     )
                 }
                 return try ReservedVmnetNetwork(configuration: configuration, log: log)
+            case .bridged:
+                return try BridgedVmnetNetwork(configuration: configuration, log: log)
             }
         }
     }

--- a/Sources/Plugins/RuntimeLinux/BridgedInterfaceStrategy.swift
+++ b/Sources/Plugins/RuntimeLinux/BridgedInterfaceStrategy.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerNetworkServiceClient
+import ContainerResource
+import ContainerSandboxService
+import ContainerXPC
+import Containerization
+import ContainerizationError
+
+@available(macOS 26, *)
+struct BridgedInterfaceStrategy: InterfaceStrategy {
+    func toInterface(attachment: Attachment, interfaceIndex: Int, additionalData: XPCMessage?) throws -> Interface {
+        guard let additionalData,
+            let ifaceName = additionalData.string(key: NetworkKeys.hostInterface.rawValue)
+        else {
+            throw ContainerizationError(.invalidState, message: "bridge network missing host interface name")
+        }
+        return BridgedNetworkInterface(hostInterfaceName: ifaceName, macAddress: attachment.macAddress)
+    }
+}

--- a/Sources/Plugins/RuntimeLinux/IsolatedInterfaceStrategy.swift
+++ b/Sources/Plugins/RuntimeLinux/IsolatedInterfaceStrategy.swift
@@ -18,15 +18,19 @@ import ContainerResource
 import ContainerSandboxService
 import ContainerXPC
 import Containerization
+import ContainerizationError
 
 /// Isolated container network interface strategy. This strategy prohibits
 /// container to container networking, but it is the only approach that
 /// works for macOS Sequoia.
 struct IsolatedInterfaceStrategy: InterfaceStrategy {
-    public func toInterface(attachment: Attachment, interfaceIndex: Int, additionalData: XPCMessage?) -> Interface {
+    public func toInterface(attachment: Attachment, interfaceIndex: Int, additionalData: XPCMessage?) throws -> Interface {
+        guard let ipv4Address = attachment.ipv4Address else {
+            throw ContainerizationError(.invalidState, message: "NAT attachment missing IPv4 address")
+        }
         let ipv4Gateway = interfaceIndex == 0 ? attachment.ipv4Gateway : nil
         return NATInterface(
-            ipv4Address: attachment.ipv4Address,
+            ipv4Address: ipv4Address,
             ipv4Gateway: ipv4Gateway,
             macAddress: attachment.macAddress,
             // https://github.com/apple/containerization/pull/38

--- a/Sources/Plugins/RuntimeLinux/NonisolatedInterfaceStrategy.swift
+++ b/Sources/Plugins/RuntimeLinux/NonisolatedInterfaceStrategy.swift
@@ -42,10 +42,13 @@ struct NonisolatedInterfaceStrategy: InterfaceStrategy {
             throw ContainerizationError(.invalidState, message: "cannot deserialize custom network reference, status \(status)")
         }
 
+        guard let ipv4Address = attachment.ipv4Address else {
+            throw ContainerizationError(.invalidState, message: "NAT attachment missing IPv4 address")
+        }
         log.info("creating NATNetworkInterface with network reference")
         let ipv4Gateway = interfaceIndex == 0 ? attachment.ipv4Gateway : nil
         return NATNetworkInterface(
-            ipv4Address: attachment.ipv4Address,
+            ipv4Address: ipv4Address,
             ipv4Gateway: ipv4Gateway,
             reference: networkRef,
             macAddress: attachment.macAddress,

--- a/Sources/Plugins/RuntimeLinux/RuntimeLinuxHelper+Start.swift
+++ b/Sources/Plugins/RuntimeLinux/RuntimeLinuxHelper+Start.swift
@@ -68,6 +68,7 @@ extension RuntimeLinuxHelper {
                     NetworkPluginInfo(plugin: "container-network-vmnet", variant: "allocationOnly"): IsolatedInterfaceStrategy()
                 ]
                 if #available(macOS 26, *) {
+                    interfaceStrategies[NetworkPluginInfo(plugin: "container-network-vmnet", variant: "bridged")] = BridgedInterfaceStrategy()
                     interfaceStrategies[NetworkPluginInfo(plugin: "container-network-vmnet", variant: "reserved")] = NonisolatedInterfaceStrategy(log: log)
                 }
 

--- a/Sources/Services/ContainerAPIService/Server/Networks/NetworksService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Networks/NetworksService.swift
@@ -100,7 +100,8 @@ public actor NetworksService {
                     ipv4Subnet: configuration.ipv4Subnet,
                     ipv6Subnet: configuration.ipv6Subnet,
                     labels: updatedLabels.map { try .init($0) } ?? configuration.labels,
-                    pluginInfo: configuration.pluginInfo ?? NetworkPluginInfo(plugin: "container-network-vmnet")
+                    pluginInfo: configuration.pluginInfo ?? NetworkPluginInfo(plugin: "container-network-vmnet"),
+                    hostInterface: configuration.hostInterface
                 )
                 try await store.update(updatedConfiguration)
 
@@ -138,7 +139,8 @@ public actor NetworksService {
                     ipv4Subnet: configuration.ipv4Subnet,
                     ipv6Subnet: configuration.ipv6Subnet,
                     labels: updatedLabels.map { try .init($0) } ?? configuration.labels,
-                    pluginInfo: helperConfig.pluginInfo
+                    pluginInfo: helperConfig.pluginInfo,
+                    hostInterface: configuration.hostInterface
                 )
                 networkState = NetworkState.created(finalConfiguration)
             case .running(let helperConfig, let status):
@@ -148,7 +150,8 @@ public actor NetworksService {
                     ipv4Subnet: configuration.ipv4Subnet,
                     ipv6Subnet: configuration.ipv6Subnet,
                     labels: updatedLabels.map { try .init($0) } ?? configuration.labels,
-                    pluginInfo: helperConfig.pluginInfo
+                    pluginInfo: helperConfig.pluginInfo,
+                    hostInterface: configuration.hostInterface
                 )
                 networkState = NetworkState.running(finalConfiguration, status)
             }
@@ -237,7 +240,8 @@ public actor NetworksService {
                 ipv4Subnet: configuration.ipv4Subnet,
                 ipv6Subnet: configuration.ipv6Subnet,
                 labels: configuration.labels,
-                pluginInfo: helperConfig.pluginInfo
+                pluginInfo: helperConfig.pluginInfo,
+                hostInterface: configuration.hostInterface
             )
 
             let networkState: NetworkState = .running(finalConfiguration, status)
@@ -410,7 +414,7 @@ public actor NetworksService {
     }
 
     private func registerService(configuration: NetworkConfiguration) async throws {
-        guard configuration.mode == .nat || configuration.mode == .hostOnly else {
+        guard configuration.mode == .nat || configuration.mode == .hostOnly || configuration.mode == .bridge else {
             throw ContainerizationError(.invalidArgument, message: "unsupported network mode \(configuration.mode.rawValue)")
         }
 
@@ -444,7 +448,7 @@ public actor NetworksService {
         if let ipv4Subnet = configuration.ipv4Subnet {
             var existingCidrs: [CIDRv4] = []
             for serviceState in serviceStates.values {
-                if case .running(_, let status) = serviceState.networkState {
+                if case .running(let config, let status) = serviceState.networkState, config.mode != .bridge {
                     existingCidrs.append(status.ipv4Subnet)
                 }
             }
@@ -483,6 +487,10 @@ public actor NetworksService {
 
         if let variant = configuration.pluginInfo?.variant {
             args += ["--variant", variant]
+        }
+
+        if let hostInterface = configuration.hostInterface {
+            args += ["--host-interface", hostInterface]
         }
 
         let entityPath = try store.entityPath(configuration.id)

--- a/Sources/Services/ContainerNetworkService/Client/NetworkKeys.swift
+++ b/Sources/Services/ContainerNetworkService/Client/NetworkKeys.swift
@@ -18,6 +18,7 @@ public enum NetworkKeys: String {
     case additionalData
     case allocatorDisabled
     case attachment
+    case hostInterface
     case hostname
     case macAddress
     case network

--- a/Sources/Services/ContainerNetworkService/Server/BridgedVmnetNetwork.swift
+++ b/Sources/Services/ContainerNetworkService/Server/BridgedVmnetNetwork.swift
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerNetworkServiceClient
+import ContainerResource
+import ContainerXPC
+import ContainerizationError
+import ContainerizationExtras
+import Foundation
+import Logging
+import XPC
+
+public actor BridgedVmnetNetwork: Network {
+    // FIXME: NetworkPluginStatus requires non-optional ipv4Subnet/ipv4Gateway; use placeholder
+    // values until the type is refactored to make them optional.
+    private static let placeholderSubnet = try! CIDRv4("0.0.0.0/0")
+    private static let placeholderGateway = IPv4Address(0)
+
+    private let log: Logger
+    private let hostInterface: String
+    private var _state: NetworkState
+
+    public init(configuration: NetworkConfiguration, log: Logger) throws {
+        guard configuration.mode == .bridge else {
+            throw ContainerizationError(.unsupported, message: "invalid network mode \(configuration.mode)")
+        }
+        guard let hostInterface = configuration.hostInterface else {
+            throw ContainerizationError(.invalidArgument, message: "bridge network requires a host interface name")
+        }
+        self.log = log
+        self.hostInterface = hostInterface
+        self._state = .created(configuration)
+    }
+
+    public var state: NetworkState {
+        self._state
+    }
+
+    public nonisolated func withAdditionalData(_ handler: (XPCMessage?) throws -> Void) throws {
+        let msg = XPCMessage(object: xpc_dictionary_create_empty())
+        msg.set(key: NetworkKeys.hostInterface.rawValue, value: hostInterface)
+        try handler(msg)
+    }
+
+    public func start() async throws {
+        guard case .created(let configuration) = _state else {
+            throw ContainerizationError(.invalidState, message: "cannot start network \(_state.id) in \(_state.state) state")
+        }
+
+        log.info(
+            "starting bridged network",
+            metadata: [
+                "id": "\(configuration.id)",
+                "hostInterface": "\(hostInterface)",
+            ]
+        )
+
+        let status = NetworkPluginStatus(
+            ipv4Subnet: Self.placeholderSubnet,
+            ipv4Gateway: Self.placeholderGateway,
+            ipv6Subnet: nil,
+        )
+        self._state = .running(configuration, status)
+        log.info(
+            "started bridged network",
+            metadata: [
+                "id": "\(configuration.id)",
+                "hostInterface": "\(hostInterface)",
+            ]
+        )
+    }
+}

--- a/Sources/Services/ContainerNetworkService/Server/NetworkService.swift
+++ b/Sources/Services/ContainerNetworkService/Server/NetworkService.swift
@@ -86,8 +86,8 @@ public actor NetworkService: Sendable {
             "allocated attachment",
             metadata: [
                 "hostname": "\(hostname)",
-                "ipv4Address": "\(attachment.ipv4Address)",
-                "ipv4Gateway": "\(attachment.ipv4Gateway)",
+                "ipv4Address": "\(attachment.ipv4Address?.description ?? "none")",
+                "ipv4Gateway": "\(attachment.ipv4Gateway?.description ?? "none")",
                 "ipv6Address": "\(attachment.ipv6Address?.description ?? "unavailable")",
                 "macAddress": "\(attachment.macAddress?.description ?? "unspecified")",
             ])

--- a/Sources/Services/ContainerNetworkService/Server/NetworkService.swift
+++ b/Sources/Services/ContainerNetworkService/Server/NetworkService.swift
@@ -25,8 +25,9 @@ import Logging
 public actor NetworkService: Sendable {
     private let network: any Network
     private let log: Logger
-    private var allocator: AttachmentAllocator
+    private var allocator: AttachmentAllocator?
     private var macAddresses: [UInt32: MACAddress]
+    private let isBridge: Bool
 
     /// Set up a network service for the specified network.
     public init(
@@ -34,14 +35,18 @@ public actor NetworkService: Sendable {
         log: Logger
     ) async throws {
         let state = await network.state
-        guard case .running(_, let status) = state else {
+        guard case .running(let configuration, let status) = state else {
             throw ContainerizationError(.invalidState, message: "invalid network state - network \(state.id) must be running")
         }
 
-        let subnet = status.ipv4Subnet
-
-        let size = Int(subnet.upper.value - subnet.lower.value - 3)
-        self.allocator = try AttachmentAllocator(lower: subnet.lower.value + 2, size: size)
+        self.isBridge = configuration.mode == .bridge
+        if !self.isBridge {
+            let subnet = status.ipv4Subnet
+            let size = Int(subnet.upper.value - subnet.lower.value - 3)
+            self.allocator = try AttachmentAllocator(lower: subnet.lower.value + 2, size: size)
+        } else {
+            self.allocator = nil
+        }
         self.macAddresses = [:]
         self.network = network
         self.log = log
@@ -70,18 +75,33 @@ public actor NetworkService: Sendable {
             try message.string(key: NetworkKeys.macAddress.rawValue)
             .map { try MACAddress($0) }
             ?? MACAddress((UInt64.random(in: 0...UInt64.max) & 0x0cff_ffff_ffff) | 0xf200_0000_0000)
-        let index = try await allocator.allocate(hostname: hostname)
-        let ipv6Address = try status.ipv6Subnet
-            .map { try CIDRv6(macAddress.ipv6Address(network: $0.lower), prefix: $0.prefix) }
-        let ip = IPv4Address(index)
-        let attachment = Attachment(
-            network: state.id,
-            hostname: hostname,
-            ipv4Address: try CIDRv4(ip, prefix: status.ipv4Subnet.prefix),
-            ipv4Gateway: status.ipv4Gateway,
-            ipv6Address: ipv6Address,
-            macAddress: macAddress
-        )
+
+        let attachment: Attachment
+        if isBridge {
+            attachment = Attachment(
+                network: state.id,
+                hostname: hostname,
+                ipv4Address: nil,
+                ipv4Gateway: nil,
+                ipv6Address: nil,
+                macAddress: macAddress
+            )
+        } else {
+            let index = try await allocator!.allocate(hostname: hostname)
+            let ipv6Address = try status.ipv6Subnet
+                .map { try CIDRv6(macAddress.ipv6Address(network: $0.lower), prefix: $0.prefix) }
+            let ip = IPv4Address(index)
+            attachment = Attachment(
+                network: state.id,
+                hostname: hostname,
+                ipv4Address: try CIDRv4(ip, prefix: status.ipv4Subnet.prefix),
+                ipv4Gateway: status.ipv4Gateway,
+                ipv6Address: ipv6Address,
+                macAddress: macAddress
+            )
+            macAddresses[index] = macAddress
+        }
+
         log.info(
             "allocated attachment",
             metadata: [
@@ -98,7 +118,6 @@ public actor NetworkService: Sendable {
                 try reply.setAdditionalData(additionalData.underlying)
             }
         }
-        macAddresses[index] = macAddress
         return reply
     }
 
@@ -108,8 +127,10 @@ public actor NetworkService: Sendable {
         defer { log.debug("exit", metadata: ["func": "\(#function)"]) }
 
         let hostname = try message.hostname()
-        if let index = try await allocator.deallocate(hostname: hostname) {
-            macAddresses.removeValue(forKey: index)
+        if !isBridge {
+            if let index = try await allocator?.deallocate(hostname: hostname) {
+                macAddresses.removeValue(forKey: index)
+            }
         }
         log.info("released attachments", metadata: ["hostname": "\(hostname)"])
         return message.reply()
@@ -120,14 +141,18 @@ public actor NetworkService: Sendable {
         log.debug("enter", metadata: ["func": "\(#function)"])
         defer { log.debug("exit", metadata: ["func": "\(#function)"]) }
 
+        let reply = message.reply()
+        guard !isBridge else {
+            return reply
+        }
+
         let state = await network.state
         guard case .running(_, let status) = state else {
             throw ContainerizationError(.invalidState, message: "invalid network state - network \(state.id) must be running")
         }
 
         let hostname = try message.hostname()
-        let index = try await allocator.lookup(hostname: hostname)
-        let reply = message.reply()
+        let index = try await allocator?.lookup(hostname: hostname)
         guard let index else {
             return reply
         }
@@ -162,7 +187,7 @@ public actor NetworkService: Sendable {
         log.debug("enter", metadata: ["func": "\(#function)"])
         defer { log.debug("exit", metadata: ["func": "\(#function)"]) }
 
-        let success = await allocator.disableAllocator()
+        let success = await allocator?.disableAllocator() ?? true
         log.info("attempted allocator disable", metadata: ["success": "\(success)"])
         let reply = message.reply()
         reply.setAllocatorDisabled(success)

--- a/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
+++ b/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
@@ -241,10 +241,10 @@ public actor SandboxService {
                 // NOTE: We can support a user providing new entries eventually, but for now craft
                 // a default /etc/hosts.
                 var hostsEntries = [Hosts.Entry.localHostIPV4()]
-                if !interfaces.isEmpty, let primaryIfaceAddr = interfaces[0].ipv4Address {
+                if !interfaces.isEmpty, let ipv4Address = interfaces[0].ipv4Address, !ipv4Address.address.isUnspecified {
                     hostsEntries.append(
                         Hosts.Entry(
-                            ipAddress: primaryIfaceAddr.address.description,
+                            ipAddress: ipv4Address.address.description,
                             hostnames: [czConfig.hostname ?? id],
                         ))
                 }

--- a/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
+++ b/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
@@ -161,6 +161,14 @@ public actor SandboxService {
             var kernel = try bundle.kernel
             kernel.commandLine.kernelArgs.append("oops=panic")
             kernel.commandLine.kernelArgs.append("lsm=lockdown,capability,landlock,yama,apparmor")
+
+            let allocatedAttachments = try message.getAllocatedAttachments()
+            for (index, alloc) in allocatedAttachments.enumerated() {
+                if alloc.attachment.ipv4Address == nil {
+                    kernel.commandLine.kernelArgs.append("ip=::::\(alloc.attachment.hostname):eth\(index):dhcp")
+                }
+            }
+
             let vmm = VZVirtualMachineManager(
                 kernel: kernel,
                 initialFilesystem: bundle.initialFilesystem.asMount,
@@ -168,19 +176,16 @@ public actor SandboxService {
                 logger: self.log
             )
 
-            let allocatedAttachments = try message.getAllocatedAttachments()
-
-            // Dynamically configure the DNS nameserver from a network if no explicit configuration
+            // Dynamically configure DNS from a network if no explicit configuration.
+            // For bridge networks (unspecified gateway), nameservers and domain come from DHCP (/proc/net/pnp).
             if let dns = config.dns, dns.nameservers.isEmpty {
                 let defaultNameservers = try await self.getDefaultNameservers(allocatedAttachments: allocatedAttachments)
-                if !defaultNameservers.isEmpty {
-                    config.dns = ContainerConfiguration.DNSConfiguration(
-                        nameservers: defaultNameservers,
-                        domain: dns.domain,
-                        searchDomains: dns.searchDomains,
-                        options: dns.options
-                    )
-                }
+                config.dns = ContainerConfiguration.DNSConfiguration(
+                    nameservers: defaultNameservers.isEmpty ? dns.nameservers : defaultNameservers,
+                    domain: defaultNameservers.isEmpty ? nil : dns.domain,
+                    searchDomains: dns.searchDomains,
+                    options: dns.options
+                )
             }
 
             var attachments: [Attachment] = []
@@ -929,6 +934,9 @@ public actor SandboxService {
         for allocatedAttach in allocatedAttachments {
             let state = try await networkClient.get(id: allocatedAttach.attachment.network)
             guard state.status.phase == "running", let gateway = state.status.ipv4Gateway else {
+                continue
+            }
+            guard !gateway.isUnspecified else {
                 continue
             }
             return [gateway.description]

--- a/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
+++ b/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
@@ -236,8 +236,7 @@ public actor SandboxService {
                 // NOTE: We can support a user providing new entries eventually, but for now craft
                 // a default /etc/hosts.
                 var hostsEntries = [Hosts.Entry.localHostIPV4()]
-                if !interfaces.isEmpty {
-                    let primaryIfaceAddr = interfaces[0].ipv4Address
+                if !interfaces.isEmpty, let primaryIfaceAddr = interfaces[0].ipv4Address {
                     hostsEntries.append(
                         Hosts.Entry(
                             ipAddress: primaryIfaceAddr.address.description,
@@ -761,7 +760,10 @@ public actor SandboxService {
                     let containerIPAddress: String
                     switch publishedPort.hostAddress {
                     case .v4(_):
-                        containerIPAddress = attachment.ipv4Address.address.description
+                        guard let ipv4Address = attachment.ipv4Address else {
+                            throw ContainerizationError(.invalidState, message: "cannot configure IPv4 port forwarding for container with unknown IPv4 address")
+                        }
+                        containerIPAddress = ipv4Address.address.description
                     case .v6(_):
                         guard let ipv6Address = attachment.ipv6Address else {
                             throw ContainerizationError(.invalidState, message: "cannot configure IPv6 port forwarding for container with unknown IPv6 address")

--- a/Tests/CLITests/Subcommands/Networks/TestCLINetwork.swift
+++ b/Tests/CLITests/Subcommands/Networks/TestCLINetwork.swift
@@ -72,7 +72,7 @@ class TestCLINetwork: CLITest {
 
             let container = try inspectContainer(name)
             #expect(container.networks.count > 0)
-            let cidrAddress = container.networks[0].ipv4Address
+            let cidrAddress = try #require(container.networks[0].ipv4Address)
             let url = "http://\(cidrAddress.address):\(port)"
             var request = HTTPClientRequest(url: url)
             request.method = .GET
@@ -244,7 +244,7 @@ class TestCLINetwork: CLITest {
             let container = try inspectContainer(name)
             #expect(container.networks.count > 0)
             let curlImage = "docker.io/curlimages/curl:8.6.0"
-            let cidrAddress = container.networks[0].ipv4Address
+            let cidrAddress = try #require(container.networks[0].ipv4Address)
             let url = "http://\(cidrAddress.address):\(port)"
             let (_, _, _, succeed) = try run(arguments: [
                 "run",

--- a/Tests/CLITests/Subcommands/Run/TestCLIRunCommand.swift
+++ b/Tests/CLITests/Subcommands/Run/TestCLIRunCommand.swift
@@ -610,7 +610,7 @@ class TestCLIRunCommand3: CLITest {
                 .map { $0.joined(separator: " ") }
 
             let inspectOutput = try inspectContainer(name)
-            let ip = inspectOutput.networks[0].ipv4Address.address
+            let ip = try #require(inspectOutput.networks[0].ipv4Address).address
             let expectedNameserver = IPv4Address((ip.value & Prefix(length: 24)!.prefixMask32) + 1).description
             let defaultDomain = try getDefaultDomain()
             let expectedLines: [String] = [
@@ -672,7 +672,7 @@ class TestCLIRunCommand3: CLITest {
             }
 
             let inspectOutput = try inspectContainer(name)
-            let ip = inspectOutput.networks[0].ipv4Address.address
+            let ip = try #require(inspectOutput.networks[0].ipv4Address).address
 
             let output = try doExec(name: name, cmd: ["cat", "/etc/hosts"])
             let lines = output.split(separator: "\n")

--- a/Tests/ContainerResourceTests/AttachmentTest.swift
+++ b/Tests/ContainerResourceTests/AttachmentTest.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import ContainerResource
+
+struct AttachmentTest {
+    @Test func testAttachmentNilIPFields() {
+        let attachment = Attachment(
+            network: "my-net",
+            hostname: "host1",
+            ipv4Address: nil,
+            ipv4Gateway: nil,
+            ipv6Address: nil,
+            macAddress: nil
+        )
+        #expect(attachment.ipv4Address == nil)
+        #expect(attachment.ipv4Gateway == nil)
+    }
+}

--- a/Tests/ContainerResourceTests/NetworkConfigurationTest.swift
+++ b/Tests/ContainerResourceTests/NetworkConfigurationTest.swift
@@ -54,6 +54,15 @@ struct NetworkConfigurationTest {
         }
     }
 
+    @Test func testValidationOkBridgeMode() throws {
+        _ = try NetworkConfiguration(
+            id: "bridge-net",
+            mode: .bridge,
+            pluginInfo: defaultNetworkPluginInfo,
+            hostInterface: "en0"
+        )
+    }
+
     @Test func testValidationBadId() throws {
         let ids = [
             String(repeating: "0", count: 64),

--- a/signing/container-runtime-linux.bridge-mode.entitlements
+++ b/signing/container-runtime-linux.bridge-mode.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.virtualization</key>
 	<true/>
+	<key>com.apple.vm.networking</key>
+	<true/>
 </dict>
 </plist>

--- a/signing/container-runtime-linux.entitlements
+++ b/signing/container-runtime-linux.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.virtualization</key>
 	<true/>
+	<key>com.apple.vm.networking</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Bridged networking can be useful for example for mDNS/Bonjour, LAN-visible services without port forwarding, or simply to have the LAN/router manage the IPs of the containers.

Fixes #489

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs
