### PR TITLE
Improve integration test speed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,8 +166,6 @@ LLVM_COV_IGNORE := \
 	--ignore-filename-regex=".pb.swift" \
 	--ignore-filename-regex=".proto" \
 	--ignore-filename-regex=".grpc.swift"
-# swift test overwrites profraw data on each invocation, so we copy to a safe spot
-SAVE_PROFRAW = mkdir -p $(COVERAGE_OUTPUT_DIR)/integration/$(1) && cp $(COV_DATA_DIR)/*.profraw $(COVERAGE_OUTPUT_DIR)/integration/$(1)/
 
 # Generate JSON + HTML coverage reports and a coverage-percent.txt from a profdata file.
 # $(1) = profdata path, $(2) = tier name (unit/integration/combined)
@@ -215,6 +213,10 @@ INTEGRATION_TEST_SUITES := \
 	TestCLINotFound \
 	TestCLINoParallelCases
 
+empty :=
+space := $(empty) $(empty)
+INTEGRATION_FILTER := $(subst $(space),|,$(strip $(INTEGRATION_TEST_SUITES)))
+
 .PHONY: coverage
 # Merge the raw coverage data generated from coverage-unit and coverage-integration into one unified report
 coverage: coverage-unit coverage-integration
@@ -249,17 +251,16 @@ coverage-integration: all
 	@bin/container --debug system start --timeout 60 $(SYSTEM_START_OPTS) && \
 	echo "Starting CLI integration tests with coverage" && \
 	{ \
-		exit_code=0; \
 		export CLITEST_LOG_ROOT=$(LOG_ROOT) ; \
-		$(foreach suite,$(INTEGRATION_TEST_SUITES), \
-			$(SWIFT) test --no-parallel --enable-code-coverage -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter $(suite) || exit_code=1 ; $(call SAVE_PROFRAW,$(suite)) ; \
-		) \
+		$(SWIFT) test --enable-code-coverage -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter "$(INTEGRATION_FILTER)" ; \
+		exit_code=$$? ; \
+		cp $(COV_DATA_DIR)/*.profraw $(COVERAGE_OUTPUT_DIR)/integration/ ; \
 		echo Ensuring apiserver stopped after the coverage integration tests ; \
 		scripts/ensure-container-stopped.sh ; \
 		exit $${exit_code} ; \
 	}
 	@echo Merging integration coverage profdata...
-	@xcrun llvm-profdata merge -sparse $(COVERAGE_OUTPUT_DIR)/integration/*/*.profraw -o $(COVERAGE_OUTPUT_DIR)/integration/default.profdata
+	@xcrun llvm-profdata merge -sparse $(COVERAGE_OUTPUT_DIR)/integration/*.profraw -o $(COVERAGE_OUTPUT_DIR)/integration/default.profdata
 	$(call GENERATE_COV_REPORTS,$(COVERAGE_OUTPUT_DIR)/integration/default.profdata,integration)
 
 .PHONY: integration
@@ -275,11 +276,9 @@ integration: init-block
 	@bin/container --debug system start --timeout 60 --enable-kernel-install $(SYSTEM_START_OPTS) && \
 	echo "Starting CLI integration tests" && \
 	{ \
-		exit_code=0; \
 		CLITEST_LOG_ROOT=$(LOG_ROOT) && export CLITEST_LOG_ROOT ; \
-		$(foreach suite,$(INTEGRATION_TEST_SUITES), \
-			$(SWIFT) test -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter $(suite) || exit_code=1 ; \
-		) \
+		$(SWIFT) test -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter "$(INTEGRATION_FILTER)" ; \
+		exit_code=$$? ; \
 		echo Ensuring apiserver stopped after the CLI integration tests ; \
 		scripts/ensure-container-stopped.sh ; \
 		exit $${exit_code} ; \

--- a/Tests/CLITests/Subcommands/Build/CLIBuildBase.swift
+++ b/Tests/CLITests/Subcommands/Build/CLIBuildBase.swift
@@ -23,7 +23,7 @@ import Testing
 // for these tests are nested in extensions of CLIBuildBase so that we can set
 // the serialized parallelization attribute across all builder tests.
 */
