### PR TITLE
Fix inconsistent volume createdAt JSON encoding

### DIFF
--- a/Sources/ContainerCommands/Volume/VolumeList.swift
+++ b/Sources/ContainerCommands/Volume/VolumeList.swift
@@ -43,7 +43,8 @@ extension Application.VolumeCommand {
             let volumes = try await ClientVolume.list()
 
             if format == .json {
-                try Output.emit(Output.renderJSON(volumes))
+                let options = JSONOptions(dateEncodingStrategy: .iso8601)
+                try Output.emit(Output.renderJSON(volumes, options: options))
                 return
             }
 

--- a/Tests/CLITests/Subcommands/Volumes/TestCLIAnonymousVolumes.swift
+++ b/Tests/CLITests/Subcommands/Volumes/TestCLIAnonymousVolumes.swift
@@ -319,7 +319,9 @@ class TestCLIAnonymousVolumes: CLITest {
 
         // Parse JSON to verify metadata
         let data = output.data(using: .utf8)!
-        let volumes = try JSONDecoder().decode([Volume].self, from: data)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let volumes = try decoder.decode([Volume].self, from: data)
 
         let anonVolume = volumes.first { $0.name == volumeName }
         #expect(anonVolume != nil, "should find anonymous volume in list")


### PR DESCRIPTION
- Closes #1533 

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
This PR aligns `volume list --format json` date encoding with volume inspect by using ISO-8601 instead of the default numeric reference-date format.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs
