### PR TITLE
Rename config file to `config.toml`.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -80,7 +80,7 @@ to prepare your build environment.
     >
     > **Note:** If you have already run `swift package edit`, whether intentionally or by accident, follow the steps in the next section to restore the normal `containerization` dependency. Otherwise, the modified `Package.swift` file will not work, and the project may fail to build.
 
-5. If you want `container` to use any changes you made in the `vminit` subproject of Containerization, set the init image in your runtime configuration file at `~/.config/container/runtime-config.toml`:
+5. If you want `container` to use any changes you made in the `vminit` subproject of Containerization, set the init image in your runtime configuration file at `~/.config/container/config.toml`:
 
     ```toml
     [vminit]
@@ -102,7 +102,7 @@ to prepare your build environment.
 
 To revert to using the Containerization dependency from your `Package.swift`:
 
-1. If you were using the local init filesystem, remove the `init` override from your `~/.config/container/runtime-config.toml` (or delete the `[vminit]` section if no other image settings are present).
+1. If you were using the local init filesystem, remove the `init` override from your `~/.config/container/config.toml` (or delete the `[vminit]` section if no other image settings are present).
 
 2. Use the Swift package manager to restore the normal `containerization` dependency and update your `Package.resolved` file. If you are using Xcode, revert your `Package.swift` change instead of using `swift package unedit`.
 
@@ -130,14 +130,14 @@ To test changes that require the `container-builder-shim` project:
 
 1. Clone the [container-builder-shim](https://github.com/apple/container-builder-shim) repository and navigate to its directory.
 
-2. After making the necessary changes, build the custom builder image, set it as the active builder image in `~/.config/container/runtime-config.toml`, and remove the existing `buildkit` container so the new image will be used:
+2. After making the necessary changes, build the custom builder image, set it as the active builder image in `~/.config/container/config.toml`, and remove the existing `buildkit` container so the new image will be used:
 
 ```bash
 container build -t builder .
 container rm -f buildkit
 ```
 
-Add the following to your `~/.config/container/runtime-config.toml`:
+Add the following to your `~/.config/container/config.toml`:
 
 ```toml
 [build]

