### PR TITLE
Add ability to configure integration test list at command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ define GENERATE_COV_REPORTS
 	@cat $(COVERAGE_OUTPUT_DIR)/$(2)/coverage-percent.txt
 endef
 
-INTEGRATION_TEST_SUITES := \
+INTEGRATION_TEST_SUITES ?= \
 	TestCLIHelp \
 	TestCLIStatus \
 	TestCLIVersion \
@@ -316,7 +316,7 @@ check-licenses:
 
 .PHONY: pre-commit
 pre-commit:
-	cp Scripts/pre-commit.fmt .git/hooks
+	cp scripts/pre-commit.fmt .git/hooks
 	touch .git/hooks/pre-commit
 	cat .git/hooks/pre-commit | grep -v 'hooks/pre-commit\.fmt' > /tmp/pre-commit.new || true
 	echo 'PRECOMMIT_NOFMT=$${PRECOMMIT_NOFMT} $$(git rev-parse --show-toplevel)/.git/hooks/pre-commit.fmt' >> /tmp/pre-commit.new


### PR DESCRIPTION
## Type of Change
- [x] New feature  

## Motivation and Context
When developing, there are times when I want to run a specific set of CLI tests. This PR allows users to set what integration tests they want to run by setting the makefile variable `INTEGRATION_TEST_SUITES`. 

Example usage: 
```
% INTEGRATION_TEST_SUITES="TestCLIVolumes TestCLIAnonymousVolumes"  make all integration
```

## Testing
- [x] Tested locally