-@Suite(.serialized)
+@Suite(.serialSuites, .serialized)
 class TestCLIBuildBase: CLITest {
     override init() throws {
         try super.init()

--- a/Tests/CLITests/Subcommands/Build/CLIRunBase.swift
+++ b/Tests/CLITests/Subcommands/Build/CLIRunBase.swift
@@ -18,6 +18,7 @@ import ContainerizationOS
 import Foundation
 import Testing
 
+@Suite(.serialSuites)
 class TestCLIRunBase: CLITest {
     var terminal: Terminal!
     var containerName: String = UUID().uuidString

--- a/Tests/CLITests/Subcommands/Containers/TestCLICreate.swift
+++ b/Tests/CLITests/Subcommands/Containers/TestCLICreate.swift
@@ -18,6 +18,7 @@ import ContainerizationExtras
 import Foundation
 import Testing
 
+@Suite(.serialSuites)
 class TestCLICreateCommand: CLITest {
     private func getTestName() -> String {
         Test.current!.name.trimmingCharacters(in: ["(", ")"]).lowercased()

--- a/Tests/CLITests/Subcommands/Containers/TestCLIExec.swift
+++ b/Tests/CLITests/Subcommands/Containers/TestCLIExec.swift
@@ -17,6 +17,7 @@
 import Foundation
 import Testing
 
+@Suite(.serialSuites)
 class TestCLIExecCommand: CLITest {
     private func getTestName() -> String {
         Test.current!.name.trimmingCharacters(in: ["(", ")"]).lowercased()

--- a/Tests/CLITests/Subcommands/Containers/TestCLIExport.swift
+++ b/Tests/CLITests/Subcommands/Containers/TestCLIExport.swift
@@ -18,6 +18,7 @@ import ContainerizationArchive
 import Foundation
 import Testing
 
+@Suite(.serialSuites)
 class TestCLIExportCommand: CLITest {
     private func getTestName() -> String {
         Test.current!.name.trimmingCharacters(in: ["(", ")"]).lowercased()

--- a/Tests/CLITests/Subcommands/Containers/TestCLINotFound.swift
+++ b/Tests/CLITests/Subcommands/Containers/TestCLINotFound.swift
@@ -18,6 +18,7 @@ import Foundation
 import Testing
 
 /// Tests that stop, kill, and delete return errors for non-existent containers.
+@Suite(.serialSuites)
 class TestCLINotFound: CLITest {
 
     @Test func testStopNonExistentContainer() throws {

--- a/Tests/CLITests/Subcommands/Containers/TestCLIPrune.swift
+++ b/Tests/CLITests/Subcommands/Containers/TestCLIPrune.swift
@@ -17,7 +17,7 @@
 import Foundation
 import Testing
 
-@Suite(.serialized)
+@Suite(.serialSuites, .serialized)
 class TestCLIPruneCommand: CLITest {
     private func getTestName() -> String {
         Test.current!.name.trimmingCharacters(in: ["(", ")"]).lowercased()

--- a/Tests/CLITests/Subcommands/Containers/TestCLIStats.swift
+++ b/Tests/CLITests/Subcommands/Containers/TestCLIStats.swift
@@ -18,6 +18,7 @@ import ContainerResource
 import Foundation
 import Testing
 
+@Suite(.serialSuites)
 class TestCLIStatsCommand: CLITest {
     private func getTestName() -> String {
         Test.current!.name.trimmingCharacters(in: ["(", ")"]).lowercased()

--- a/Tests/CLITests/Subcommands/Images/TestCLIImagesCommand.swift
+++ b/Tests/CLITests/Subcommands/Images/TestCLIImagesCommand.swift
@@ -20,6 +20,7 @@ import ContainerizationOCI
 import Foundation
 import Testing
 
+@Suite(.serialSuites)
 class TestCLIImagesCommand: CLITest {
     @Test func testPull() throws {
         do {

--- a/Tests/CLITests/Subcommands/Networks/TestCLINetwork.swift
+++ b/Tests/CLITests/Subcommands/Networks/TestCLINetwork.swift
@@ -22,7 +22,7 @@ import ContainerizationOS
 import Foundation
 import Testing
 
-@Suite(.serialized)
+@Suite(.serialSuites, .serialized)
 class TestCLINetwork: CLITest {
     private static let retries = 10
     private static let retryDelaySeconds = Int64(3)

--- a/Tests/CLITests/Subcommands/Registry/TestCLIRegistry.swift
+++ b/Tests/CLITests/Subcommands/Registry/TestCLIRegistry.swift
@@ -17,6 +17,7 @@
 import Foundation
 import Testing
 
+@Suite(.serialSuites)
 class TestCLIRegistry: CLITest {
     @Test func testListDefaultFormat() throws {
         let (_, output, error, status) = try run(arguments: ["registry", "list"])

--- a/Tests/CLITests/Subcommands/Run/TestCLIRunCapabilities.swift
+++ b/Tests/CLITests/Subcommands/Run/TestCLIRunCapabilities.swift
@@ -18,6 +18,7 @@ import ContainerAPIClient
 import Foundation
 import Testing
 
+@Suite(.serialSuites)
 class TestCLIRunCapabilities: CLITest {
     func getTestName() -> String {
         Test.current!.name.trimmingCharacters(in: ["(", ")"]).lowercased()

--- a/Tests/CLITests/Subcommands/Run/TestCLIRunCommand.swift
+++ b/Tests/CLITests/Subcommands/Run/TestCLIRunCommand.swift
@@ -28,6 +28,7 @@ import Testing
 // When https://github.com/swiftlang/swift-testing/pull/1390 lands
 // and is available on the CI runners, we can try setting the
 // environment variable to limit concurrency and rejoin these suites.
+@Suite(.serialSuites)
 class TestCLIRunCommand1: CLITest {
     func getTestName() -> String {
         Test.current!.name.trimmingCharacters(in: ["(", ")"]).lowercased()
@@ -295,6 +296,7 @@ class TestCLIRunCommand1: CLITest {
     }
 }
 
+@Suite(.serialSuites)
 class TestCLIRunCommand2: CLITest {
     func getTestName() -> String {
         Test.current!.name.trimmingCharacters(in: ["(", ")"]).lowercased()
@@ -563,6 +565,7 @@ class TestCLIRunCommand2: CLITest {
     }
 }
 
+@Suite(.serialSuites)
 class TestCLIRunCommand3: CLITest {
     func getTestName() -> String {
         Test.current!.name.trimmingCharacters(in: ["(", ")"]).lowercased()

--- a/Tests/CLITests/Subcommands/Run/TestCLIRunInitImage.swift
+++ b/Tests/CLITests/Subcommands/Run/TestCLIRunInitImage.swift
@@ -26,6 +26,7 @@ import Testing
 /// Note: A full integration test that verifies custom init behavior would require
 /// a pre-built test init image that writes a marker to /dev/kmsg. This can be added
 /// once a test init image is published to the registry.
+@Suite(.serialSuites)
 class TestCLIRunInitImage: CLITest {
     private func getTestName() -> String {
         Test.current!.name.trimmingCharacters(in: ["(", ")"]).lowercased()

--- a/Tests/CLITests/Subcommands/Run/TestCLIRunLifecycle.swift
+++ b/Tests/CLITests/Subcommands/Run/TestCLIRunLifecycle.swift
@@ -19,6 +19,7 @@ import Darwin
 import Foundation
 import Testing
 
+@Suite(.serialSuites)
 class TestCLIRunLifecycle: CLITest {
     private func getTestName() -> String {
         Test.current!.name.trimmingCharacters(in: ["(", ")"]).lowercased()

--- a/Tests/CLITests/Subcommands/System/TestCLIStatus.swift
+++ b/Tests/CLITests/Subcommands/System/TestCLIStatus.swift
@@ -18,6 +18,7 @@ import Foundation
 import Testing
 
 /// Tests for `container system status` output formats and content validation.
+@Suite(.serialSuites)
 final class TestCLIStatus: CLITest {
     struct StatusJSON: Codable {
         let status: String

--- a/Tests/CLITests/Subcommands/System/TestCLIVersion.swift
+++ b/Tests/CLITests/Subcommands/System/TestCLIVersion.swift
@@ -19,6 +19,7 @@ import Testing
 import Yams
 
 /// Tests for `container system version` output formats and build type detection.
+@Suite(.serialSuites)
 final class TestCLIVersion: CLITest {
     struct VersionInfo: Codable {
         let version: String

--- a/Tests/CLITests/Subcommands/System/TestKernelSet.swift
+++ b/Tests/CLITests/Subcommands/System/TestKernelSet.swift
@@ -21,7 +21,7 @@ import Foundation
 import Testing
 
 // This suite is run serialized since each test modifies the global default kernel
-@Suite(.serialized)
+@Suite(.serialSuites, .serialized)
 class TestCLIKernelSet: CLITest {
     let defaultKernelTar = DefaultsStore.get(key: .defaultKernelURL)
     var remoteTar: URL! {

--- a/Tests/CLITests/Subcommands/Volumes/TestCLIAnonymousVolumes.swift
+++ b/Tests/CLITests/Subcommands/Volumes/TestCLIAnonymousVolumes.swift
@@ -18,7 +18,7 @@ import ContainerResource
 import Foundation
 import Testing
 
-@Suite(.serialized)
+@Suite(.serialSuites, .serialized)
 class TestCLIAnonymousVolumes: CLITest {
 
     override init() throws {

--- a/Tests/CLITests/Subcommands/Volumes/TestCLIVolumes.swift
+++ b/Tests/CLITests/Subcommands/Volumes/TestCLIVolumes.swift
@@ -18,7 +18,7 @@ import ContainerAPIClient
 import Foundation
 import Testing
 
-@Suite(.serialized)
+@Suite(.serialSuites, .serialized)
 class TestCLIVolumes: CLITest {
 
     func doVolumeCreate(name: String) throws {

--- a/Tests/CLITests/TestCLIHelp.swift
+++ b/Tests/CLITests/TestCLIHelp.swift
@@ -17,6 +17,7 @@
 import Foundation
 import Testing
 
+@Suite(.serialSuites)
 class TestCLIHelp: CLITest {
     @Test func testHelp() throws {
         let (_, output, error, status) = try run(arguments: ["help"])

--- a/Tests/CLITests/TestCLINoParallelCases.swift
+++ b/Tests/CLITests/TestCLINoParallelCases.swift
@@ -22,7 +22,7 @@ import Foundation
 import Testing
 
 /// Tests that need total control over environment to avoid conflicts.
-@Suite(.serialized)
+@Suite(.serialSuites, .serialized)
 class TestCLINoParallelCases: CLITest {
     func getTestName() -> String {
         Test.current!.name.trimmingCharacters(in: ["(", ")"]).lowercased()

--- a/Tests/CLITests/Utilities/SerialSuiteTrait.swift
+++ b/Tests/CLITests/Utilities/SerialSuiteTrait.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+/// Integration test suites share mutable system state (apiserver, containers, networks, volumes).
+/// Running multiple suites concurrently causes resource conflicts and flaky failures.
+/// This trait gates suite execution so only one suite runs at a time, while tests within
+/// each suite still run in parallel.
+struct SerialSuiteTrait: SuiteTrait, TestScoping {
+    var isRecursive: Bool { false }
+
+    func provideScope(
+        for test: Test,
+        testCase: Test.Case?,
+        performing function: @Sendable () async throws -> Void
+    ) async throws {
+        await SuiteGate.shared.enter()
+        do {
+            try await function()
+        } catch {
+            await SuiteGate.shared.leave()
+            throw error
+        }
+        await SuiteGate.shared.leave()
+    }
+}
+
+extension Trait where Self == SerialSuiteTrait {
+    static var serialSuites: Self { Self() }
+}

--- a/Tests/CLITests/Utilities/SuiteGate.swift
+++ b/Tests/CLITests/Utilities/SuiteGate.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// Async semaphore with capacity 1. Used by SerialSuiteTrait to ensure only one
+/// integration test suite executes at a time.
+actor SuiteGate {
+    static let shared = SuiteGate()
+
+    private var isOccupied = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func enter() async {
+        if !isOccupied {
+            isOccupied = true
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    // Must remain synchronous (non-async body). This guarantees the call
+    // completes even if the calling task is cancelled, because actor hops
+    // for synchronous methods are not cancellation points.
+    func leave() {
+        if let next = waiters.first {
+            waiters.removeFirst()
+            next.resume()
+        } else {
+            isOccupied = false
+        }
+    }
+}

--- a/Tests/CLITests/Utilities/SuiteGateTests.swift
+++ b/Tests/CLITests/Utilities/SuiteGateTests.swift
@@ -1,0 +1,139 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+/// Helper actor that tracks how many callers are active simultaneously.
+actor ConcurrencyTracker {
+    private var current = 0
+    private var peak = 0
+
+    func enterAndGetCount() -> Int {
+        current += 1
+        if current > peak { peak = current }
+        return current
+    }
+
+    func leave() {
+        current -= 1
+    }
+
+    func peakConcurrency() -> Int {
+        peak
+    }
+}
+
+/// Async countdown latch. N callers suspend on arriveAndWait(); the Nth arrival
+/// resumes them all simultaneously, proving they were running concurrently.
+actor Barrier {
+    private let count: Int
+    private var arrived = 0
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(count: Int) {
+        self.count = count
+    }
+
+    func arriveAndWait() async {
+        arrived += 1
+        if arrived >= count {
+            for waiter in waiters {
+                waiter.resume()
+            }
+            waiters.removeAll()
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+}
+
+/// Helper actor that records the order in which tasks complete.
+private actor CompletionRecorder {
+    private var order: [Int] = []
+
+    func record(_ id: Int) {
+        order.append(id)
+    }
+
+    func completedCount() -> Int {
+        order.count
+    }
+}
+
+@Suite struct SuiteGateTests {
+    @Test func mutualExclusion() async {
+        let gate = SuiteGate()
+        let tracker = ConcurrencyTracker()
+        let barrier = Barrier(count: 5)
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<5 {
+                group.addTask {
+                    // Barrier ensures all 5 tasks are live before any enters the gate
+                    await barrier.arriveAndWait()
+                    await gate.enter()
+                    let count = await tracker.enterAndGetCount()
+                    #expect(count == 1, "Only 1 task should be inside the gate at a time")
+                    await tracker.leave()
+                    await gate.leave()
+                }
+            }
+        }
+    }
+
+    @Test func multipleWaiters() async {
+        let gate = SuiteGate()
+        let recorder = CompletionRecorder()
+        let barrier = Barrier(count: 3)
+
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<3 {
+                group.addTask {
+                    await barrier.arriveAndWait()
+                    await gate.enter()
+                    await recorder.record(i)
+                    await gate.leave()
+                }
+            }
+        }
+
+        let count = await recorder.completedCount()
+        #expect(count == 3, "All 3 tasks should have completed")
+    }
+}
+
+/// Verifies that tests within a `.serialSuites`-annotated suite still run in parallel.
+/// All 3 tests rendezvous at a shared barrier. If they run concurrently, the barrier
+/// opens and tests pass instantly. If serialized, the first test deadlocks waiting for
+/// the others and the time limit fails the suite.
+@Suite(.serialSuites, .timeLimit(.minutes(1)))
+struct InnerParallelismTests {
+    static let barrier = Barrier(count: 3)
+
+    @Test func parallelA() async {
+        await Self.barrier.arriveAndWait()
+    }
+
+    @Test func parallelB() async {
+        await Self.barrier.arriveAndWait()
+    }
+
+    @Test func parallelC() async {
+        await Self.barrier.arriveAndWait()
+    }
+}


### PR DESCRIPTION
This improves the integration test suite speed by running all integration tests in a single `swift test` invocation. We maintain the one `@Suite` at a time behavior by introducing a new test trait that uses a single mutex to limit inter-suite parallelism.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
This is meant to improve the CI/CD experience by reducing execution time.

## Testing
- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
