### PR TITLE
Tests/CLITests: drain stdout/stderr concurrently in CLITest.run

### DIFF
--- a/Tests/CLITests/Utilities/CLITest.swift
+++ b/Tests/CLITests/Utilities/CLITest.swift
@@ -165,31 +165,29 @@ class CLITest {
         }
 
         let inputPipe = Pipe()
-        let outputPipe = Pipe()
-        let errorPipe = Pipe()
         process.standardInput = inputPipe
-        process.standardOutput = outputPipe
-        process.standardError = errorPipe
 
-        // Drain stdout and stderr concurrently via readability handlers so the
-        // child process never blocks on `write()` when one of its streams fills
-        // the kernel pipe buffer. Reading stdout to EOF before stderr deadlocks
-        // any process that emits more than a pipe-buffer's worth of stderr.
-        let outputBuffer = Mutex<Data>(Data())
-        let errorBuffer = Mutex<Data>(Data())
         let outputData: Data
         let errorData: Data
         do {
-            outputPipe.fileHandleForReading.readabilityHandler = { handle in
-                let chunk = handle.availableData
-                guard !chunk.isEmpty else { return }
-                outputBuffer.withLock { $0.append(chunk) }
+            // Redirect stdout/stderr to temp files so the child process never
+            // blocks on `write()` when one stream fills the kernel pipe buffer
+            // before the parent drains it (issue #1456).
+            let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer {
+                try? FileManager.default.removeItem(at: tempDir)
             }
-            errorPipe.fileHandleForReading.readabilityHandler = { handle in
-                let chunk = handle.availableData
-                guard !chunk.isEmpty else { return }
-                errorBuffer.withLock { $0.append(chunk) }
-            }
+
+            let stdoutURL = tempDir.appendingPathComponent("stdout")
+            let stderrURL = tempDir.appendingPathComponent("stderr")
+            FileManager.default.createFile(atPath: stdoutURL.path, contents: nil)
+            FileManager.default.createFile(atPath: stderrURL.path, contents: nil)
+
+            let stdoutHandle = try FileHandle(forWritingTo: stdoutURL)
+            let stderrHandle = try FileHandle(forWritingTo: stderrURL)
+            process.standardOutput = stdoutHandle
+            process.standardError = stderrHandle
 
             try process.run()
             if let data = stdin {
@@ -198,23 +196,12 @@ class CLITest {
             inputPipe.fileHandleForWriting.closeFile()
             process.waitUntilExit()
 
-            // Clear handlers and drain any data the kernel buffered after the
-            // last handler invocation but before the process exited.
-            outputPipe.fileHandleForReading.readabilityHandler = nil
-            errorPipe.fileHandleForReading.readabilityHandler = nil
-            let finalOut = outputPipe.fileHandleForReading.readDataToEndOfFile()
-            if !finalOut.isEmpty {
-                outputBuffer.withLock { $0.append(finalOut) }
-            }
-            let finalErr = errorPipe.fileHandleForReading.readDataToEndOfFile()
-            if !finalErr.isEmpty {
-                errorBuffer.withLock { $0.append(finalErr) }
-            }
-            outputData = outputBuffer.withLock { $0 }
-            errorData = errorBuffer.withLock { $0 }
+            try? stdoutHandle.close()
+            try? stderrHandle.close()
+
+            outputData = try Data(contentsOf: stdoutURL)
+            errorData = try Data(contentsOf: stderrURL)
         } catch {
-            outputPipe.fileHandleForReading.readabilityHandler = nil
-            errorPipe.fileHandleForReading.readabilityHandler = nil
             throw CLIError.executionFailed("Failed to run CLI: \(error)")
         }
 

--- a/Tests/CLITests/Utilities/CLITest.swift
+++ b/Tests/CLITests/Utilities/CLITest.swift
@@ -185,7 +185,9 @@ class CLITest {
             FileManager.default.createFile(atPath: stderrURL.path, contents: nil)
 
             let stdoutHandle = try FileHandle(forWritingTo: stdoutURL)
+            defer { try? stdoutHandle.close() }
             let stderrHandle = try FileHandle(forWritingTo: stderrURL)
+            defer { try? stderrHandle.close() }
             process.standardOutput = stdoutHandle
             process.standardError = stderrHandle
 
@@ -195,9 +197,6 @@ class CLITest {
             }
             inputPipe.fileHandleForWriting.closeFile()
             process.waitUntilExit()
-
-            try? stdoutHandle.close()
-            try? stderrHandle.close()
 
             outputData = try Data(contentsOf: stdoutURL)
             errorData = try Data(contentsOf: stderrURL)

--- a/Tests/CLITests/Utilities/CLITest.swift
+++ b/Tests/CLITests/Utilities/CLITest.swift
@@ -171,18 +171,50 @@ class CLITest {
         process.standardOutput = outputPipe
         process.standardError = errorPipe
 
+        // Drain stdout and stderr concurrently via readability handlers so the
+        // child process never blocks on `write()` when one of its streams fills
+        // the kernel pipe buffer. Reading stdout to EOF before stderr deadlocks
+        // any process that emits more than a pipe-buffer's worth of stderr.
+        let outputBuffer = Mutex<Data>(Data())
+        let errorBuffer = Mutex<Data>(Data())
         let outputData: Data
         let errorData: Data
         do {
+            outputPipe.fileHandleForReading.readabilityHandler = { handle in
+                let chunk = handle.availableData
+                guard !chunk.isEmpty else { return }
+                outputBuffer.withLock { $0.append(chunk) }
+            }
+            errorPipe.fileHandleForReading.readabilityHandler = { handle in
+                let chunk = handle.availableData
+                guard !chunk.isEmpty else { return }
+                errorBuffer.withLock { $0.append(chunk) }
+            }
+
             try process.run()
             if let data = stdin {
                 inputPipe.fileHandleForWriting.write(data)
             }
             inputPipe.fileHandleForWriting.closeFile()
-            outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-            errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
             process.waitUntilExit()
+
+            // Clear handlers and drain any data the kernel buffered after the
+            // last handler invocation but before the process exited.
+            outputPipe.fileHandleForReading.readabilityHandler = nil
+            errorPipe.fileHandleForReading.readabilityHandler = nil
+            let finalOut = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            if !finalOut.isEmpty {
+                outputBuffer.withLock { $0.append(finalOut) }
+            }
+            let finalErr = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if !finalErr.isEmpty {
+                errorBuffer.withLock { $0.append(finalErr) }
+            }
+            outputData = outputBuffer.withLock { $0 }
+            errorData = errorBuffer.withLock { $0 }
         } catch {
+            outputPipe.fileHandleForReading.readabilityHandler = nil
+            errorPipe.fileHandleForReading.readabilityHandler = nil
             throw CLIError.executionFailed("Failed to run CLI: \(error)")
         }
 


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

`CLITest.run(arguments:stdin:currentDirectory:env:)` reads stdout to EOF before stderr begins draining (`Tests/CLITests/Utilities/CLITest.swift:182-183`). If a child process writes more than a pipe-buffer's worth of data to stderr (~64 KB on macOS), the child blocks in `write()` on stderr while we block in `readDataToEndOfFile()` on stdout, and neither side makes progress until `process.waitUntilExit()` returns. This is a latent deadlock that any future test or CLI verbosity bump can trigger.

This PR drains both streams concurrently using `readabilityHandler` closures backed by `Mutex<Data>` buffers. After `process.waitUntilExit()` returns the handlers are cleared and `readDataToEndOfFile()` flushes any bytes the kernel buffered between the last handler invocation and exit. The error path also clears handlers so a failed `process.run()` does not leak callbacks. `Mutex` matches the locking primitive the file already uses for `commandSeq`.

Fixes #1456

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

`swift build --target CLITests` passes against the change. `make swift-fmt-check` is clean. Behavior is unchanged for any test command that previously fit within a single pipe buffer, so the existing CLITests still exercise the helper end-to-end.

I did not add a new test that emits >64 KB to stderr because every existing CLITest invocation goes through `executablePath` (the `container` binary), and reproducing the deadlock requires a child that emits a controllable amount on stderr. Happy to follow up with a small refactor that extracts the drain into a static helper plus a regression test that drives it via `/bin/sh` if that would be useful.
