### PR TITLE
Refine custom init how-to and BUILDING documentation.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -11,10 +11,11 @@ To build the `container` project, you need:
 
 ## Compile and test
 
-Build `container` and the background services from source, and run basic and integration tests:
+Build `container` and the background services from source, and run basic and integration tests in an isolated application data directory:
 
 ```bash
-make all test integration
+rm -rf test-data
+make APP_ROOT=test-data all test integration
 ```
 
 Copy the binaries to `/usr/local/bin` and `/usr/local/libexec` (requires entering an administrator password):

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -603,10 +603,14 @@ CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o wrapper wrapper.go
 
 **3. Create a Containerfile:**
 
-```dockerfile
-FROM ghcr.io/apple/containerization/vminit:latest AS base
+Use the `vminit` image tag corresponding to the `scVersion` value in the project `Package.swift` file.
 
-FROM ghcr.io/apple/containerization/vminit:latest
+Or, use `vminit:latest` if you have a local `containerization` project in [edit mode](../BUILDING.md#develop-using-a-local-copy-of-containerization).
+
+```dockerfile
+FROM ghcr.io/apple/containerization/vminit:0.32.2 AS base
+
+FROM ghcr.io/apple/containerization/vminit:0.32.2
 COPY --from=base /sbin/vminitd /sbin/vminitd.real
 COPY wrapper /sbin/vminitd
 ```


### PR DESCRIPTION
- Closes #1540.
- Use a published vminit image in the custom init example.
- Refine the integration test example in BUILDING.md to build in an isolated app-root directory.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context
We don't make `latest` tags for vminit images, so the example would fail.

## Testing
- [ ] Tested locally
- [ ] Added/updated tests
- [x] Added/updated docs
