### PR TITLE
Reject conflicting DNS flags

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/Flags.swift
+++ b/Sources/Services/ContainerAPIService/Client/Flags.swift
@@ -344,6 +344,21 @@ public struct Flags {
 
         @Option(name: [.customLong("volume"), .short], help: "Bind mount a volume into the container")
         public var volumes: [String] = []
+
+        public func validate() throws {
+            if dnsDisabled {
+                let hasDNSConfig =
+                    !dns.nameservers.isEmpty
+                    || dns.domain != nil
+                    || !dns.options.isEmpty
+                    || !dns.searchDomains.isEmpty
+                if hasDNSConfig {
+                    throw ValidationError(
+                        "`--no-dns` cannot be used with DNS configuration flags (`--dns`, `--dns-domain`, `--dns-option`, `--dns-search`)"
+                    )
+                }
+            }
+        }
     }
 
     public struct Progress: ParsableArguments {

--- a/Tests/ContainerAPIClientTests/ParserTest.swift
+++ b/Tests/ContainerAPIClientTests/ParserTest.swift
@@ -1296,4 +1296,44 @@ struct ParserTest {
         #expect(result.cpus == 2)
         #expect(result.memoryInBytes == 2048.mib())
     }
+
+    // MARK: - DNS Flag Validation Tests
+
+    @Test
+    func testManagementFlagsRejectsNoDNSWithDNS() throws {
+        #expect(throws: (any Error).self) {
+            _ = try Flags.Management.parse(["--dns", "1.1.1.1", "--no-dns"])
+        }
+    }
+
+    @Test
+    func testManagementFlagsRejectsNoDNSWithDNSDomain() throws {
+        #expect(throws: (any Error).self) {
+            _ = try Flags.Management.parse(["--dns-domain", "example.com", "--no-dns"])
+        }
+    }
+
+    @Test
+    func testManagementFlagsRejectsNoDNSWithDNSSearch() throws {
+        #expect(throws: (any Error).self) {
+            _ = try Flags.Management.parse(["--dns-search", "example.com", "--no-dns"])
+        }
+    }
+
+    @Test
+    func testManagementFlagsRejectsNoDNSWithDNSOption() throws {
+        #expect(throws: (any Error).self) {
+            _ = try Flags.Management.parse(["--dns-option", "debug", "--no-dns"])
+        }
+    }
+
+    @Test
+    func testManagementFlagsAcceptsDNSAlone() throws {
+        _ = try Flags.Management.parse(["--dns", "1.1.1.1"])
+    }
+
+    @Test
+    func testManagementFlagsAcceptsNoDNSAlone() throws {
+        _ = try Flags.Management.parse(["--no-dns"])
+    }
 }


### PR DESCRIPTION
## Summary

Rejects conflicting DNS configuration when `--no-dns` is supplied together with explicit DNS flags.

## Motivation

`--no-dns` disables DNS configuration, while `--dns`, `--dns-domain`, `--dns-option`, and `--dns-search` explicitly request DNS configuration. Accepting both makes the command ambiguous.

Fixes #1536.

## Testing

- Added parser coverage for conflicting `--no-dns` usage with:
  - `--dns`
  - `--dns-domain`
  - `--dns-option`
  - `--dns-search`
- Added parser coverage for valid standalone DNS flag usage.
- Ran `swift format`.
- Verified `Sources/Services/ContainerAPIService/Client/Flags.swift` parses with `swift -frontend -parse`.

Note: full `swift build`/test execution is blocked in my local environment by an unrelated dependency/toolchain header issue.