### PR TITLE
ImagePush: print image reference to stdout on success

### DIFF
--- a/Sources/ContainerCommands/Image/ImagePush.swift
+++ b/Sources/ContainerCommands/Image/ImagePush.swift
@@ -75,6 +75,7 @@ extension Application {
             progress.start()
             _ = try await image.push(platform: p, scheme: scheme, progressUpdate: progress.handler)
             progress.finish()
+            print(image.reference)
         }
     }
 }


### PR DESCRIPTION
Resolves #1466.

`container image push <ref>` previously produced no standard output on success. Print the fully qualified reference (`image.reference`) after the push completes so callers can pipe the output into subsequent commands.

The issue raised the question: "echo back the supplied reference, or print the fully qualified reference?" — this PR prints `image.reference`, which is the normalized/fully-qualified form (e.g. `docker.io/max-mustermann/scratch/test:latest` from the issue's example), matching the same field that `ImagePull` and the progress bar already use.

This mirrors the existing pattern in `ImageTag.run()`, which prints the resolved target after the tag completes:

```swift
try await existing.tag(new: targetReference)
print(target)
```

Diff: 1 line.