### PR TITLE
Sort networks by ID in API server `list()`.

### DIFF
--- a/Sources/Services/ContainerAPIService/Server/Networks/NetworksService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Networks/NetworksService.swift
@@ -179,6 +179,7 @@ public actor NetworksService {
         return serviceStates.reduce(into: [NetworkState]()) {
             $0.append($1.value.networkState)
         }
+        .sorted { $0.id < $1.id }
     }
 
     /// Create a new network from the provided configuration.

--- a/Tests/CLITests/Subcommands/Networks/TestCLINetwork.swift
+++ b/Tests/CLITests/Subcommands/Networks/TestCLINetwork.swift
@@ -50,6 +50,16 @@ class TestCLINetwork: CLITest {
             defer {
                 _ = try? run(arguments: networkDeleteArgs)
             }
+
+            let listResult = try? run(arguments: ["network", "ls", "--quiet"])
+            let networkIds =
+                listResult?.output
+                .components(separatedBy: .newlines)
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter({ !$0.isEmpty })
+                ?? ["OUTPUT MISSING"]
+            #expect(networkIds == networkIds.sorted(), "network IDs should be sorted")
+
             let port = UInt16.random(in: 50000..<60000)
             try doLongRun(
                 name: name,


### PR DESCRIPTION
- Closes #1483.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Consistent well-defined behavior for server APIs.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs
