### PR TITLE
Ensure read-only user config removed on every startup.

### DIFF
--- a/Sources/ContainerPersistence/ConfigurationLoader.swift
+++ b/Sources/ContainerPersistence/ConfigurationLoader.swift
@@ -198,15 +198,16 @@ public enum ConfigurationLoader {
         let destPath = configurationFile(in: destBase)
 
         let fm = FileManager.default
-        guard fm.fileExists(atPath: sourcePath.string) else { return }
-
-        let destDir = destPath.removingLastComponent()
-        try fm.createDirectory(atPath: destDir.string, withIntermediateDirectories: true)
 
         if fm.fileExists(atPath: destPath.string) {
             try fm.setAttributes([.posixPermissions: READ_AND_WRITE], ofItemAtPath: destPath.string)
             try fm.removeItem(at: URL(filePath: destPath.string))
         }
+
+        guard fm.fileExists(atPath: sourcePath.string) else { return }
+
+        let destDir = destPath.removingLastComponent()
+        try fm.createDirectory(atPath: destDir.string, withIntermediateDirectories: true)
 
         try fm.copyItem(
             at: URL(filePath: sourcePath.string),


### PR DESCRIPTION
- Closes #1566.
- Currently on `system start` we only remove the read-only user config if the user config file exists. This means that changes to the config are processed properly on restart, but a removal is ignored, and the old read-only settings linger.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
See above.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
