### PR TITLE
Use FilePath for app, install, and log roots.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -450,13 +450,6 @@ let package = Package(
                 "ContainerPlugin"
             ]
         ),
-        .testTarget(
-            name: "ContainerVersionTests",
-            dependencies: [
-                .product(name: "SystemPackage", package: "swift-system"),
-                "ContainerVersion",
-            ]
-        ),
         .target(
             name: "ContainerXPC",
             dependencies: [
@@ -521,8 +514,16 @@ let package = Package(
         .target(
             name: "ContainerVersion",
             dependencies: [
-                "CVersion"
+                .product(name: "SystemPackage", package: "swift-system"),
+                "CVersion",
             ],
+        ),
+        .testTarget(
+            name: "ContainerVersionTests",
+            dependencies: [
+                .product(name: "SystemPackage", package: "swift-system"),
+                "ContainerVersion",
+            ]
         ),
         .target(
             name: "CVersion",

--- a/Package.swift
+++ b/Package.swift
@@ -450,6 +450,13 @@ let package = Package(
                 "ContainerPlugin"
             ]
         ),
+        .testTarget(
+            name: "ContainerVersionTests",
+            dependencies: [
+                .product(name: "SystemPackage", package: "swift-system"),
+                "ContainerVersion",
+            ]
+        ),
         .target(
             name: "ContainerXPC",
             dependencies: [

--- a/Sources/APIServer/APIServer+Start.swift
+++ b/Sources/APIServer/APIServer+Start.swift
@@ -52,7 +52,7 @@ extension APIServer {
         func run() async throws {
             let containerSystemConfig: ContainerSystemConfig = try await ConfigurationLoader.load()
             let commandName = APIServer._commandName
-            let logPath = logRoot.map { $0.appending("\(commandName).log") }
+            let logPath = logRoot.map { $0.appending(FilePath.Component("\(commandName).log") ?? "unknown") }
             let log = ServiceLogger.bootstrap(category: "APIServer", debug: debug, logPath: logPath)
             log.info("starting helper", metadata: ["name": "\(commandName)"])
             defer {
@@ -318,7 +318,7 @@ extension APIServer {
         ) async throws -> NetworksService {
             log.info("initializing networks service")
 
-            let resourceRoot = appRoot.appending("networks")
+            let resourceRoot = appRoot.appending(FilePath.Component("networks"))
             let service = try await NetworksService(
                 pluginLoader: pluginLoader,
                 resourceRoot: resourceRoot,
@@ -361,7 +361,7 @@ extension APIServer {
         ) throws -> VolumesService {
             log.info("initializing volume service")
 
-            let resourceRoot = appRoot.appending("volumes")
+            let resourceRoot = appRoot.appending(FilePath.Component("volumes"))
             let service = try VolumesService(resourceRoot: resourceRoot, containersService: containersService, log: log)
             let harness = VolumesHarness(service: service, log: log)
 

--- a/Sources/APIServer/APIServer+Start.swift
+++ b/Sources/APIServer/APIServer+Start.swift
@@ -318,7 +318,6 @@ extension APIServer {
         ) async throws -> NetworksService {
             log.info("initializing networks service")
 
-            // TODO: This goes away when we convert our roots to FilePath
             let resourceRoot = appRoot.appending("networks")
             let service = try await NetworksService(
                 pluginLoader: pluginLoader,
@@ -362,7 +361,6 @@ extension APIServer {
         ) throws -> VolumesService {
             log.info("initializing volume service")
 
-            // TODO: This goes away when we convert our roots to FilePath
             let resourceRoot = appRoot.appending("volumes")
             let service = try VolumesService(resourceRoot: resourceRoot, containersService: containersService, log: log)
             let harness = VolumesHarness(service: service, log: log)

--- a/Sources/APIServer/APIServer+Start.swift
+++ b/Sources/APIServer/APIServer+Start.swift
@@ -43,9 +43,9 @@ extension APIServer {
         @Flag(name: .long, help: "Enable debug logging")
         var debug = false
 
-        var appRoot = ApplicationRoot.url
+        var appRoot = ApplicationRoot.path
 
-        var installRoot = InstallRoot.url
+        var installRoot = InstallRoot.path
 
         var logRoot = LogRoot.path
 
@@ -179,22 +179,24 @@ extension APIServer {
             log.info(
                 "initializing plugin loader",
                 metadata: [
-                    "installRoot": "\(installRoot.path(percentEncoded: false))"
+                    "installRoot": "\(installRoot.string)"
                 ])
 
-            let pluginsURL = PluginLoader.userPluginsDir(installRoot: installRoot)
+            // TODO: Remove when we convert PluginLoader to FilePath
+            let installRootURL = URL(fileURLWithPath: installRoot.string)
+            let pluginsURL = PluginLoader.userPluginsDir(installRoot: installRootURL)
             log.info("detecting user plugins directory", metadata: ["path": "\(pluginsURL.path(percentEncoded: false))"])
             var directoryExists: ObjCBool = false
             _ = FileManager.default.fileExists(atPath: pluginsURL.path, isDirectory: &directoryExists)
             let userPluginsURL = directoryExists.boolValue ? pluginsURL : nil
 
             // plugins built into the application installed as a Unix-like application
-            let installRootPluginsURL =
+            let installRootPluginsPath =
                 installRoot
-                .appendingPathComponent("libexec")
-                .appendingPathComponent("container")
-                .appendingPathComponent("plugins")
-                .standardized
+                .appending(FilePath.Component("libexec"))
+                .appending(FilePath.Component("container"))
+                .appending(FilePath.Component("plugins"))
+            let installRootPluginsURL = URL(fileURLWithPath: installRootPluginsPath.string)
 
             let pluginDirectories = [
                 userPluginsURL,
@@ -210,9 +212,10 @@ extension APIServer {
                 log.info("discovered plugin directory", metadata: ["path": "\(pluginDirectory.path(percentEncoded: false))"])
             }
 
+            let appRootURL = URL(fileURLWithPath: appRoot.string)
             return try PluginLoader(
-                appRoot: appRoot,
-                installRoot: installRoot,
+                appRoot: appRootURL,
+                installRoot: installRootURL,
                 logRoot: logRoot,
                 pluginDirectories: pluginDirectories,
                 pluginFactories: pluginFactories,
@@ -245,9 +248,12 @@ extension APIServer {
         private func initializeHealthCheckService(log: Logger, routes: inout [XPCRoute: XPCServer.RouteHandler]) {
             log.info("initializing health check service")
 
+            // TODO: Remove when we convert HealthCheckHarness to FilePath
+            let installRootURL = URL(fileURLWithPath: installRoot.string)
+            let appRootURL = URL(fileURLWithPath: appRoot.string)
             let svc = HealthCheckHarness(
-                appRoot: appRoot,
-                installRoot: installRoot,
+                appRoot: appRootURL,
+                installRoot: installRootURL,
                 logRoot: logRoot,
                 log: log
             )
@@ -257,7 +263,9 @@ extension APIServer {
         private func initializeKernelService(log: Logger, routes: inout [XPCRoute: XPCServer.RouteHandler]) throws {
             log.info("initializing kernel service")
 
-            let svc = try KernelService(log: log, appRoot: appRoot)
+            // TODO: Remove when we convert KernelService to FilePath
+            let appRootURL = URL(fileURLWithPath: appRoot.string)
+            let svc = try KernelService(log: log, appRoot: appRootURL)
             let harness = KernelHarness(service: svc, log: log)
             routes[XPCRoute.installKernel] = XPCServer.route(harness.install)
             routes[XPCRoute.getDefaultKernel] = XPCServer.route(harness.getDefaultKernel)
@@ -271,8 +279,10 @@ extension APIServer {
         ) throws -> ContainersService {
             log.info("initializing containers service")
 
+            // TODO: Remove when we convert ContainersService to FilePath
+            let appRootURL = URL(fileURLWithPath: appRoot.string)
             let service = try ContainersService(
-                appRoot: appRoot,
+                appRoot: appRootURL,
                 pluginLoader: pluginLoader,
                 containerSystemConfig: containerSystemConfig,
                 log: log,
@@ -309,8 +319,7 @@ extension APIServer {
             log.info("initializing networks service")
 
             // TODO: This goes away when we convert our roots to FilePath
-            let appPath = FilePath(appRoot.absolutePath())
-            let resourceRoot = appPath.appending("networks")
+            let resourceRoot = appRoot.appending("networks")
             let service = try await NetworksService(
                 pluginLoader: pluginLoader,
                 resourceRoot: resourceRoot,
@@ -354,8 +363,7 @@ extension APIServer {
             log.info("initializing volume service")
 
             // TODO: This goes away when we convert our roots to FilePath
-            let appPath = FilePath(appRoot.absolutePath())
-            let resourceRoot = appPath.appending("volumes")
+            let resourceRoot = appRoot.appending("volumes")
             let service = try VolumesService(resourceRoot: resourceRoot, containersService: containersService, log: log)
             let harness = VolumesHarness(service: service, log: log)
 

--- a/Sources/ContainerCommands/Application.swift
+++ b/Sources/ContainerCommands/Application.swift
@@ -23,6 +23,7 @@ import ContainerizationError
 import ContainerizationOS
 import Foundation
 import Logging
+import SystemPackage
 import TerminalProgress
 
 // This logger is only used until `asyncCommand.run()`.
@@ -135,11 +136,12 @@ public struct Application: AsyncLoggableCommand {
     }
 
     public static func createPluginLoader() async throws -> PluginLoader {
-        let installRoot = CommandLine.executablePathUrl
-            .deletingLastPathComponent()
-            .appendingPathComponent("..")
-            .standardized
-        let pluginsURL = PluginLoader.userPluginsDir(installRoot: installRoot)
+        let installRootPath = CommandLine.executablePath
+            .removingLastComponent()
+            .removingLastComponent()
+        // TODO: Remove when we convert PluginLoader to FilePath.
+        let installRootURL = URL(fileURLWithPath: installRootPath.string)
+        let pluginsURL = PluginLoader.userPluginsDir(installRoot: installRootURL)
         var directoryExists: ObjCBool = false
         _ = FileManager.default.fileExists(atPath: pluginsURL.path, isDirectory: &directoryExists)
         let userPluginsURL = directoryExists.boolValue ? pluginsURL : nil
@@ -148,13 +150,12 @@ public struct Application: AsyncLoggableCommand {
         let appBundlePluginsURL = Bundle.main.resourceURL?.appending(path: "plugins")
 
         // plugins built into the application installed as a Unix-like application
-        let installRootPluginsURL =
-            installRoot
-            .appendingPathComponent("libexec")
-            .appendingPathComponent("container")
-            .appendingPathComponent("plugins")
-            .standardized
-
+        let installRootPluginsPath =
+            installRootPath
+            .appending(FilePath.Component("libexec"))
+            .appending(FilePath.Component("container"))
+            .appending(FilePath.Component("plugins"))
+        let installRootPluginsURL = URL(fileURLWithPath: installRootPluginsPath.string)
         let pluginDirectories = [
             userPluginsURL,
             appBundlePluginsURL,

--- a/Sources/ContainerCommands/DefaultCommand.swift
+++ b/Sources/ContainerCommands/DefaultCommand.swift
@@ -19,6 +19,7 @@ import ContainerAPIClient
 import ContainerPlugin
 import Darwin
 import Foundation
+import SystemPackage
 
 struct DefaultCommand: AsyncLoggableCommand {
     public static let configuration = CommandConfiguration(
@@ -48,17 +49,19 @@ struct DefaultCommand: AsyncLoggableCommand {
         }
 
         // Compute canonical plugin directories to show in helpful errors (avoid hard-coded paths)
-        let installRoot = CommandLine.executablePathUrl
-            .deletingLastPathComponent()
-            .appendingPathComponent("..")
-            .standardized
-        let userPluginsURL = PluginLoader.userPluginsDir(installRoot: installRoot)
-        let installRootPluginsURL =
+        let installRoot = CommandLine.executablePath
+            .removingLastComponent()
+            .removingLastComponent()
+
+        // TODO: Remove when we convert PluginLoader to FilePath
+        let installRootURL = URL(fileURLWithPath: installRoot.string)
+        let userPluginsURL = PluginLoader.userPluginsDir(installRoot: installRootURL)
+        let installRootPluginsPath =
             installRoot
-            .appendingPathComponent("libexec")
-            .appendingPathComponent("container")
-            .appendingPathComponent("plugins")
-            .standardized
+            .appending(FilePath.Component("libexec"))
+            .appending(FilePath.Component("container"))
+            .appending(FilePath.Component("plugins"))
+        let installRootPluginsURL = URL(fileURLWithPath: installRootPluginsPath.string)
         let hintPaths = [userPluginsURL, installRootPluginsURL]
             .map { $0.appendingPathComponent(command).path(percentEncoded: false) }
             .joined(separator: "\n  - ")

--- a/Sources/ContainerCommands/System/SystemStart.swift
+++ b/Sources/ContainerCommands/System/SystemStart.swift
@@ -34,31 +34,19 @@ extension Application {
         @Option(
             name: .shortAndLong,
             help: "Path to the root directory for application data",
-            transform: {
-                let p = FilePath($0)
-                guard !p.isAbsolute else { return p }
-                return FilePath(FileManager.default.currentDirectoryPath).appending(p.components)
-            })
+            transform: { FilePath(FileManager.default.currentDirectoryPath).resolve($0, defaultPath: FilePath($0)) })
         var appRoot = ApplicationRoot.defaultPath
 
         @Option(
             name: .long,
             help: "Path to the root directory for application executables and plugins",
-            transform: {
-                let p = FilePath($0)
-                guard !p.isAbsolute else { return p }
-                return FilePath(FileManager.default.currentDirectoryPath).appending(p.components)
-            })
+            transform: { FilePath(FileManager.default.currentDirectoryPath).resolve($0, defaultPath: FilePath($0)) })
         var installRoot = InstallRoot.defaultPath
 
         @Option(
             name: .long,
             help: "Path to the root directory for log data, using macOS log facility if not set",
-            transform: {
-                let p = FilePath($0)
-                guard !p.isAbsolute else { return p }
-                return FilePath(FileManager.default.currentDirectoryPath).appending(p.components)
-            })
+            transform: { FilePath(FileManager.default.currentDirectoryPath).resolve($0, defaultPath: FilePath($0)) })
         var logRoot: FilePath? = nil
 
         @Flag(
@@ -121,10 +109,7 @@ extension Application {
             env[ApplicationRoot.environmentName] = appRoot.string
             env[InstallRoot.environmentName] = installRoot.string
             if let logRoot {
-                env[LogRoot.environmentName] =
-                    logRoot.isAbsolute
-                    ? logRoot.string
-                    : FilePath(FileManager.default.currentDirectoryPath).appending(logRoot.components).string
+                env[LogRoot.environmentName] = logRoot.string
             }
             let plist = LaunchPlist(
                 label: "com.apple.container.apiserver",

--- a/Sources/ContainerCommands/System/SystemStart.swift
+++ b/Sources/ContainerCommands/System/SystemStart.swift
@@ -34,19 +34,31 @@ extension Application {
         @Option(
             name: .shortAndLong,
             help: "Path to the root directory for application data",
-            transform: { URL(filePath: $0) })
-        var appRoot = ApplicationRoot.defaultURL
+            transform: {
+                let p = FilePath($0)
+                guard !p.isAbsolute else { return p }
+                return FilePath(FileManager.default.currentDirectoryPath).appending(p.components)
+            })
+        var appRoot = ApplicationRoot.defaultPath
 
         @Option(
             name: .long,
             help: "Path to the root directory for application executables and plugins",
-            transform: { URL(filePath: $0) })
-        var installRoot = InstallRoot.defaultURL
+            transform: {
+                let p = FilePath($0)
+                guard !p.isAbsolute else { return p }
+                return FilePath(FileManager.default.currentDirectoryPath).appending(p.components)
+            })
+        var installRoot = InstallRoot.defaultPath
 
         @Option(
             name: .long,
             help: "Path to the root directory for log data, using macOS log facility if not set",
-            transform: { FilePath($0) })
+            transform: {
+                let p = FilePath($0)
+                guard !p.isAbsolute else { return p }
+                return FilePath(FileManager.default.currentDirectoryPath).appending(p.components)
+            })
         var logRoot: FilePath? = nil
 
         @Flag(
@@ -72,9 +84,7 @@ extension Application {
         public init() {}
 
         public func run() async throws {
-            let appRootPath = FilePath(appRoot.path(percentEncoded: false))
-            let installRootPath = FilePath(installRoot.path(percentEncoded: false))
-            try ConfigurationLoader.copyConfigurationToReadOnly(to: appRootPath)
+            try ConfigurationLoader.copyConfigurationToReadOnly(to: appRoot)
             // Pass appRoot before installRoot: ConfigurationLoader uses first-match-wins
             // precedence, so user-provided config in appRoot overrides the defaults
             // shipped under installRoot. Both layers are passed explicitly because
@@ -82,8 +92,8 @@ extension Application {
             // loader's default search would otherwise ignore those overrides.
             let containerSystemConfig: ContainerSystemConfig = try await ConfigurationLoader.load(
                 configurationFiles: [
-                    ConfigurationLoader.configurationFile(in: appRootPath, of: .appRoot),
-                    ConfigurationLoader.configurationFile(in: installRootPath, of: .installRoot),
+                    ConfigurationLoader.configurationFile(in: appRoot, of: .appRoot),
+                    ConfigurationLoader.configurationFile(in: installRoot, of: .installRoot),
                 ])
 
             // Without the true path to the binary in the plist, `container-apiserver` won't launch properly.
@@ -91,24 +101,25 @@ extension Application {
             // Gatekeeper / amfid validates code signatures relative to the enclosing .app bundle
             // hierarchy; launching via a symlink outside the bundle fails that check.
             // TODO: Can we use the plugin loader to bootstrap the API server?
-            let executableUrl = CommandLine.executablePathUrl
-                .deletingLastPathComponent()
-                .appendingPathComponent("container-apiserver")
-                .resolvingSymlinksInPath()
+            let executablePath = try CommandLine.executablePath
+                .removingLastComponent()
+                .appending(FilePath.Component("container-apiserver"))
+                .resolvingSymlinks()
 
-            var args = [executableUrl.absolutePath()]
+            var args = [executablePath.string]
 
             args.append("start")
             if logOptions.debug {
                 args.append("--debug")
             }
 
-            let apiServerDataUrl = appRoot.appending(path: "apiserver")
-            try! FileManager.default.createDirectory(at: apiServerDataUrl, withIntermediateDirectories: true)
+            let apiServerDataPath = appRoot.appending(FilePath.Component("apiserver"))
+            let apiServerDataURL = URL(fileURLWithPath: apiServerDataPath.string)
+            try! FileManager.default.createDirectory(at: apiServerDataURL, withIntermediateDirectories: true)
 
             var env = PluginLoader.filterEnvironment()
-            env[ApplicationRoot.environmentName] = appRoot.path(percentEncoded: false)
-            env[InstallRoot.environmentName] = installRoot.path(percentEncoded: false)
+            env[ApplicationRoot.environmentName] = appRoot.string
+            env[InstallRoot.environmentName] = installRoot.string
             if let logRoot {
                 env[LogRoot.environmentName] =
                     logRoot.isAbsolute
@@ -124,7 +135,8 @@ extension Application {
                 machServices: ["com.apple.container.apiserver"]
             )
 
-            let plistURL = apiServerDataUrl.appending(path: "apiserver.plist")
+            let plistPath = apiServerDataPath.appending(FilePath.Component("apiserver.plist"))
+            let plistURL = URL(fileURLWithPath: plistPath.string)
             let data = try plist.encode()
             try data.write(to: plistURL)
 

--- a/Sources/ContainerPersistence/FilePath+Symlinks.swift
+++ b/Sources/ContainerPersistence/FilePath+Symlinks.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Darwin
+import SystemPackage
+
+extension FilePath {
+    /// Returns a new `FilePath` with all symlinks resolved and `.`/`..`
+    /// components normalized, by calling `realpath(3)`.
+    ///
+    /// Unlike ``lexicallyNormalized()``, this method accesses the file system.
+    /// It throws ``Errno/noSuchFileOrDirectory`` if any component of the path
+    /// does not exist.
+    ///
+    /// The returned path is always absolute. If the receiver is a relative path,
+    /// it is resolved against the process's current working directory.
+    public func resolvingSymlinks() throws -> FilePath {
+        try withPlatformString { cPath in
+            guard let resolved = Darwin.realpath(cPath, nil) else {
+                throw Errno(rawValue: Darwin.errno)
+            }
+            defer { free(resolved) }
+            return FilePath(platformString: resolved)
+        }
+    }
+}

--- a/Sources/ContainerPersistence/PathUtils.swift
+++ b/Sources/ContainerPersistence/PathUtils.swift
@@ -51,11 +51,10 @@ public enum PathUtils {
                 // rather than argv[0]: when the binary is invoked through PATH (e.g.
                 // `container ...`), argv[0] is just the basename and resolves to an
                 // empty FilePath, which FileManager treats as CWD-relative.
-                let installRootURL = CommandLine.executablePathUrl
-                    .deletingLastPathComponent()
-                    .appendingPathComponent("..")
-                    .standardized
-                return FilePath(installRootURL.path(percentEncoded: false))
+                let installRootPath = CommandLine.executablePath
+                    .removingLastComponent()
+                    .removingLastComponent()
+                return installRootPath
             }
         }
     }

--- a/Sources/ContainerPlugin/ApplicationRoot.swift
+++ b/Sources/ContainerPlugin/ApplicationRoot.swift
@@ -32,18 +32,11 @@ public struct ApplicationRoot {
     .appending(FilePath.Component("com.apple.container"))
 
     /// The path object for the root directory
-    public static let path = resolve(
+    public static let path = FilePath(FileManager.default.currentDirectoryPath).resolve(
         ProcessInfo.processInfo.environment[environmentName],
-        currentDirectory: FilePath(FileManager.default.currentDirectoryPath)
+        defaultPath: defaultPath
     )
 
     /// The pathname to the root directory
     public static let pathname = path.string
-
-    static func resolve(_ rawValue: String?, currentDirectory: FilePath) -> FilePath {
-        guard let rawValue, !rawValue.isEmpty else { return defaultPath }
-        let p = FilePath(rawValue)
-        guard !p.isAbsolute else { return p }
-        return currentDirectory.appending(p.components)
-    }
 }

--- a/Sources/ContainerPlugin/ApplicationRoot.swift
+++ b/Sources/ContainerPlugin/ApplicationRoot.swift
@@ -15,19 +15,35 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import SystemPackage
 
 /// Provides the application data root path.
 public struct ApplicationRoot {
+    /// The environment variable that if set, determines the root directory for the application data store.
+    /// Otherwise, the system uses the default "~/Library/Application Support/com.apple.container".
     public static let environmentName = "CONTAINER_APP_ROOT"
 
-    public static let defaultURL = FileManager.default.urls(
-        for: .applicationSupportDirectory,
-        in: .userDomainMask
-    ).first!.appendingPathComponent("com.apple.container")
+    public static let defaultPath = FilePath(
+        FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first!.path(percentEncoded: false)
+    )
+    .appending(FilePath.Component("com.apple.container"))
 
-    private static let envPath = ProcessInfo.processInfo.environment[Self.environmentName]
+    /// The path object for the root directory
+    public static let path = resolve(
+        ProcessInfo.processInfo.environment[environmentName],
+        currentDirectory: FilePath(FileManager.default.currentDirectoryPath)
+    )
 
-    public static let url = envPath.map { URL(fileURLWithPath: $0) } ?? defaultURL
+    /// The pathname to the root directory
+    public static let pathname = path.string
 
-    public static let path = url.path(percentEncoded: false)
+    static func resolve(_ rawValue: String?, currentDirectory: FilePath) -> FilePath {
+        guard let rawValue, !rawValue.isEmpty else { return defaultPath }
+        let p = FilePath(rawValue)
+        guard !p.isAbsolute else { return p }
+        return currentDirectory.appending(p.components)
+    }
 }

--- a/Sources/ContainerPlugin/ApplicationRoot.swift
+++ b/Sources/ContainerPlugin/ApplicationRoot.swift
@@ -23,6 +23,8 @@ public struct ApplicationRoot {
     /// Otherwise, the system uses the default "~/Library/Application Support/com.apple.container".
     public static let environmentName = "CONTAINER_APP_ROOT"
 
+    /// The default root directory used when ``environmentName`` is not set:
+    /// `~/Library/Application Support/com.apple.container`.
     public static let defaultPath = FilePath(
         FileManager.default.urls(
             for: .applicationSupportDirectory,
@@ -31,7 +33,11 @@ public struct ApplicationRoot {
     )
     .appending(FilePath.Component("com.apple.container"))
 
-    /// The path object for the root directory
+    /// The resolved root directory path, always lexically normalized.
+    ///
+    /// If the environment variable is set to an absolute path, that path is used directly.
+    /// If it is set to a relative path, the path is resolved against the working directory.
+    /// Otherwise, ``defaultPath`` is used.
     public static let path = FilePath(FileManager.default.currentDirectoryPath).resolve(
         ProcessInfo.processInfo.environment[environmentName],
         defaultPath: defaultPath

--- a/Sources/ContainerPlugin/FilePath+Resolve.swift
+++ b/Sources/ContainerPlugin/FilePath+Resolve.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025-2026 Apple Inc. and the container project authors.
+// Copyright © 2026 Apple Inc. and the container project authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,26 +14,17 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SystemPackage
-import Testing
 
-@testable import ContainerPlugin
-
-struct CommandLineExecutableTest {
-    @Test func lastComponentIsTestBinary() {
-        #expect(CommandLine.executablePath.lastComponent?.string == "swiftpm-testing-helper")
+extension FilePath {
+    func resolve(_ pathname: String?) -> FilePath? {
+        guard let pathname, !pathname.isEmpty else { return nil }
+        let path = FilePath(pathname)
+        guard !path.isAbsolute else { return path }
+        return self.appending(path.components)
     }
 
-    @Test func pathIsAbsolute() {
-        #expect(CommandLine.executablePath.isAbsolute)
-    }
-
-    @Test func pathIsNonEmpty() {
-        #expect(!CommandLine.executablePath.string.isEmpty)
-    }
-
-    @Test func removingLastComponentTwiceIsAbsolute() {
-        #expect(CommandLine.executablePath.removingLastComponent().removingLastComponent().isAbsolute)
+    func resolve(_ pathname: String?, defaultPath: FilePath) -> FilePath {
+        resolve(pathname) ?? defaultPath
     }
 }

--- a/Sources/ContainerPlugin/FilePath+Resolve.swift
+++ b/Sources/ContainerPlugin/FilePath+Resolve.swift
@@ -17,14 +17,32 @@
 import SystemPackage
 
 extension FilePath {
-    func resolve(_ pathname: String?) -> FilePath? {
+    /// Resolves a pathname string relative to this path.
+    ///
+    /// The result is lexically normalized — `.` components are removed and `..` components
+    /// collapse the preceding component. Absolute pathnames are returned normalized as-is;
+    /// relative pathnames are appended to `self` before normalizing.
+    ///
+    /// - Parameter pathname: The pathname to resolve.
+    /// - Returns: The resolved ``FilePath``, or `nil` if `pathname` is `nil` or empty.
+    package func resolve(_ pathname: String?) -> FilePath? {
         guard let pathname, !pathname.isEmpty else { return nil }
         let path = FilePath(pathname)
-        guard !path.isAbsolute else { return path }
-        return self.appending(path.components)
+        guard !path.isAbsolute else { return path.lexicallyNormalized() }
+        return self.appending(path.components).lexicallyNormalized()
     }
 
-    func resolve(_ pathname: String?, defaultPath: FilePath) -> FilePath {
-        resolve(pathname) ?? defaultPath
+    /// Resolves a pathname string relative to this path, falling back to a default.
+    ///
+    /// The result is lexically normalized — `.` components are removed and `..` components
+    /// collapse the preceding component. Absolute pathnames are returned normalized as-is;
+    /// relative pathnames are appended to `self` before normalizing.
+    ///
+    /// - Parameters:
+    ///   - pathname: The pathname to resolve.
+    ///   - defaultPath: The path returned when `pathname` is `nil` or empty.
+    /// - Returns: The resolved ``FilePath``, or `defaultPath` lexically normalized if `pathname` is `nil` or empty.
+    package func resolve(_ pathname: String?, defaultPath: FilePath) -> FilePath {
+        resolve(pathname) ?? defaultPath.lexicallyNormalized()
     }
 }

--- a/Sources/ContainerPlugin/InstallRoot.swift
+++ b/Sources/ContainerPlugin/InstallRoot.swift
@@ -25,11 +25,20 @@ public struct InstallRoot {
     /// application binary (for example, "/usr/local/bin/container" -> "/usr/local").
     public static let environmentName = "CONTAINER_INSTALL_ROOT"
 
+    /// The default root directory used when the environment variable is not set.
+    ///
+    /// Computed as the grandparent of ``CommandLine/executablePath``
+    /// (for example, `/usr/local/bin/container` → `/usr/local`).
+    /// Lexically normalized but not canonical, as symlinks in the executable path are not resolved.
     public static let defaultPath = CommandLine.executablePath
         .removingLastComponent()
         .removingLastComponent()
 
-    /// The path object for the root directory
+    /// The resolved root directory path, always lexically normalized.
+    ///
+    /// If the environment variable is set to an absolute path, that path is used directly.
+    /// If it is set to a relative path, the path is resolved against the working directory.
+    /// Otherwise, ``defaultPath`` is used.
     public static let path = FilePath(FileManager.default.currentDirectoryPath).resolve(
         ProcessInfo.processInfo.environment[environmentName],
         defaultPath: defaultPath

--- a/Sources/ContainerPlugin/InstallRoot.swift
+++ b/Sources/ContainerPlugin/InstallRoot.swift
@@ -29,23 +29,12 @@ public struct InstallRoot {
         .removingLastComponent()
         .removingLastComponent()
 
-    private static let envPath = ProcessInfo.processInfo.environment[Self.environmentName].flatMap {
-        $0.isEmpty ? nil : FilePath($0)
-    }
-
     /// The path object for the root directory
-    public static let path = resolve(
+    public static let path = FilePath(FileManager.default.currentDirectoryPath).resolve(
         ProcessInfo.processInfo.environment[environmentName],
-        currentDirectory: FilePath(FileManager.default.currentDirectoryPath)
+        defaultPath: defaultPath
     )
 
     /// The pathname to the root directory
     public static let pathname = path.string
-
-    static func resolve(_ rawValue: String?, currentDirectory: FilePath) -> FilePath {
-        guard let rawValue, !rawValue.isEmpty else { return defaultPath }
-        let p = FilePath(rawValue)
-        guard !p.isAbsolute else { return p }
-        return currentDirectory.appending(p.components)
-    }
 }

--- a/Sources/ContainerPlugin/InstallRoot.swift
+++ b/Sources/ContainerPlugin/InstallRoot.swift
@@ -16,19 +16,36 @@
 
 import ContainerVersion
 import Foundation
+import SystemPackage
 
 /// Provides the application installation root path.
 public struct InstallRoot {
+    /// The environment variable that if set, determines the root directory for installed application.
+    /// Otherwise, the system computes the install path as the parent of the directory containing the
+    /// application binary (for example, "/usr/local/bin/container" -> "/usr/local").
     public static let environmentName = "CONTAINER_INSTALL_ROOT"
 
-    public static let defaultURL = CommandLine.executablePathUrl
-        .deletingLastPathComponent()
-        .appendingPathComponent("..")
-        .standardized
+    public static let defaultPath = CommandLine.executablePath
+        .removingLastComponent()
+        .removingLastComponent()
 
-    private static let envPath = ProcessInfo.processInfo.environment[Self.environmentName]
+    private static let envPath = ProcessInfo.processInfo.environment[Self.environmentName].flatMap {
+        $0.isEmpty ? nil : FilePath($0)
+    }
 
-    public static let url = envPath.map { URL(fileURLWithPath: $0) } ?? defaultURL
+    /// The path object for the root directory
+    public static let path = resolve(
+        ProcessInfo.processInfo.environment[environmentName],
+        currentDirectory: FilePath(FileManager.default.currentDirectoryPath)
+    )
 
-    public static let path = url.path(percentEncoded: false)
+    /// The pathname to the root directory
+    public static let pathname = path.string
+
+    static func resolve(_ rawValue: String?, currentDirectory: FilePath) -> FilePath {
+        guard let rawValue, !rawValue.isEmpty else { return defaultPath }
+        let p = FilePath(rawValue)
+        guard !p.isAbsolute else { return p }
+        return currentDirectory.appending(p.components)
+    }
 }

--- a/Sources/ContainerPlugin/LogRoot.swift
+++ b/Sources/ContainerPlugin/LogRoot.swift
@@ -19,21 +19,23 @@ import SystemPackage
 
 /// Provides the application data root path.
 public struct LogRoot {
-
-    private static let envPath = ProcessInfo.processInfo.environment[Self.environmentName].flatMap {
-        $0.isEmpty ? nil : FilePath($0)
-    }
-
     /// The environment variable that if set, determines the root directory for log files.
     /// Otherwise, the application uses the macOS log facility.
     public static let environmentName = "CONTAINER_LOG_ROOT"
 
-    /// The path object for the log file root directory
-    public static let path = envPath.map {
-        guard !$0.isAbsolute else { return $0 }
-        return FilePath(FileManager.default.currentDirectoryPath).appending($0.components)
-    }
+    /// The path object for the root directory
+    public static let path = resolve(
+        ProcessInfo.processInfo.environment[environmentName],
+        currentDirectory: FilePath(FileManager.default.currentDirectoryPath)
+    )
 
-    /// The pathname to the log file root directory
+    /// The pathname to the root directory
     public static let pathname = path?.string
+
+    static func resolve(_ rawValue: String?, currentDirectory: FilePath) -> FilePath? {
+        guard let rawValue, !rawValue.isEmpty else { return nil }
+        let p = FilePath(rawValue)
+        guard !p.isAbsolute else { return p }
+        return currentDirectory.appending(p.components)
+    }
 }

--- a/Sources/ContainerPlugin/LogRoot.swift
+++ b/Sources/ContainerPlugin/LogRoot.swift
@@ -23,7 +23,11 @@ public struct LogRoot {
     /// Otherwise, the application uses the macOS log facility.
     public static let environmentName = "CONTAINER_LOG_ROOT"
 
-    /// The path object for the root directory
+    /// The resolved root directory for log files, or `nil` if the environment variable is not set.
+    ///
+    /// When non-nil, the path is always lexically normalized.
+    /// If the environment variable is set to an absolute path, that path is used directly.
+    /// If it is set to a relative path, the path is resolved against the working directory.
     public static let path = FilePath(FileManager.default.currentDirectoryPath).resolve(
         ProcessInfo.processInfo.environment[environmentName]
     )

--- a/Sources/ContainerVersion/Bundle+AppBundle.swift
+++ b/Sources/ContainerVersion/Bundle+AppBundle.swift
@@ -14,18 +14,26 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import Darwin
 import Foundation
+import SystemPackage
 
 /// Retrieve the application bundle for a path that refers to a macOS executable.
 extension Bundle {
-    public static func appBundle(executableURL: URL) -> Bundle? {
-        let resolvedURL = executableURL.resolvingSymlinksInPath()
-        let macOSURL = resolvedURL.deletingLastPathComponent()
-        let contentsURL = macOSURL.deletingLastPathComponent()
-        let bundleURL = contentsURL.deletingLastPathComponent()
-        if bundleURL.pathExtension == "app" {
-            return Bundle(url: bundleURL)
-        }
-        return nil
+    public static func appBundle(executablePath: FilePath) -> Bundle? {
+        let resolvedPath =
+            executablePath.withPlatformString { cPath in
+                Darwin.realpath(cPath, nil).map { ptr -> FilePath in
+                    defer { free(ptr) }
+                    return FilePath(platformString: ptr)
+                }
+            } ?? executablePath
+        let bundlePath =
+            resolvedPath
+            .removingLastComponent()  // MacOS/
+            .removingLastComponent()  // Contents/
+            .removingLastComponent()  // Foo.app/
+        guard bundlePath.lastComponent?.extension == "app" else { return nil }
+        return Bundle(url: URL(fileURLWithPath: bundlePath.string))
     }
 }

--- a/Sources/ContainerVersion/Bundle+AppBundle.swift
+++ b/Sources/ContainerVersion/Bundle+AppBundle.swift
@@ -18,8 +18,15 @@ import Darwin
 import Foundation
 import SystemPackage
 
-/// Retrieve the application bundle for a path that refers to a macOS executable.
 extension Bundle {
+    /// Retrieves the application bundle for a path that refers to a macOS executable.
+    ///
+    /// Resolves symlinks in `executablePath`, then walks up the standard macOS bundle layout
+    /// (`MacOS/` → `Contents/` → `Foo.app/`) and verifies the `.app` extension.
+    ///
+    /// - Parameter executablePath: The path to a macOS executable inside a bundle.
+    /// - Returns: The ``Bundle`` at the resolved `.app` directory, or `nil` if the executable
+    ///   is not inside a valid macOS application bundle.
     public static func appBundle(executablePath: FilePath) -> Bundle? {
         let resolvedPath =
             executablePath.withPlatformString { cPath in

--- a/Sources/ContainerVersion/CommandLine+Executable.swift
+++ b/Sources/ContainerVersion/CommandLine+Executable.swift
@@ -18,6 +18,10 @@ import Foundation
 import SystemPackage
 
 extension CommandLine {
+    /// The path of the running executable.
+    ///
+    /// Obtained via `_NSGetExecutablePath`, which returns an absolute, lexically normalized path
+    /// (no `.` or `..` components). Symlinks are not resolved, so the path is not canonical.
     public static var executablePath: FilePath {
         /// _NSGetExecutablePath with a zero-length buffer returns the needed buffer length
         var bufferSize: Int32 = 0

--- a/Sources/ContainerVersion/CommandLine+Executable.swift
+++ b/Sources/ContainerVersion/CommandLine+Executable.swift
@@ -15,9 +15,10 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import SystemPackage
 
 extension CommandLine {
-    public static var executablePathUrl: URL {
+    public static var executablePath: FilePath {
         /// _NSGetExecutablePath with a zero-length buffer returns the needed buffer length
         var bufferSize: Int32 = 0
         var buffer = [CChar](repeating: 0, count: Int(bufferSize))
@@ -31,6 +32,6 @@ extension CommandLine {
 
         /// Return the path with the executable file component removed the last component and
         let executablePath = String(cString: &buffer)
-        return URL(filePath: executablePath)
+        return FilePath(executablePath)
     }
 }

--- a/Sources/ContainerVersion/ReleaseVersion.swift
+++ b/Sources/ContainerVersion/ReleaseVersion.swift
@@ -35,8 +35,7 @@ public struct ReleaseVersion {
     }
 
     public static func version() -> String {
-        let executableURL = URL(fileURLWithPath: CommandLine.executablePath.string)
-        let appBundle = Bundle.appBundle(executableURL: executableURL)
+        let appBundle = Bundle.appBundle(executablePath: CommandLine.executablePath)
         let bundleVersion = appBundle?.infoDictionary?["CFBundleShortVersionString"] as? String
         return bundleVersion ?? get_release_version().map { String(cString: $0) } ?? "0.0.0"
     }

--- a/Sources/ContainerVersion/ReleaseVersion.swift
+++ b/Sources/ContainerVersion/ReleaseVersion.swift
@@ -35,7 +35,8 @@ public struct ReleaseVersion {
     }
 
     public static func version() -> String {
-        let appBundle = Bundle.appBundle(executableURL: CommandLine.executablePathUrl)
+        let executableURL = URL(fileURLWithPath: CommandLine.executablePath.string)
+        let appBundle = Bundle.appBundle(executableURL: executableURL)
         let bundleVersion = appBundle?.infoDictionary?["CFBundleShortVersionString"] as? String
         return bundleVersion ?? get_release_version().map { String(cString: $0) } ?? "0.0.0"
     }

--- a/Sources/Plugins/CoreImages/ImagesHelper.swift
+++ b/Sources/Plugins/CoreImages/ImagesHelper.swift
@@ -25,6 +25,7 @@ import ContainerXPC
 import Containerization
 import Foundation
 import Logging
+import SystemPackage
 
 @main
 struct ImagesHelper: AsyncParsableCommand {
@@ -51,9 +52,9 @@ extension ImagesHelper {
         @Option(name: .long, help: "XPC service prefix")
         var serviceIdentifier: String = "com.apple.container.core.container-core-images"
 
-        var appRoot = ApplicationRoot.url
+        var appRoot = ApplicationRoot.path
 
-        var installRoot = InstallRoot.url
+        var installRoot = InstallRoot.path
 
         var logRoot = LogRoot.path
 
@@ -90,11 +91,13 @@ extension ImagesHelper {
             }
         }
 
-        private func initializeImagesService(root: URL, containerSystemConfig: ContainerSystemConfig, log: Logger, routes: inout [String: XPCServer.RouteHandler]) throws {
+        private func initializeImagesService(root: FilePath, containerSystemConfig: ContainerSystemConfig, log: Logger, routes: inout [String: XPCServer.RouteHandler]) throws {
+            // TODO: remove as part of ImageStore URL removal PR
+            let rootURL = URL(fileURLWithPath: root.string)
             let contentStore = RemoteContentStoreClient()
-            let imageStore = try ImageStore(path: root, contentStore: contentStore)
+            let imageStore = try ImageStore(path: rootURL, contentStore: contentStore)
             let unpackStrategy = SnapshotStore.defaultUnpackStrategy(initImage: containerSystemConfig.vminit.image)
-            let snapshotStore = try SnapshotStore(path: root, unpackStrategy: unpackStrategy, log: log)
+            let snapshotStore = try SnapshotStore(path: rootURL, unpackStrategy: unpackStrategy, log: log)
             let service = try ImagesService(contentStore: contentStore, imageStore: imageStore, snapshotStore: snapshotStore, log: log)
             let harness = ImagesServiceHarness(service: service, log: log)
 
@@ -112,8 +115,10 @@ extension ImagesHelper {
             routes[ImagesServiceXPCRoute.snapshotGet.rawValue] = XPCServer.route(harness.getSnapshot)
         }
 
-        private func initializeContentService(root: URL, log: Logger, routes: inout [String: XPCServer.RouteHandler]) throws {
-            let service = try ContentStoreService(root: root, log: log)
+        private func initializeContentService(root: FilePath, log: Logger, routes: inout [String: XPCServer.RouteHandler]) throws {
+            // TODO: remove as part of ImageStore URL removal PR
+            let rootURL = URL(fileURLWithPath: root.string)
+            let service = try ContentStoreService(root: rootURL, log: log)
             let harness = ContentServiceHarness(service: service, log: log)
 
             routes[ImagesServiceXPCRoute.contentClean.rawValue] = XPCServer.route(harness.clean)

--- a/Tests/ContainerPersistenceTests/FilePathSymlinksTests.swift
+++ b/Tests/ContainerPersistenceTests/FilePathSymlinksTests.swift
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerTestSupport
+import Foundation
+import SystemPackage
+import Testing
+
+@testable import ContainerPersistence
+
+struct FilePathSymlinksTests {
+    @Test func realPathReturnsAbsolutePath() throws {
+        let resolved = try FilePath("/tmp").resolvingSymlinks()
+        #expect(resolved.isAbsolute)
+    }
+
+    @Test func symlinkResolvesToTarget() async throws {
+        try await TemporaryStorage.withTempDir { dir in
+            let target = dir.appending(FilePath.Component("target"))
+            let link = dir.appending(FilePath.Component("link"))
+            try "content".write(toFile: target.string, atomically: true, encoding: .utf8)
+            try FileManager.default.createSymbolicLink(atPath: link.string, withDestinationPath: target.string)
+
+            #expect(try link.resolvingSymlinks() == target.resolvingSymlinks())
+        }
+    }
+
+    @Test func nonExistentPathThrows() {
+        #expect(throws: Errno.noSuchFileOrDirectory) {
+            try FilePath("/nonexistent/path/that/does/not/exist").resolvingSymlinks()
+        }
+    }
+
+    @Test func relativePathResolvesToAbsolute() throws {
+        let resolved = try FilePath(".").resolvingSymlinks()
+        #expect(resolved.isAbsolute)
+    }
+}

--- a/Tests/ContainerPluginTests/CommandLine+ExecutableTest.swift
+++ b/Tests/ContainerPluginTests/CommandLine+ExecutableTest.swift
@@ -15,13 +15,25 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import SystemPackage
 import Testing
 
 @testable import ContainerPlugin
 
 struct CommandLineExecutableTest {
-    @Test
-    func testCLIPluginConfigLoad() async throws {
-        #expect(CommandLine.executablePathUrl.lastPathComponent == "swiftpm-testing-helper")
+    @Test func lastComponentIsTestBinary() {
+        #expect(CommandLine.executablePath.lastComponent?.string == "swiftpm-testing-helper")
+    }
+
+    @Test func pathIsAbsolute() {
+        #expect(CommandLine.executablePath.isAbsolute)
+    }
+
+    @Test func pathIsNonEmpty() {
+        #expect(!CommandLine.executablePath.string.isEmpty)
+    }
+
+    @Test func removingLastComponentTwiceIsAbsolute() {
+        #expect(CommandLine.executablePath.removingLastComponent().removingLastComponent().isAbsolute)
     }
 }

--- a/Tests/ContainerPluginTests/FilePath+ResolveTests.swift
+++ b/Tests/ContainerPluginTests/FilePath+ResolveTests.swift
@@ -38,8 +38,20 @@ struct FilePathResolveTests {
         #expect(cwd.resolve("data") == FilePath("/current/dir/data"))
     }
 
-    @Test func relativePathnameWithDotDotPrependsCurrentDirectory() {
-        #expect(cwd.resolve("../sibling") == FilePath("/current/dir/../sibling"))
+    @Test func relativePathnameWithDotDotIsLexicallyNormalized() {
+        #expect(cwd.resolve("../sibling") == FilePath("/current/sibling"))
+    }
+
+    @Test func relativePathnameWithDotIsLexicallyNormalized() {
+        #expect(cwd.resolve("./data") == FilePath("/current/dir/data"))
+    }
+
+    @Test func absolutePathnameWithDotDotIsLexicallyNormalized() {
+        #expect(cwd.resolve("/custom/../root") == FilePath("/root"))
+    }
+
+    @Test func absolutePathnameWithDotIsLexicallyNormalized() {
+        #expect(cwd.resolve("/custom/./root") == FilePath("/custom/root"))
     }
 
     @Test func defaultPathUsedWhenPathnameIsNil() {
@@ -50,6 +62,10 @@ struct FilePathResolveTests {
     @Test func defaultPathUsedWhenPathnameIsEmpty() {
         let fallback = FilePath("/fallback")
         #expect(cwd.resolve("", defaultPath: fallback) == fallback)
+    }
+
+    @Test func defaultPathIsLexicallyNormalized() {
+        #expect(cwd.resolve(nil, defaultPath: FilePath("/fallback/../normalized")) == FilePath("/normalized"))
     }
 
     @Test func absolutePathnameOverridesDefaultPath() {

--- a/Tests/ContainerPluginTests/FilePath+ResolveTests.swift
+++ b/Tests/ContainerPluginTests/FilePath+ResolveTests.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import SystemPackage
+import Testing
+
+@testable import ContainerPlugin
+
+private let cwd = FilePath("/current/dir")
+
+struct FilePathResolveTests {
+    @Test func nilWhenPathnameIsNil() {
+        #expect(cwd.resolve(nil) == nil)
+    }
+
+    @Test func nilWhenPathnameIsEmpty() {
+        #expect(cwd.resolve("") == nil)
+    }
+
+    @Test func absolutePathnameReturnedAsIs() {
+        #expect(cwd.resolve("/custom/root") == FilePath("/custom/root"))
+    }
+
+    @Test func relativePathnamePrependsCurrentDirectory() {
+        #expect(cwd.resolve("data") == FilePath("/current/dir/data"))
+    }
+
+    @Test func relativePathnameWithDotDotPrependsCurrentDirectory() {
+        #expect(cwd.resolve("../sibling") == FilePath("/current/dir/../sibling"))
+    }
+
+    @Test func defaultPathUsedWhenPathnameIsNil() {
+        let fallback = FilePath("/fallback")
+        #expect(cwd.resolve(nil, defaultPath: fallback) == fallback)
+    }
+
+    @Test func defaultPathUsedWhenPathnameIsEmpty() {
+        let fallback = FilePath("/fallback")
+        #expect(cwd.resolve("", defaultPath: fallback) == fallback)
+    }
+
+    @Test func absolutePathnameOverridesDefaultPath() {
+        #expect(cwd.resolve("/custom", defaultPath: FilePath("/fallback")) == FilePath("/custom"))
+    }
+}

--- a/Tests/ContainerPluginTests/RootPathTests.swift
+++ b/Tests/ContainerPluginTests/RootPathTests.swift
@@ -20,28 +20,6 @@ import Testing
 @testable import ContainerPlugin
 
 struct ApplicationRootTests {
-    private static let cwd = FilePath("/current/dir")
-
-    @Test func defaultWhenEnvUnset() {
-        #expect(ApplicationRoot.resolve(nil, currentDirectory: Self.cwd) == ApplicationRoot.defaultPath)
-    }
-
-    @Test func defaultWhenEnvEmpty() {
-        #expect(ApplicationRoot.resolve("", currentDirectory: Self.cwd) == ApplicationRoot.defaultPath)
-    }
-
-    @Test func absoluteEnvReturnedAsIs() {
-        #expect(ApplicationRoot.resolve("/custom/root", currentDirectory: Self.cwd) == FilePath("/custom/root"))
-    }
-
-    @Test func relativeEnvPrependsCurrentDirectory() {
-        #expect(ApplicationRoot.resolve("data", currentDirectory: Self.cwd) == FilePath("/current/dir/data"))
-    }
-
-    @Test func relativeEnvWithDotDotPrependsCurrentDirectory() {
-        #expect(ApplicationRoot.resolve("../sibling", currentDirectory: Self.cwd) == FilePath("/current/dir/../sibling"))
-    }
-
     @Test func defaultPathIsAbsolute() {
         #expect(ApplicationRoot.defaultPath.isAbsolute)
     }
@@ -52,45 +30,18 @@ struct ApplicationRootTests {
 }
 
 struct InstallRootTests {
-    private static let cwd = FilePath("/current/dir")
-
-    @Test func defaultWhenEnvUnset() {
-        #expect(InstallRoot.resolve(nil, currentDirectory: Self.cwd) == InstallRoot.defaultPath)
-    }
-
-    @Test func defaultWhenEnvEmpty() {
-        #expect(InstallRoot.resolve("", currentDirectory: Self.cwd) == InstallRoot.defaultPath)
-    }
-
-    @Test func absoluteEnvReturnedAsIs() {
-        #expect(InstallRoot.resolve("/usr/local", currentDirectory: Self.cwd) == FilePath("/usr/local"))
-    }
-
-    @Test func relativeEnvPrependsCurrentDirectory() {
-        #expect(InstallRoot.resolve("local", currentDirectory: Self.cwd) == FilePath("/current/dir/local"))
-    }
-
     @Test func defaultPathIsAbsolute() {
         #expect(InstallRoot.defaultPath.isAbsolute)
+    }
+
+    @Test func defaultPathIsGrandparentOfExecutable() {
+        #expect(InstallRoot.defaultPath == CommandLine.executablePath.removingLastComponent().removingLastComponent())
     }
 }
 
 struct LogRootTests {
-    private static let cwd = FilePath("/current/dir")
-
-    @Test func nilWhenEnvUnset() {
-        #expect(LogRoot.resolve(nil, currentDirectory: Self.cwd) == nil)
-    }
-
-    @Test func nilWhenEnvEmpty() {
-        #expect(LogRoot.resolve("", currentDirectory: Self.cwd) == nil)
-    }
-
-    @Test func absoluteEnvReturnedAsIs() {
-        #expect(LogRoot.resolve("/var/log/container", currentDirectory: Self.cwd) == FilePath("/var/log/container"))
-    }
-
-    @Test func relativeEnvPrependsCurrentDirectory() {
-        #expect(LogRoot.resolve("logs", currentDirectory: Self.cwd) == FilePath("/current/dir/logs"))
+    @Test func pathIsNilWhenEnvUnset() {
+        // CONTAINER_LOG_ROOT is not set in the unit test environment
+        #expect(LogRoot.path == nil)
     }
 }

--- a/Tests/ContainerPluginTests/RootPathTests.swift
+++ b/Tests/ContainerPluginTests/RootPathTests.swift
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import SystemPackage
+import Testing
+
+@testable import ContainerPlugin
+
+struct ApplicationRootTests {
+    private static let cwd = FilePath("/current/dir")
+
+    @Test func defaultWhenEnvUnset() {
+        #expect(ApplicationRoot.resolve(nil, currentDirectory: Self.cwd) == ApplicationRoot.defaultPath)
+    }
+
+    @Test func defaultWhenEnvEmpty() {
+        #expect(ApplicationRoot.resolve("", currentDirectory: Self.cwd) == ApplicationRoot.defaultPath)
+    }
+
+    @Test func absoluteEnvReturnedAsIs() {
+        #expect(ApplicationRoot.resolve("/custom/root", currentDirectory: Self.cwd) == FilePath("/custom/root"))
+    }
+
+    @Test func relativeEnvPrependsCurrentDirectory() {
+        #expect(ApplicationRoot.resolve("data", currentDirectory: Self.cwd) == FilePath("/current/dir/data"))
+    }
+
+    @Test func relativeEnvWithDotDotPrependsCurrentDirectory() {
+        #expect(ApplicationRoot.resolve("../sibling", currentDirectory: Self.cwd) == FilePath("/current/dir/../sibling"))
+    }
+
+    @Test func defaultPathIsAbsolute() {
+        #expect(ApplicationRoot.defaultPath.isAbsolute)
+    }
+
+    @Test func defaultPathEndsWithContainerComponent() {
+        #expect(ApplicationRoot.defaultPath.lastComponent?.string == "com.apple.container")
+    }
+}
+
+struct InstallRootTests {
+    private static let cwd = FilePath("/current/dir")
+
+    @Test func defaultWhenEnvUnset() {
+        #expect(InstallRoot.resolve(nil, currentDirectory: Self.cwd) == InstallRoot.defaultPath)
+    }
+
+    @Test func defaultWhenEnvEmpty() {
+        #expect(InstallRoot.resolve("", currentDirectory: Self.cwd) == InstallRoot.defaultPath)
+    }
+
+    @Test func absoluteEnvReturnedAsIs() {
+        #expect(InstallRoot.resolve("/usr/local", currentDirectory: Self.cwd) == FilePath("/usr/local"))
+    }
+
+    @Test func relativeEnvPrependsCurrentDirectory() {
+        #expect(InstallRoot.resolve("local", currentDirectory: Self.cwd) == FilePath("/current/dir/local"))
+    }
+
+    @Test func defaultPathIsAbsolute() {
+        #expect(InstallRoot.defaultPath.isAbsolute)
+    }
+}
+
+struct LogRootTests {
+    private static let cwd = FilePath("/current/dir")
+
+    @Test func nilWhenEnvUnset() {
+        #expect(LogRoot.resolve(nil, currentDirectory: Self.cwd) == nil)
+    }
+
+    @Test func nilWhenEnvEmpty() {
+        #expect(LogRoot.resolve("", currentDirectory: Self.cwd) == nil)
+    }
+
+    @Test func absoluteEnvReturnedAsIs() {
+        #expect(LogRoot.resolve("/var/log/container", currentDirectory: Self.cwd) == FilePath("/var/log/container"))
+    }
+
+    @Test func relativeEnvPrependsCurrentDirectory() {
+        #expect(LogRoot.resolve("logs", currentDirectory: Self.cwd) == FilePath("/current/dir/logs"))
+    }
+}

--- a/Tests/ContainerVersionTests/Bundle+AppBundleTests.swift
+++ b/Tests/ContainerVersionTests/Bundle+AppBundleTests.swift
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import SystemPackage
+import Testing
+
+@testable import ContainerVersion
+
+struct BundleAppBundleTests {
+    @Test func returnsNilForUnixInstallPath() {
+        // /usr/local/bin/container — no .app bundle in the hierarchy
+        let path = FilePath("/usr/local/bin/container")
+        #expect(Bundle.appBundle(executablePath: path) == nil)
+    }
+
+    @Test func returnsBundleForAppBundleExecutable() throws {
+        // Build a minimal Foo.app bundle on disk — Bundle(url:) requires the directory to exist.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BundleTest-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let bundleURL = tmp.appendingPathComponent("Foo.app", isDirectory: true)
+        let contentsURL = bundleURL.appendingPathComponent("Contents", isDirectory: true)
+        let macOSURL = contentsURL.appendingPathComponent("MacOS", isDirectory: true)
+        try FileManager.default.createDirectory(at: macOSURL, withIntermediateDirectories: true)
+        try Data("<plist version=\"1.0\"><dict/></plist>".utf8)
+            .write(to: contentsURL.appendingPathComponent("Info.plist"))
+
+        let executablePath = FilePath(macOSURL.path(percentEncoded: false))
+            .appending(FilePath.Component("Foo"))
+        let bundle = Bundle.appBundle(executablePath: executablePath)
+        #expect(bundle != nil)
+        #expect(bundle?.bundleURL.lastPathComponent == "Foo.app")
+    }
+
+    @Test func returnsBundleForSymlinkedExecutable() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BundleTest-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let bundleURL = tmp.appendingPathComponent("Foo.app", isDirectory: true)
+        let contentsURL = bundleURL.appendingPathComponent("Contents", isDirectory: true)
+        let macOSURL = contentsURL.appendingPathComponent("MacOS", isDirectory: true)
+        try FileManager.default.createDirectory(at: macOSURL, withIntermediateDirectories: true)
+        try Data("<plist version=\"1.0\"><dict/></plist>".utf8)
+            .write(to: contentsURL.appendingPathComponent("Info.plist"))
+        let executableURL = macOSURL.appendingPathComponent("Foo")
+        try Data().write(to: executableURL)
+
+        // Symlink outside the bundle pointing at the real executable
+        let symlinkURL = tmp.appendingPathComponent("foo-link")
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: executableURL)
+
+        let bundle = Bundle.appBundle(executablePath: FilePath(symlinkURL.path(percentEncoded: false)))
+        #expect(bundle != nil)
+        #expect(bundle?.bundleURL.lastPathComponent == "Foo.app")
+    }
+
+    @Test func returnsNilWhenTooShallow() {
+        // Only one component above executable — can't be a bundle
+        let path = FilePath("/Foo.app/binary")
+        #expect(Bundle.appBundle(executablePath: path) == nil)
+    }
+
+    @Test func returnsNilWhenThirdAncestorLacksAppExtension() {
+        // Parent hierarchy exists but doesn't end in .app
+        let path = FilePath("/opt/tools/bin/helper")
+        #expect(Bundle.appBundle(executablePath: path) == nil)
+    }
+}

--- a/Tests/ContainerVersionTests/CommandLine+ExecutableTests.swift
+++ b/Tests/ContainerVersionTests/CommandLine+ExecutableTests.swift
@@ -14,20 +14,25 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import SystemPackage
+import Testing
 
-/// Provides the application data root path.
-public struct LogRoot {
-    /// The environment variable that if set, determines the root directory for log files.
-    /// Otherwise, the application uses the macOS log facility.
-    public static let environmentName = "CONTAINER_LOG_ROOT"
+@testable import ContainerVersion
 
-    /// The path object for the root directory
-    public static let path = FilePath(FileManager.default.currentDirectoryPath).resolve(
-        ProcessInfo.processInfo.environment[environmentName]
-    )
+struct CommandLineExecutableTests {
+    @Test func lastComponentIsTestBinary() {
+        #expect(CommandLine.executablePath.lastComponent?.string == "swiftpm-testing-helper")
+    }
 
-    /// The pathname to the root directory
-    public static let pathname = path?.string
+    @Test func pathIsAbsolute() {
+        #expect(CommandLine.executablePath.isAbsolute)
+    }
+
+    @Test func pathIsNonEmpty() {
+        #expect(!CommandLine.executablePath.string.isEmpty)
+    }
+
+    @Test func removingLastComponentTwiceIsAbsolute() {
+        #expect(CommandLine.executablePath.removingLastComponent().removingLastComponent().isAbsolute)
+    }
 }


### PR DESCRIPTION
- Closes #1557.
- Replaces `executableURL` utility function for getting app executable path with `executablePath`.
- Adds `FilePath.resolvingSymlinks()` extension.
- Also converts for FilePath for types in `ContainerVersion` target.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Part of general purge of URL-for-filesystem-paths anti-pattern.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs
