### PR TITLE
Add --add-host flag for static /etc/hosts entries

### DIFF
--- a/Sources/ContainerResource/Container/ContainerConfiguration.swift
+++ b/Sources/ContainerResource/Container/ContainerConfiguration.swift
@@ -35,6 +35,10 @@ public struct ContainerConfiguration: Sendable, Codable {
     public var networks: [AttachmentConfiguration] = []
     /// The DNS configuration for the container.
     public var dns: DNSConfiguration? = nil
+    /// Additional host-to-IP mappings to inject into the container's
+    /// `/etc/hosts` (the `--add-host` flag, equivalent to compose's
+    /// `extra_hosts`).
+    public var extraHosts: [ExtraHost] = []
     /// Whether to enable rosetta x86-64 translation for the container.
     public var rosetta: Bool = false
     /// Initial or main process of the container.
@@ -70,6 +74,7 @@ public struct ContainerConfiguration: Sendable, Codable {
         case sysctls
         case networks
         case dns
+        case extraHosts
         case rosetta
         case initProcess
         case platform
@@ -104,6 +109,7 @@ public struct ContainerConfiguration: Sendable, Codable {
         }
 
         dns = try container.decodeIfPresent(DNSConfiguration.self, forKey: .dns)
+        extraHosts = try container.decodeIfPresent([ExtraHost].self, forKey: .extraHosts) ?? []
         rosetta = try container.decodeIfPresent(Bool.self, forKey: .rosetta) ?? false
         initProcess = try container.decode(ProcessConfiguration.self, forKey: .initProcess)
         platform = try container.decodeIfPresent(ContainerizationOCI.Platform.self, forKey: .platform) ?? .current
@@ -116,6 +122,19 @@ public struct ContainerConfiguration: Sendable, Codable {
         capAdd = try container.decodeIfPresent([String].self, forKey: .capAdd) ?? []
         capDrop = try container.decodeIfPresent([String].self, forKey: .capDrop) ?? []
         shmSize = try container.decodeIfPresent(UInt64.self, forKey: .shmSize)
+    }
+
+    /// A static host-to-IP mapping appended to the container's
+    /// `/etc/hosts` at boot. Populated from `--add-host host:ip` on
+    /// `container run`/`create` and from compose's `extra_hosts`.
+    public struct ExtraHost: Sendable, Codable, Equatable {
+        public let hostname: String
+        public let ipAddress: String
+
+        public init(hostname: String, ipAddress: String) {
+            self.hostname = hostname
+            self.ipAddress = ipAddress
+        }
     }
 
     public struct DNSConfiguration: Sendable, Codable {

--- a/Sources/Services/ContainerAPIService/Client/Flags.swift
+++ b/Sources/Services/ContainerAPIService/Client/Flags.swift
@@ -173,6 +173,7 @@ public struct Flags {
             detach: Bool,
             dns: Flags.DNS,
             dnsDisabled: Bool,
+            extraHosts: [String] = [],
             entrypoint: String?,
             initImage: String?,
             kernel: String?,
@@ -201,6 +202,7 @@ public struct Flags {
             self.detach = detach
             self.dns = dns
             self.dnsDisabled = dnsDisabled
+            self.extraHosts = extraHosts
             self.entrypoint = entrypoint
             self.initImage = initImage
             self.kernel = kernel
@@ -246,6 +248,12 @@ public struct Flags {
 
         @OptionGroup
         public var dns: Flags.DNS
+
+        @Option(
+            name: .customLong("add-host"),
+            help: .init("Add a custom host-to-IP mapping to /etc/hosts (format: host:ip)", valueName: "host:ip")
+        )
+        public var extraHosts: [String] = []
 
         @Option(
             name: .long,

--- a/Sources/Services/ContainerAPIService/Client/Parser.swift
+++ b/Sources/Services/ContainerAPIService/Client/Parser.swift
@@ -224,6 +224,49 @@ public struct Parser {
         return envVar
     }
 
+    /// Parse `--add-host host:ip` arguments into `ExtraHost` values.
+    ///
+    /// The IP may be IPv4 or IPv6. Splits on the first `:` so that
+    /// IPv6 addresses (which themselves contain `:`) parse correctly —
+    /// DNS hostnames cannot contain `:`, so the first `:` is always
+    /// the separator. Matches Docker's `--add-host` and compose's
+    /// `extra_hosts` semantics.
+    public static func extraHosts(_ rawExtraHosts: [String]) throws -> [ContainerConfiguration.ExtraHost] {
+        var result: [ContainerConfiguration.ExtraHost] = []
+        for raw in rawExtraHosts {
+            guard let firstColon = raw.firstIndex(of: ":") else {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "invalid --add-host value '\(raw)' (expected host:ip)"
+                )
+            }
+            let hostname = String(raw[..<firstColon])
+            let ipString = String(raw[raw.index(after: firstColon)...])
+            guard !hostname.isEmpty else {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "invalid --add-host value '\(raw)' (hostname is empty)"
+                )
+            }
+            guard !ipString.isEmpty else {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "invalid --add-host value '\(raw)' (IP address is empty)"
+                )
+            }
+            do {
+                _ = try IPAddress(ipString)
+            } catch {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "invalid --add-host value '\(raw)': '\(ipString)' is not a valid IPv4 or IPv6 address"
+                )
+            }
+            result.append(.init(hostname: hostname, ipAddress: ipString))
+        }
+        return result
+    }
+
     public static func labels(_ rawLabels: [String]) throws -> [String: String] {
         var result: [String: String] = [:]
         for label in rawLabels {

--- a/Sources/Services/ContainerAPIService/Client/Utility.swift
+++ b/Sources/Services/ContainerAPIService/Client/Utility.swift
@@ -235,6 +235,8 @@ public struct Utility {
             )
         }
 
+        config.extraHosts = try Parser.extraHosts(management.extraHosts)
+
         config.rosetta = management.rosetta || (Platform.current.architecture == "arm64" && requestedPlatform.architecture == "amd64")
 
         if management.rosetta && Platform.current.architecture != "arm64" {

--- a/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
+++ b/Sources/Services/ContainerSandboxService/Server/SandboxService.swift
@@ -259,8 +259,10 @@ public actor SandboxService {
                 czConfig.process.stdout = stdout
                 czConfig.process.stderr = stderr
                 czConfig.process.stdin = stdin
-                // NOTE: We can support a user providing new entries eventually, but for now craft
-                // a default /etc/hosts.
+                // Build the default /etc/hosts (loopback + the
+                // container's own primary-interface address), then
+                // append any user-supplied `--add-host` entries from
+                // the container configuration.
                 var hostsEntries = [Hosts.Entry.localHostIPV4()]
                 if !interfaces.isEmpty {
                     let primaryIfaceAddr = interfaces[0].ipv4Address
@@ -268,6 +270,13 @@ public actor SandboxService {
                         Hosts.Entry(
                             ipAddress: primaryIfaceAddr.address.description,
                             hostnames: [czConfig.hostname ?? id],
+                        ))
+                }
+                for extra in config.extraHosts {
+                    hostsEntries.append(
+                        Hosts.Entry(
+                            ipAddress: extra.ipAddress,
+                            hostnames: [extra.hostname],
                         ))
                 }
                 czConfig.hosts = Hosts(entries: hostsEntries)

--- a/Tests/ContainerAPIClientTests/ParserTest.swift
+++ b/Tests/ContainerAPIClientTests/ParserTest.swift
@@ -22,6 +22,7 @@ import Testing
 
 @testable import ContainerAPIClient
 @testable import ContainerPersistence
+@testable import ContainerResource
 
 struct ParserTest {
     @Test
@@ -1335,5 +1336,74 @@ struct ParserTest {
     @Test
     func testManagementFlagsAcceptsNoDNSAlone() throws {
         _ = try Flags.Management.parse(["--no-dns"])
+    }
+
+    @Test
+    func testExtraHostsParserIPv4() throws {
+        let result = try Parser.extraHosts(["db:192.168.66.2"])
+        #expect(result == [.init(hostname: "db", ipAddress: "192.168.66.2")])
+    }
+
+    @Test
+    func testExtraHostsParserIPv6() throws {
+        let result = try Parser.extraHosts(["db:fe80::1"])
+        #expect(result == [.init(hostname: "db", ipAddress: "fe80::1")])
+    }
+
+    @Test
+    func testExtraHostsParserMultiple() throws {
+        let result = try Parser.extraHosts([
+            "db:10.0.0.5",
+            "cache:10.0.0.6",
+            "api.example.com:10.0.0.7",
+        ])
+        #expect(result.count == 3)
+        #expect(result[0].hostname == "db")
+        #expect(result[2].hostname == "api.example.com")
+    }
+
+    @Test
+    func testExtraHostsParserIPv6FullForm() throws {
+        // IPv6 addresses contain `:`; split must be on the FIRST `:`
+        // (DNS hostnames cannot contain `:`, so this is unambiguous).
+        let result = try Parser.extraHosts(["host:2001:db8::1"])
+        #expect(result == [.init(hostname: "host", ipAddress: "2001:db8::1")])
+    }
+
+    @Test
+    func testExtraHostsParserRejectsMissingColon() throws {
+        #expect(throws: (any Error).self) {
+            _ = try Parser.extraHosts(["db-192.168.1.1"])
+        }
+    }
+
+    @Test
+    func testExtraHostsParserRejectsEmptyHostname() throws {
+        #expect(throws: (any Error).self) {
+            _ = try Parser.extraHosts([":192.168.1.1"])
+        }
+    }
+
+    @Test
+    func testExtraHostsParserRejectsEmptyIP() throws {
+        #expect(throws: (any Error).self) {
+            _ = try Parser.extraHosts(["db:"])
+        }
+    }
+
+    @Test
+    func testExtraHostsParserRejectsInvalidIP() throws {
+        #expect(throws: (any Error).self) {
+            _ = try Parser.extraHosts(["db:not-an-ip"])
+        }
+    }
+
+    @Test
+    func testManagementFlagsAcceptsAddHost() throws {
+        let flags = try Flags.Management.parse([
+            "--add-host", "db:192.168.66.2",
+            "--add-host", "cache:192.168.66.3",
+        ])
+        #expect(flags.extraHosts == ["db:192.168.66.2", "cache:192.168.66.3"])
     }
 }

--- a/Tests/ContainerResourceTests/ContainerConfigurationExtraHostsTests.swift
+++ b/Tests/ContainerResourceTests/ContainerConfigurationExtraHostsTests.swift
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerizationOCI
+import Foundation
+import Testing
+
+@testable import ContainerResource
+
+struct ContainerConfigurationExtraHostsTests {
+
+    private func makeConfig() -> ContainerConfiguration {
+        let image = ImageDescription(
+            reference: "docker.io/library/alpine:latest",
+            descriptor: .init(
+                mediaType: "application/vnd.oci.image.manifest.v1+json",
+                digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+                size: 0
+            )
+        )
+        let process = ProcessConfiguration(
+            executable: "/bin/sh",
+            arguments: [],
+            environment: []
+        )
+        return ContainerConfiguration(id: "abc123", image: image, process: process)
+    }
+
+    /// A configuration encoded by an older daemon will not contain the
+    /// `extraHosts` key at all. Decoding such payload must succeed and
+    /// default `extraHosts` to `[]`.
+    @Test("Legacy configuration JSON decodes with empty extraHosts")
+    func legacyConfigDecodes() throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        let original = makeConfig()
+        let data = try encoder.encode(original)
+
+        guard var dict = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            Issue.record("encoded configuration was not a JSON object")
+            return
+        }
+        dict.removeValue(forKey: "extraHosts")
+        let strippedData = try JSONSerialization.data(withJSONObject: dict)
+
+        let decoded = try decoder.decode(ContainerConfiguration.self, from: strippedData)
+        #expect(decoded.extraHosts == [])
+    }
+
+    @Test("Populated extraHosts round-trip through JSON")
+    func extraHostsRoundTrip() throws {
+        var config = makeConfig()
+        config.extraHosts = [
+            .init(hostname: "db", ipAddress: "192.168.66.2"),
+            .init(hostname: "cache", ipAddress: "fe80::1"),
+        ]
+
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        let data = try encoder.encode(config)
+        let decoded = try decoder.decode(ContainerConfiguration.self, from: data)
+
+        #expect(decoded.extraHosts == config.extraHosts)
+    }
+
+    @Test("Default configuration has empty extraHosts")
+    func defaultExtraHostsIsEmpty() {
+        let config = makeConfig()
+        #expect(config.extraHosts == [])
+    }
+}


### PR DESCRIPTION
## Summary

Add a `--add-host host:ip` flag on `container create` / `container run` (repeatable), so callers can inject arbitrary host-to-IP mappings into the container's `/etc/hosts`. Mirrors Docker's flag of the same name and compose's `extra_hosts`.

The daemon already builds a minimal `/etc/hosts` (loopback + the container's primary-interface address) and the SandboxService even carries a hint at this gap:

```swift
// NOTE: We can support a user providing new entries eventually, but
// for now craft a default /etc/hosts.
```

This PR fills that in by mirroring the existing `--dns-*` flag plumbing.

## Changes

- `Flags.Management` gains an `--add-host` `@Option` (repeatable, `host:ip` format).
- `Parser.extraHosts(_:)` validates each value via `IPAddress` (accepts both IPv4 and IPv6) and splits on the **first** `:` — DNS hostnames cannot contain `:`, so the first colon is unambiguous as the separator and IPv6 addresses (`host:2001:db8::1`) parse correctly.
- `ContainerConfiguration` gains an `extraHosts: [ExtraHost]` field, decoded with `decodeIfPresent` and defaulting to `[]` so older snapshots decode unchanged.
- `Utility.makeContainerConfig` plumbs parsed values into the new field.
- `SandboxService` appends each `ExtraHost` to `hostsEntries` before constructing the `Hosts(entries:)` written into the VM.

## Motivation

We're building [crunchloop/devcontainer](https://github.com/crunchloop/devcontainer) — an open-source Go runtime for [Dev Containers](https://containers.dev/) — and are wiring up `apple/container` as a backend alongside Docker. Several Dev Container / compose features need static host mappings:

- `extra_hosts` in compose service definitions.
- Aliasing an external service (DB, API) to a stable name inside the container so application config doesn't need per-environment URLs.
- Pointing services at the host loopback (the typical `host.docker.internal`-style escape hatch).

Without `--add-host` today, the workaround is to `container run` → `container inspect` → `container exec --user 0` to append to `/etc/hosts` post-start, which is racy (intra-level peers can resolve each other before either has been patched) and brittle (fails for distroless images that have no `sh`).

The capability is also useful well beyond compose — anything that needs deterministic name resolution without standing up a DNS server: pinning a CI artifact registry by IP, aliasing internal hostnames in air-gapped environments, etc. It's the same role `--add-host` plays in Docker, `--dns-search` plays today in `apple/container`, and `extra_hosts` plays in compose.

## Test plan

- [x] `swift build` (full project) — clean
- [x] `swift test --filter "ParserTest|ContainerConfigurationExtraHostsTests"` — 12/12 pass
  - Parser: IPv4, IPv6, multiple flags, IPv6 full-form `host:2001:db8::1`, rejects missing colon, rejects empty hostname / IP, rejects invalid IP
  - Flags: `--add-host db:192.168.66.2 --add-host cache:192.168.66.3` round-trips through `Flags.Management.parse`
  - Configuration: legacy JSON (no `extraHosts` key) decodes to `extraHosts == []`; populated values round-trip through JSON; default-initialized config has `extraHosts == []`
- [x] `make fmt` — no changes

## Notes

- Format strictly follows Docker's: `--add-host host:ip` only. `host:host-gateway` and `host=ip` are deliberately out of scope; either can be added in a follow-up without breaking this surface.
- No existing tracking issue (filed this directly per `apple/container`'s general "small fixes welcome" guidance in CONTRIBUTING.md). Happy to file an issue first if maintainers prefer.