### PR TITLE
Use SystemPath for HostDNSResolver.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -152,6 +152,7 @@ let package = Package(
                 .product(name: "GRPCNIOTransportHTTP2", package: "grpc-swift-nio-transport"),
                 .product(name: "GRPCProtobuf", package: "grpc-swift-protobuf"),
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "SystemPackage", package: "swift-system"),
                 "ContainerAPIService",
                 "ContainerAPIClient",
                 "ContainerLog",
@@ -214,6 +215,7 @@ let package = Package(
             name: "ContainerAPIClientTests",
             dependencies: [
                 .product(name: "Containerization", package: "containerization"),
+                .product(name: "SystemPackage", package: "swift-system"),
                 "ContainerAPIClient",
                 "ContainerPersistence",
             ]

--- a/Sources/APIServer/LocalhostDNSHandler.swift
+++ b/Sources/APIServer/LocalhostDNSHandler.swift
@@ -23,6 +23,7 @@ import DNSServer
 import Foundation
 import Logging
 import Synchronization
+import SystemPackage
 
 actor LocalhostDNSHandler: DNSHandler {
     private let ttl: UInt32
@@ -30,10 +31,10 @@ actor LocalhostDNSHandler: DNSHandler {
 
     private var dns: [DNSName: IPv4Address]
 
-    public init(resolversURL: URL = HostDNSResolver.defaultConfigPath, ttl: UInt32 = 5, log: Logger) {
+    public init(configPath: FilePath = HostDNSResolver.defaultConfigPath, ttl: UInt32 = 5, log: Logger) {
         self.ttl = ttl
 
-        self.watcher = DirectoryWatcher(directoryURL: resolversURL, log: log)
+        self.watcher = DirectoryWatcher(directoryURL: URL(filePath: configPath.string), log: log)
         self.dns = [DNSName: IPv4Address]()
     }
 

--- a/Sources/Services/ContainerAPIService/Client/HostDNSResolver.swift
+++ b/Sources/Services/ContainerAPIService/Client/HostDNSResolver.swift
@@ -51,7 +51,7 @@ public struct HostDNSResolver {
                 throw ContainerizationError(.invalidState, message: "expected \(self.configPath.string) to be a directory, but found a file")
             }
         } else {
-            try fm.createDirectory(atPath: self.configPath.string, withIntermediateDirectories: true, attributes: nil)
+            try fm.createDirectory(atPath: self.configPath.string, withIntermediateDirectories: true)
         }
 
         guard !fm.fileExists(atPath: path.string) else {

--- a/Sources/Services/ContainerAPIService/Client/HostDNSResolver.swift
+++ b/Sources/Services/ContainerAPIService/Client/HostDNSResolver.swift
@@ -18,37 +18,43 @@ import ContainerizationError
 import ContainerizationExtras
 import DNSServer
 import Foundation
+import SystemPackage
 
 /// Functions for managing local DNS domains for containers.
 public struct HostDNSResolver {
-    public static let defaultConfigPath = URL(filePath: "/etc/resolver")
+    public static let defaultConfigPath = FilePath("/etc/resolver")
 
     // prefix used to mark our files as /etc/resolver/{prefix}{domainName}
     public static let containerizationPrefix = "containerization."
     public static let localhostOptionsRegex = #"options localhost:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"#
 
-    private let configURL: URL
+    private let configPath: FilePath
 
-    public init(configURL: URL = Self.defaultConfigPath) {
-        self.configURL = configURL
+    public init(configPath: FilePath = Self.defaultConfigPath) {
+        self.configPath = configPath
     }
 
     /// Creates a DNS resolver configuration file for domain resolved by the application.
     public func createDomain(name: DNSName, localhost: IPAddress? = nil) throws {
         let name = name.pqdn
 
-        let path = self.configURL.appending(path: "\(Self.containerizationPrefix)\(name)").path
+        let resolverFilename = "\(Self.containerizationPrefix)\(name)"
+        guard let component = FilePath.Component(resolverFilename) else {
+            throw ContainerizationError(.invalidState, message: "invalid resolver filename \(resolverFilename)")
+        }
+        let path = self.configPath.appending(component)
         let fm: FileManager = FileManager.default
 
-        if fm.fileExists(atPath: self.configURL.path) {
-            guard let isDir = try self.configURL.resourceValues(forKeys: [.isDirectoryKey]).isDirectory, isDir else {
-                throw ContainerizationError(.invalidState, message: "expected \(self.configURL.path) to be a directory, but found a file")
+        var isDirectory: ObjCBool = false
+        if fm.fileExists(atPath: self.configPath.string, isDirectory: &isDirectory) {
+            guard isDirectory.boolValue else {
+                throw ContainerizationError(.invalidState, message: "expected \(self.configPath.string) to be a directory, but found a file")
             }
         } else {
-            try fm.createDirectory(at: self.configURL, withIntermediateDirectories: true)
+            try fm.createDirectory(atPath: self.configPath.string, withIntermediateDirectories: true, attributes: nil)
         }
 
-        guard !fm.fileExists(atPath: path) else {
+        guard !fm.fileExists(atPath: path.string) else {
             throw ContainerizationError(.exists, message: "domain \(name) already exists")
         }
 
@@ -66,27 +72,31 @@ public struct HostDNSResolver {
             \(options)
             """
 
-        try resolverText.write(toFile: path, atomically: true, encoding: .utf8)
+        try resolverText.write(toFile: path.string, atomically: true, encoding: .utf8)
     }
 
     /// Removes a DNS resolver configuration file for domain resolved by the application.
     public func deleteDomain(name: DNSName) throws -> IPAddress? {
         let name = name.pqdn
 
-        let path = self.configURL.appending(path: "\(Self.containerizationPrefix)\(name)").path
+        let resolverFilename = "\(Self.containerizationPrefix)\(name)"
+        guard let component = FilePath.Component(resolverFilename) else {
+            throw ContainerizationError(.invalidState, message: "invalid resolver filename \(resolverFilename)")
+        }
+        let path = self.configPath.appending(component)
         let fm = FileManager.default
-        guard fm.fileExists(atPath: path) else {
+        guard fm.fileExists(atPath: path.string) else {
             throw ContainerizationError(.notFound, message: "domain \(name) at \(path) not found")
         }
 
         var localhost: IPAddress?
-        let content = try String(contentsOfFile: path, encoding: .utf8)
+        let content = try String(contentsOfFile: path.string, encoding: .utf8)
         if let match = content.firstMatch(of: try Regex(HostDNSResolver.localhostOptionsRegex)) {
             localhost = try? IPAddress(String(match[1].substring ?? ""))
         }
 
         do {
-            try fm.removeItem(atPath: path)
+            try fm.removeItem(atPath: path.string)
         } catch {
             throw ContainerizationError(.invalidState, message: "cannot delete domain (try sudo?)")
         }
@@ -97,19 +107,17 @@ public struct HostDNSResolver {
     /// Lists application-created local DNS domains.
     public func listDomains() -> [DNSName] {
         let fm: FileManager = FileManager.default
-        guard
-            let resolverPaths = try? fm.contentsOfDirectory(
-                at: self.configURL,
-                includingPropertiesForKeys: [.isDirectoryKey]
-            )
-        else {
+        guard let filenames = try? fm.contentsOfDirectory(atPath: self.configPath.string) else {
             return []
         }
 
         return
-            resolverPaths
-            .filter { $0.lastPathComponent.starts(with: Self.containerizationPrefix) }
-            .compactMap { try? getDomainFromResolver(url: $0) }
+            filenames
+            .filter { $0.starts(with: Self.containerizationPrefix) }
+            .compactMap { filename -> DNSName? in
+                guard let component = FilePath.Component(filename) else { return nil }
+                return try? getDomainFromResolver(path: self.configPath.appending(component))
+            }
             .sorted { a, b in a.pqdn < b.pqdn }
     }
 
@@ -133,8 +141,8 @@ public struct HostDNSResolver {
         }
     }
 
-    private func getDomainFromResolver(url: URL) throws -> DNSName? {
-        let text = try String(contentsOf: url, encoding: .utf8)
+    private func getDomainFromResolver(path: FilePath) throws -> DNSName? {
+        let text = try String(contentsOfFile: path.string, encoding: .utf8)
         for line in text.components(separatedBy: .newlines) {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
             let components = trimmed.split(whereSeparator: { $0.isWhitespace })

--- a/Tests/ContainerAPIClientTests/HostDNSResolverTest.swift
+++ b/Tests/ContainerAPIClientTests/HostDNSResolverTest.swift
@@ -18,6 +18,7 @@ import ContainerizationError
 import ContainerizationExtras
 import DNSServer
 import Foundation
+import SystemPackage
 import Testing
 
 @testable import ContainerAPIClient
@@ -32,12 +33,13 @@ struct HostDNSResolverTest {
             appropriateFor: .temporaryDirectory,
             create: true
         )
+        let tempPath = FilePath(tempURL.path)
         defer { try? FileManager.default.removeItem(at: tempURL) }
 
-        let resolver = HostDNSResolver(configURL: tempURL)
+        let resolver = HostDNSResolver(configPath: tempPath)
         try resolver.createDomain(name: try! DNSName("foo.bar"))
-        let resolverConfigURL = tempURL.appending(path: "containerization.foo.bar")
-        let actualText = try String(contentsOf: resolverConfigURL, encoding: .utf8)
+        let resolverConfigPath = tempPath.appending(FilePath.Component("containerization.foo.bar"))
+        let actualText = try String(contentsOfFile: resolverConfigPath.string, encoding: .utf8)
         let expectedText = """
             domain foo.bar
             search foo.bar
@@ -62,9 +64,10 @@ struct HostDNSResolverTest {
             appropriateFor: .temporaryDirectory,
             create: true
         )
+        let tempPath = FilePath(tempURL.path)
         defer { try? FileManager.default.removeItem(at: tempURL) }
 
-        let resolver = HostDNSResolver(configURL: tempURL)
+        let resolver = HostDNSResolver(configPath: tempPath)
         try resolver.createDomain(name: try! DNSName("foo.bar"))
         #expect {
             try resolver.createDomain(name: try! DNSName("foo.bar"))
@@ -85,9 +88,10 @@ struct HostDNSResolverTest {
             appropriateFor: .temporaryDirectory,
             create: true
         )
+        let tempPath = FilePath(tempURL.path)
         defer { try? FileManager.default.removeItem(at: tempURL) }
 
-        let resolver = HostDNSResolver(configURL: tempURL)
+        let resolver = HostDNSResolver(configPath: tempPath)
         try resolver.createDomain(name: try! DNSName("foo.bar"))
         _ = try resolver.deleteDomain(name: try! DNSName("foo.bar"))
 
@@ -109,9 +113,10 @@ struct HostDNSResolverTest {
             appropriateFor: .temporaryDirectory,
             create: true
         )
+        let tempPath = FilePath(tempURL.path)
         defer { try? FileManager.default.removeItem(at: tempURL) }
 
-        let resolver = HostDNSResolver(configURL: tempURL)
+        let resolver = HostDNSResolver(configPath: tempPath)
         try resolver.createDomain(name: try! DNSName("foo.bar"))
         #expect {
             _ = try resolver.deleteDomain(name: try! DNSName("bar.foo"))

--- a/Tests/DNSServerTests/RecordsTests.swift
+++ b/Tests/DNSServerTests/RecordsTests.swift
@@ -48,7 +48,17 @@ struct RecordsTests {
         @Test("DNS name with newline should throw")
         func DNSNameWithNewLine() throws {
             #expect(throws: DNSBindError.self) {
-                _ = try DNSName("foo.com\n")
+                _ = try DNSName("foo.com\npwned")
+            }
+        }
+
+        @Test("DNS name with newline should throw")
+        func DNSNameWithPathTraversal() throws {
+            #expect(throws: DNSBindError.self) {
+                _ = try DNSName("../pwned")
+            }
+            #expect(throws: DNSBindError.self) {
+                _ = try DNSName("myhost./../../pwned")
             }
         }
 


### PR DESCRIPTION
- Closes #1479.
- Using URL for filesystem paths is bad practice. FilePath is safer and more ergonomic.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
See above

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs
