### PR TITLE
Add app bundle support to APIServer plugin loader

### DIFF
--- a/Sources/APIServer/APIServer+Start.swift
+++ b/Sources/APIServer/APIServer+Start.swift
@@ -184,6 +184,9 @@ extension APIServer {
             _ = FileManager.default.fileExists(atPath: pluginsURL.path, isDirectory: &directoryExists)
             let userPluginsURL = directoryExists.boolValue ? pluginsURL : nil
 
+            // plugins built into the application installed as a macOS app bundle
+            let appBundlePluginsURL = Bundle.main.resourceURL?.appending(path: "plugins")
+
             // plugins built into the application installed as a Unix-like application
             let installRootPluginsURL =
                 installRoot
@@ -194,6 +197,7 @@ extension APIServer {
 
             let pluginDirectories = [
                 userPluginsURL,
+                appBundlePluginsURL,
                 installRootPluginsURL,
             ].compactMap { $0 }
 


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context
Other locations in the code, including the CLI commands [here](https://github.com/apple/container/blob/1ee2d9d05429008bd98809d7cbfe1e0293248bfc/Sources/ContainerCommands/Application.swift#L160), additionally support loading plugins from a macOS bundle. This PR adds that support to the APIServer's PluginLoader as well for consistency. 

## Testing
- [x] Tested locally
