### PR TITLE
Adds vertical space between groups in help.

### DIFF
--- a/Sources/ContainerCommands/Application.swift
+++ b/Sources/ContainerCommands/Application.swift
@@ -238,12 +238,18 @@ extension Application {
     static func printModifiedHelpText(pluginLoader: PluginLoader?) async {
         let original = Application.helpMessage(for: Application.self)
         guard let pluginLoader else {
-            print(original)
-            print("PLUGINS: not available, run `container system start`")
+            print(addGroupSpacing(original))
+            print("\nPLUGINS: not available, run `container system start`")
             return
         }
         let altered = pluginLoader.alterCLIHelpText(original: original)
-        print(altered)
+        print(addGroupSpacing(altered))
+    }
+
+    private static func addGroupSpacing(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "\n([A-Z].+SUBCOMMANDS:)", with: "\n\n$1", options: .regularExpression)
+            .replacingOccurrences(of: "\nPLUGINS:", with: "\n\nPLUGINS:")
     }
 
     func isTranslated() throws -> Bool {


### PR DESCRIPTION
- Closes #1513.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Space between the groups simplifies scanning the help text.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
