### PR TITLE
Allow macOS 15 to list and delete networks

### DIFF
--- a/Sources/APIServer/APIServer+Start.swift
+++ b/Sources/APIServer/APIServer+Start.swift
@@ -324,12 +324,12 @@ extension APIServer {
 
             let harness = NetworksHarness(service: service, log: log)
 
-            // network creation/deletion/list is not supported pre-macOS 26 (refer to AllocationOnlyVmnetNetwork)
+            // network creation is not supported pre-macOS 26 (refer to AllocationOnlyVmnetNetwork)
             if #available(macOS 26, *) {
                 routes[XPCRoute.networkCreate] = harness.create
-                routes[XPCRoute.networkDelete] = harness.delete
-                routes[XPCRoute.networkList] = harness.list
             }
+            routes[XPCRoute.networkList] = harness.list
+            routes[XPCRoute.networkDelete] = harness.delete
 
             return service
         }


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context
A recent change moved the list and delete network XPC calls within an availability check, making them only available on macOS 26. However, there are some code flows that rely on being able to call `list` on the NetworksService, such as [here](https://github.com/apple/container/blob/651811cc090937457956643dd2c454df77eb141b/Sources/Services/ContainerAPIService/Client/Utility.swift#L204). `container` does not officially support macOS 15 and as a result we do not have GitHub action runners for validation on macOS 15. That said, we try to avoid breaking compatibility on macOS 15 as much as possible. This PR allows macOS clients to call `list` and `delete` on networks. 

## Testing
- [x] Tested locally