--- a/Sources/ContainerCommands/Builder/BuilderStatus.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStatus.swift
@@ -77,7 +77,7 @@ private struct PrintableBuilder: ListDisplayable {
     }
 
     static var tableHeader: [String] {
-        ["ID", "IMAGE", "STATE", "ADDR", "CPUS", "MEMORY"]
+        ["ID", "IMAGE", "STATE", "IP", "CPUS", "MEMORY"]
     }
 
     var tableRow: [String] {

--- a/Sources/ContainerCommands/Container/ContainerList.swift
+++ b/Sources/ContainerCommands/Container/ContainerList.swift
@@ -54,7 +54,7 @@ extension Application {
 
 extension PrintableContainer: ListDisplayable {
     static var tableHeader: [String] {
-        ["ID", "IMAGE", "OS", "ARCH", "STATE", "ADDR", "CPUS", "MEMORY", "STARTED"]
+        ["ID", "IMAGE", "OS", "ARCH", "STATE", "IP", "CPUS", "MEMORY", "STARTED"]
     }
 
     var tableRow: [String] {

--- a/Sources/ContainerPersistence/ConfigurationLoader.swift
+++ b/Sources/ContainerPersistence/ConfigurationLoader.swift
@@ -31,7 +31,7 @@ public protocol LoadablePluginConfiguration: LoadableConfiguration {
 }
 
 public enum ConfigurationLoader {
-    private static let configFilename = "runtime-config.toml"
+    private static let configFilename = "config.toml"
     private static let configDirectory = "config"
     private static let READ_ONLY: Int = 0o444
     private static let READ_AND_WRITE: Int = 0o644
@@ -50,12 +50,12 @@ public enum ConfigurationLoader {
     /// Returns the configuration file path under an explicit base directory.
     ///
     /// Path shape depends on `kind`:
-    /// - `.home`: `<base>/runtime-config.toml` (user source under `~/.config/container`)
-    ///     - e.g. `~/.config/container/runtime-config.toml`
-    /// - `.appRoot`: `<base>/config/runtime-config.toml` (read-only copy of user config)
-    ///     - e.g. `~/Library/Application Support/com.apple.container/config/runtime-config.toml`
-    /// - `.installRoot`: `<base>/etc/container/runtime-config.toml` (system defaults shipped with install)
-    ///     - e.g. `/usr/local/etc/container/runtime-config.toml`
+    /// - `.home`: `<base>/config.toml` (user source under `~/.config/container`)
+    ///     - e.g. `~/.config/container/config.toml`
+    /// - `.appRoot`: `<base>/config/config.toml` (read-only copy of user config)
+    ///     - e.g. `~/Library/Application Support/com.apple.container/config/config.toml`
+    /// - `.installRoot`: `<base>/etc/container/config.toml` (system defaults shipped with install)
+    ///     - e.g. `/usr/local/etc/container/config.toml`
     ///
     /// - Parameters:
     ///   - base: Directory to resolve against.
@@ -83,8 +83,8 @@ public enum ConfigurationLoader {
     /// Load the `ContainerSystemConfig` by layering TOML files with first-match-wins precedence.
     ///
     /// Providers are consulted in the order given — values from earlier files override
-    /// later ones. The default order is user config (`<appRoot>/config/runtime-config.toml`)
-    /// > system config (`<installRoot>/etc/container/config/runtime-config.toml`).
+    /// later ones. The default order is user config (`<appRoot>/config/config.toml`)
+    /// > system config (`<installRoot>/etc/container/config/config.toml`).
     ///
     /// An empty `configurationFiles` array falls back to `defaultConfigFiles()`.
     ///
@@ -186,9 +186,9 @@ public enum ConfigurationLoader {
     /// is deleted and replaced with a fresh copy, which is then marked read-only.
     ///
     /// - Parameters:
-    ///   - source: File to copy from. Defaults to `<home>/container/runtime-config.toml`.
+    ///   - source: File to copy from. Defaults to `<home>/container/config.toml`.
     ///   - destination: Directory to copy into — the filename is appended automatically.
-    ///     Defaults to `<appRoot>/config/runtime-config.toml`.
+    ///     Defaults to `<appRoot>/config/config.toml`.
     public static func copyConfigurationToReadOnly(
         from source: FilePath? = nil,
         to destination: FilePath? = nil

--- a/Sources/ContainerPersistence/ContainerSystemConfig.swift
+++ b/Sources/ContainerPersistence/ContainerSystemConfig.swift
@@ -19,7 +19,7 @@ import ContainerVersion
 import ContainerizationExtras
 import Foundation
 
-/// Top-level configuration decoded from runtime-config.toml.
+/// Top-level configuration decoded from config.toml.
 ///
 /// Each section maps to a nested struct. Missing keys fall back to
 /// hardcoded defaults via custom `init(from:)` implementations.

--- a/Tests/ContainerPersistenceTests/ConfigurationLoaderTests.swift
+++ b/Tests/ContainerPersistenceTests/ConfigurationLoaderTests.swift
@@ -217,13 +217,13 @@ struct ConfigurationLoaderTests {
 
     @Test func copyConfigToAppRoot() async throws {
         try await TemporaryStorage.withTempDir { tempDir in
-            let source = tempDir.appending("runtime-config.toml")
+            let source = tempDir.appending("config.toml")
             try Self.writeToml("[build]\ncpus = 8", to: source)
 
             let destBase = tempDir.appending("dest")
             try ConfigurationLoader.copyConfigurationToReadOnly(from: source, to: destBase)
 
-            let destFile = destBase.appending("config").appending("runtime-config.toml")
+            let destFile = destBase.appending("config").appending("config.toml")
             let copied = try String(contentsOf: URL(filePath: destFile.string), encoding: .utf8)
             #expect(copied.contains("cpus = 8"))
 
@@ -235,7 +235,7 @@ struct ConfigurationLoaderTests {
 
     @Test func copyConfigOverwritesExistingReadOnlyDestination() async throws {
         try await TemporaryStorage.withTempDir { tempDir in
-            let source = tempDir.appending("runtime-config.toml")
+            let source = tempDir.appending("config.toml")
             let destBase = tempDir.appending("dest")
 
             try Self.writeToml("[build]\ncpus = 8", to: source)
@@ -244,7 +244,7 @@ struct ConfigurationLoaderTests {
             try Self.writeToml("[build]\ncpus = 16", to: source)
             try ConfigurationLoader.copyConfigurationToReadOnly(from: source, to: destBase)
 
-            let destFile = destBase.appending("config").appending("runtime-config.toml")
+            let destFile = destBase.appending("config").appending("config.toml")
             let copied = try String(contentsOf: URL(filePath: destFile.string), encoding: .utf8)
             #expect(copied.contains("cpus = 16"))
 
@@ -259,7 +259,7 @@ struct ConfigurationLoaderTests {
             let source = tempDir.appending("nonexistent.toml")
             let destBase = tempDir.appending("dest")
             try ConfigurationLoader.copyConfigurationToReadOnly(from: source, to: destBase)
-            let destFile = destBase.appending("config").appending("runtime-config.toml")
+            let destFile = destBase.appending("config").appending("config.toml")
             #expect(!FileManager.default.fileExists(atPath: destFile.string))
         }
     }

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -345,7 +345,7 @@ Use `container ls` to see that the container is on the `foo` subnet:
 
 ```console
  % container ls
-ID             IMAGE            OS     ARCH   STATE    ADDR
+ID             IMAGE            OS     ARCH   STATE    IP
 my-web-server  web-test:latest  linux  arm64  running  192.168.65.2
 ```
 

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -360,7 +360,7 @@ Networks support both IPv4 and IPv6. When creating a network without explicit su
 
 ## Configure default network subnets
 
-You can customize the default IPv4 and IPv6 subnets used for new networks by editing your runtime configuration file at `~/.config/container/runtime-config.toml`:
+You can customize the default IPv4 and IPv6 subnets used for new networks by editing your runtime configuration file at `~/.config/container/config.toml`:
 
 ```toml
 [network]
@@ -668,7 +668,7 @@ image = "ghcr.io/apple/containerization/vminit:0.30.1"
 
 ### Example: Disable Rosetta for builds
 
-If you want to prevent the use of Rosetta translation during container builds on Apple Silicon Macs, set the following in `~/.config/container/runtime-config.toml`:
+If you want to prevent the use of Rosetta translation during container builds on Apple Silicon Macs, set the following in `~/.config/container/config.toml`:
 
 ```toml
 [build]

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -113,7 +113,7 @@ sudo container system dns create test
 
 Enter your administrator password when prompted. The first command requires administrator privileges to create a file containing the domain configuration under the `/etc/resolver` directory, and to tell the macOS DNS resolver to reload its configuration files.
 
-With the domain set to `test`, if you use `--name my-web-server` to start a container, queries to `my-web-server.test` will respond with that container's IP address. You can customize the domain in `~/.config/container/runtime-config.toml`.
+With the domain set to `test`, if you use `--name my-web-server` to start a container, queries to `my-web-server.test` will respond with that container's IP address. You can customize the domain in `~/.config/container/config.toml`.
 
 ## Build an image
 
@@ -305,7 +305,7 @@ container image push some-registry.example.com/fido/web-test:latest
 
 > [!NOTE]
 > By default `container` is configured to use Docker Hub.
-> You can change the default registry by setting `domain` under `[registry]` in `~/.config/container/runtime-config.toml`:
+> You can change the default registry by setting `domain` under `[registry]` in `~/.config/container/config.toml`:
 > ```toml
 > [registry]
 > domain = "some-registry.example.com"

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -42,7 +42,7 @@ If you haven't created any containers yet, the command outputs an empty list:
 
 <pre>
 % container list --all
-ID  IMAGE  OS  ARCH  STATE  ADDR
+ID  IMAGE  OS  ARCH  STATE  IP
 %
 </pre>
 
@@ -97,7 +97,7 @@ You can save keystrokes by abbreviating commands and options. For example, abbre
 
 <pre>
 % container ls -a
-ID  IMAGE  OS  ARCH  STATE  ADDR
+ID  IMAGE  OS  ARCH  STATE  IP
 %
 </pre>
 
@@ -182,11 +182,11 @@ container run --name my-web-server --detach --rm web-test
 
 The `--detach` flag runs the container in the background, so that you can continue running commands in the same terminal. The `--rm` flag causes the container to be removed automatically after it stops.
 
-When you list containers now, `my-web-server` is present, along with the container that `container` started to build your image. Note that its IP address, shown in the `ADDR` column, is `192.168.64.3`:
+When you list containers now, `my-web-server` is present, along with the container that `container` started to build your image. Note that its IP address, shown in the `IP` column, is `192.168.64.3`:
 
 <pre>
 % container ls
-ID             IMAGE                                               OS     ARCH   STATE    ADDR
+ID             IMAGE                                               OS     ARCH   STATE    IP
 buildkit       ghcr.io/apple/container-builder-shim/builder:0.0.3  linux  arm64  running  192.168.64.2
 my-web-server  web-test:latest                                     linux  arm64  running  192.168.64.3
 %
@@ -338,7 +338,7 @@ If you list all running and stopped containers, you will see that the `--rm` fla
 
 <pre>
 % container list --all
-ID        IMAGE                                               OS     ARCH   STATE    ADDR
+ID        IMAGE                                               OS     ARCH   STATE    IP
 buildkit  ghcr.io/apple/container-builder-shim/builder:0.0.3  linux  arm64  running  192.168.64.2
 %
 </pre>


### PR DESCRIPTION
- Closes #1565.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [x] Breaking change
- [x] Documentation update

## Motivation and Context
`runtime-config.toml` suggests the config pertains to just the runtime (managing container workloads) aspect of the system.

## Testing
- [ ] Tested locally
- [x] Added/updated tests
- [x] Added/updated docs
