### PR TITLE
Add shmSize to management flag's init

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/Flags.swift
+++ b/Sources/Services/ContainerAPIService/Client/Flags.swift
@@ -189,6 +189,7 @@ public struct Flags {
             rosetta: Bool,
             runtime: String?,
             ssh: Bool,
+            shmSize: String?,
             tmpFs: [String],
             useInit: Bool,
             virtualization: Bool,
@@ -217,6 +218,7 @@ public struct Flags {
             self.rosetta = rosetta
             self.runtime = runtime
             self.ssh = ssh
+            self.shmSize = shmSize
             self.tmpFs = tmpFs
             self.useInit = useInit
             self.virtualization = virtualization


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context
Ensure all fields are initialized in the management flags' init function. Without this change, if someone calls init() on this set of flags, they will get an error like 

```
Can't read a value from a parsable argument definition.

This error indicates that a property declared with an `@Argument`,
`@Option`, `@Flag`, or `@OptionGroup` property wrapper was neither
initialized to a value nor decoded from command-line arguments.

To get a valid value, either call one of the static parsing methods
(`parse`, `parseAsRoot`, or `main`) or define an initializer that
initializes _every_ property of your parsable type.
```

## Testing
- [x] Tested locally
