### PR TITLE
De-duplicate building during testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,9 +217,14 @@ empty :=
 space := $(empty) $(empty)
 INTEGRATION_FILTER := $(subst $(space),|,$(strip $(INTEGRATION_TEST_SUITES)))
 
+.PHONY: coverage-build
+coverage-build:
+	@echo Building tests with coverage instrumentation...
+	@$(SWIFT) build --build-tests --enable-code-coverage -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION)
+
 .PHONY: coverage
 # Merge the raw coverage data generated from coverage-unit and coverage-integration into one unified report
-coverage: coverage-unit coverage-integration
+coverage: coverage-build coverage-unit coverage-integration
 	@echo Merging combined coverage profdata...
 	@mkdir -p $(COVERAGE_OUTPUT_DIR)/combined
 	@xcrun llvm-profdata merge -sparse \
@@ -233,12 +238,9 @@ coverage-unit:
 	@echo Running unit test coverage...
 	@rm -f $(COV_DATA_DIR)/*.profraw
 	@mkdir -p $(COVERAGE_OUTPUT_DIR)/unit
-# Run the test suite with profiler (exclude integration tests)
-	@$(SWIFT) test --enable-code-coverage -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --skip TestCLI
-# Move the profiling data to a staging area for later consumption in full coverage aggregation
+	@$(SWIFT) test --skip-build --enable-code-coverage -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --skip TestCLI
 	@echo Merging unit coverage profdata...
 	@xcrun llvm-profdata merge -sparse $(COV_DATA_DIR)/*.profraw -o $(COVERAGE_OUTPUT_DIR)/unit/default.profdata
-# Generate both JSON (for machines) and html (for humans)
 	$(call GENERATE_COV_REPORTS,$(COVERAGE_OUTPUT_DIR)/unit/default.profdata,unit)
 
 .PHONY: coverage-integration
@@ -252,7 +254,7 @@ coverage-integration: all
 	echo "Starting CLI integration tests with coverage" && \
 	{ \
 		export CLITEST_LOG_ROOT=$(LOG_ROOT) ; \
-		$(SWIFT) test --enable-code-coverage -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter "$(INTEGRATION_FILTER)" ; \
+		$(SWIFT) test --skip-build --enable-code-coverage -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter "$(INTEGRATION_FILTER)" ; \
 		exit_code=$$? ; \
 		cp $(COV_DATA_DIR)/*.profraw $(COVERAGE_OUTPUT_DIR)/integration/ ; \
 		echo Ensuring apiserver stopped after the coverage integration tests ; \


### PR DESCRIPTION
This utilizes swift test `--skip-build` in combination with a single big swift test compilation step. By doing this we reduce duplicated swift compilation between unit and integration.

## Type of Change
- [ ] Bug fix
- [X] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Coverage GitHub action is taking too long, so hopefully reducing duplicated work decreases time.

## Testing
- [X] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
