### PR TITLE
Reject conflicting volume delete flags

### DIFF
--- a/Sources/ContainerCommands/Volume/VolumeDelete.swift
+++ b/Sources/ContainerCommands/Volume/VolumeDelete.swift
@@ -39,6 +39,18 @@ extension Application.VolumeCommand {
 
         public init() {}
 
+        public func validate() throws {
+            if names.count == 0 && !all {
+                throw ContainerizationError(.invalidArgument, message: "no volumes specified and --all not supplied")
+            }
+            if names.count > 0 && all {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "explicitly supplied volume name(s) conflict with the --all flag"
+                )
+            }
+        }
+
         public func run() async throws {
             let uniqueVolumeNames = Set<String>(names)
             let volumes: [Volume]

--- a/Tests/CLITests/Subcommands/Volumes/TestCLIVolumes.swift
+++ b/Tests/CLITests/Subcommands/Volumes/TestCLIVolumes.swift
@@ -453,6 +453,19 @@ class TestCLIVolumes: CLITest {
         #expect(!listFinal.contains(volumeName), "volume should be pruned after container is deleted")
     }
 
+    // MARK: - Delete validation tests
+
+    @Test func testVolumeDeleteNoArgs() throws {
+        let (_, _, _, status) = try run(arguments: ["volume", "delete"])
+        #expect(status != 0, "Expected non-zero exit when no args and no --all")
+    }
+
+    @Test func testVolumeDeleteExplicitNamesConflictWithAll() throws {
+        let (_, _, error, status) = try run(arguments: ["volume", "delete", "--all", "some-volume"])
+        #expect(status != 0, "Expected non-zero exit for conflicting flags")
+        #expect(error.contains("conflict"))
+    }
+
     // MARK: - Journal option tests
 
     @Test func testVolumeCreateWithJournalOrdered() throws {


### PR DESCRIPTION
- Closes #1531 

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Reject explicitly supplied volume names when `--all` is passed to volume delete, matching the behavior of container/image/network delete.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs
