### PR TITLE
Add TOML configuration for default DNS nameservers, search, options

### DIFF
--- a/Sources/ContainerCommands/BuildCommand.swift
+++ b/Sources/ContainerCommands/BuildCommand.swift
@@ -163,14 +163,17 @@ extension Application {
                 progress.start()
 
                 progress.set(description: "Dialing builder")
-
                 let dnsNameservers = self.dns.nameservers
-                let builder: Builder? = try await withThrowingTaskGroup(of: Builder.self) { [vsockPort, cpus, memory, dnsNameservers] group in
+                let dnsDomain = self.dns.domain
+                let dnsSearchDomains = self.dns.searchDomains
+                let dnsOptions = self.dns.options
+                let builder: Builder? = try await withThrowingTaskGroup(of: Builder.self) {
+                    [vsockPort, cpus, memory, dnsNameservers, dnsDomain, dnsSearchDomains, dnsOptions] group in
                     defer {
                         group.cancelAll()
                     }
 
-                    group.addTask { [vsockPort, cpus, memory, log, dnsNameservers] in
+                    group.addTask { [vsockPort, cpus, memory, log, dnsNameservers, dnsDomain, dnsSearchDomains, dnsOptions] in
                         let client = ContainerClient()
                         while true {
                             do {
@@ -193,6 +196,9 @@ extension Application {
                                     memory: memory,
                                     log: log,
                                     dnsNameservers: dnsNameservers,
+                                    dnsDomain: dnsDomain,
+                                    dnsSearchDomains: dnsSearchDomains,
+                                    dnsOptions: dnsOptions,
                                     progressUpdate: progress.handler,
                                     containerSystemConfig: containerSystemConfig,
                                 )

--- a/Sources/ContainerCommands/Builder/BuilderStart.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStart.swift
@@ -91,6 +91,16 @@ extension Application {
             progressUpdate: @escaping ProgressUpdateHandler,
             containerSystemConfig: ContainerSystemConfig,
         ) async throws {
+            let dns = Utility.dnsConfiguration(
+                from: .init(
+                    domain: dnsDomain,
+                    nameservers: dnsNameservers,
+                    options: dnsOptions,
+                    searchDomains: dnsSearchDomains
+                ),
+                defaults: containerSystemConfig.container.dns
+            )
+
             await progressUpdate([
                 .setDescription("Fetching BuildKit image"),
                 .setItemsName("blobs"),
@@ -150,21 +160,7 @@ extension Application {
                 let imageChanged = existingImage != builderImage
                 let cpuChanged = existingResources.cpus != resources.cpus
                 let memChanged = existingResources.memoryInBytes != resources.memoryInBytes
-                let dnsChanged = {
-                    if !dnsNameservers.isEmpty {
-                        return existingDNS?.nameservers != dnsNameservers
-                    }
-                    if dnsDomain != nil {
-                        return existingDNS?.domain != dnsDomain
-                    }
-                    if !dnsSearchDomains.isEmpty {
-                        return existingDNS?.searchDomains != dnsSearchDomains
-                    }
-                    if !dnsOptions.isEmpty {
-                        return existingDNS?.options != dnsOptions
-                    }
-                    return false
-                }()
+                let dnsChanged = Self.dnsConfigurationChanged(existing: existingDNS, desired: dns)
 
                 switch existingContainer.status {
                 case .running:
@@ -270,10 +266,10 @@ extension Application {
                 AttachmentConfiguration(network: defaultNetwork.id, options: AttachmentOptions(hostname: Builder.builderContainerId))
             ]
             config.dns = ContainerConfiguration.DNSConfiguration(
-                nameservers: dnsNameservers,
-                domain: dnsDomain,
-                searchDomains: dnsSearchDomains,
-                options: dnsOptions
+                nameservers: dns.nameservers,
+                domain: dns.domain,
+                searchDomains: dns.searchDomains,
+                options: dns.options
             )
 
             let kernel = try await {
@@ -298,6 +294,17 @@ extension Application {
 
             try await startBuildKit(client: client, id: Builder.builderContainerId, progressUpdate, taskManager)
             log.debug("starting BuildKit and BuildKit-shim")
+        }
+
+        static func dnsConfigurationChanged(
+            existing: ContainerConfiguration.DNSConfiguration?,
+            desired: ContainerConfiguration.DNSConfiguration
+        ) -> Bool {
+            let existing = existing ?? .init()
+            return existing.nameservers != desired.nameservers
+                || existing.domain != desired.domain
+                || existing.searchDomains != desired.searchDomains
+                || existing.options != desired.options
         }
     }
 }

--- a/Sources/ContainerPersistence/ContainerSystemConfig.swift
+++ b/Sources/ContainerPersistence/ContainerSystemConfig.swift
@@ -113,16 +113,23 @@ final public class ContainerConfig: Codable, Sendable {
 
     public let cpus: Int
     public let memory: MemorySize
+    public let dns: ContainerDNSConfig
 
-    public init(cpus: Int = defaultCPUs, memory: MemorySize = defaultMemory) {
+    public init(
+        cpus: Int = defaultCPUs,
+        memory: MemorySize = defaultMemory,
+        dns: ContainerDNSConfig = .init()
+    ) {
         self.cpus = cpus
         self.memory = memory
+        self.dns = dns
     }
 
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.cpus = try container.decodeIfPresent(Int.self, forKey: .cpus) ?? Self.defaultCPUs
         self.memory = try container.decodeIfPresent(MemorySize.self, forKey: .memory) ?? Self.defaultMemory
+        self.dns = try container.decodeIfPresent(ContainerDNSConfig.self, forKey: .dns) ?? .init()
     }
 }
 
@@ -136,6 +143,37 @@ final public class DNSConfig: Codable, Sendable {
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.domain = try container.decodeIfPresent(String.self, forKey: .domain)
+    }
+}
+
+final public class ContainerDNSConfig: Codable, Sendable {
+    public static let defaultNameservers: [String] = []
+    public static let defaultSearchDomains: [String] = []
+    public static let defaultOptions: [String] = []
+
+    public let domain: String?
+    public let nameservers: [String]
+    public let searchDomains: [String]
+    public let options: [String]
+
+    public init(
+        domain: String? = nil,
+        nameservers: [String] = defaultNameservers,
+        searchDomains: [String] = defaultSearchDomains,
+        options: [String] = defaultOptions
+    ) {
+        self.domain = domain
+        self.nameservers = nameservers
+        self.searchDomains = searchDomains
+        self.options = options
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.domain = try container.decodeIfPresent(String.self, forKey: .domain)
+        self.nameservers = try container.decodeIfPresent([String].self, forKey: .nameservers) ?? Self.defaultNameservers
+        self.searchDomains = try container.decodeIfPresent([String].self, forKey: .searchDomains) ?? Self.defaultSearchDomains
+        self.options = try container.decodeIfPresent([String].self, forKey: .options) ?? Self.defaultOptions
     }
 }
 

--- a/Sources/Services/ContainerAPIService/Client/Utility.swift
+++ b/Sources/Services/ContainerAPIService/Client/Utility.swift
@@ -223,13 +223,7 @@ public struct Utility {
         if management.dnsDisabled {
             config.dns = nil
         } else {
-            let domain = management.dns.domain ?? containerSystemConfig.dns.domain
-            config.dns = .init(
-                nameservers: management.dns.nameservers,
-                domain: domain,
-                searchDomains: management.dns.searchDomains,
-                options: management.dns.options
-            )
+            config.dns = dnsConfiguration(from: management.dns, defaults: containerSystemConfig.container.dns)
         }
 
         config.rosetta = management.rosetta || (Platform.current.architecture == "arm64" && requestedPlatform.architecture == "amd64")
@@ -328,6 +322,31 @@ public struct Utility {
             throw ContainerizationError(.invalidState, message: "builtin network is not present")
         }
         return [AttachmentConfiguration(network: builtinNetworkId, options: AttachmentOptions(hostname: fqdn ?? containerId, macAddress: nil, mtu: 1280))]
+    }
+
+    public static func dnsConfiguration(
+        from flags: Flags.DNS,
+        defaults: ContainerDNSConfig
+    ) -> ContainerConfiguration.DNSConfiguration {
+        let nameservers =
+            flags.nameservers.isEmpty
+            ? defaults.nameservers
+            : flags.nameservers
+        let domain = flags.domain ?? defaults.domain
+        let searchDomains =
+            flags.searchDomains.isEmpty
+            ? defaults.searchDomains
+            : flags.searchDomains
+        let options =
+            flags.options.isEmpty
+            ? defaults.options
+            : flags.options
+        return .init(
+            nameservers: nameservers,
+            domain: domain,
+            searchDomains: searchDomains,
+            options: options
+        )
     }
 
     private static func getKernel(management: Flags.Management) async throws -> Kernel {

--- a/Sources/Services/ContainerAPIService/Client/Utility.swift
+++ b/Sources/Services/ContainerAPIService/Client/Utility.swift
@@ -223,7 +223,11 @@ public struct Utility {
         if management.dnsDisabled {
             config.dns = nil
         } else {
-            config.dns = dnsConfiguration(from: management.dns, defaults: containerSystemConfig.container.dns)
+            config.dns = dnsConfiguration(
+                from: management.dns,
+                defaults: containerSystemConfig.container.dns,
+                hostDomainFallback: containerSystemConfig.dns.domain
+            )
         }
 
         config.rosetta = management.rosetta || (Platform.current.architecture == "arm64" && requestedPlatform.architecture == "amd64")
@@ -326,13 +330,14 @@ public struct Utility {
 
     public static func dnsConfiguration(
         from flags: Flags.DNS,
-        defaults: ContainerDNSConfig
+        defaults: ContainerDNSConfig,
+        hostDomainFallback: String? = nil
     ) -> ContainerConfiguration.DNSConfiguration {
         let nameservers =
             flags.nameservers.isEmpty
             ? defaults.nameservers
             : flags.nameservers
-        let domain = flags.domain ?? defaults.domain
+        let domain = flags.domain ?? defaults.domain ?? hostDomainFallback
         let searchDomains =
             flags.searchDomains.isEmpty
             ? defaults.searchDomains

--- a/Tests/CLITests/Subcommands/Run/TestCLIRunCommand.swift
+++ b/Tests/CLITests/Subcommands/Run/TestCLIRunCommand.swift
@@ -914,7 +914,7 @@ class TestCLIRunCommand3: CLITest {
 
     func getDefaultDomain() throws -> String? {
         let config = try getSystemConfig()
-        return config.dns.domain
+        return config.container.dns.domain
     }
 
     @Test func testPrivilegedPortError() throws {

--- a/Tests/ContainerAPIClientTests/UtilityTests.swift
+++ b/Tests/ContainerAPIClientTests/UtilityTests.swift
@@ -162,6 +162,36 @@ struct UtilityTests {
     }
 
     @Test
+    func testDNSConfigurationDomainFallsBackToHostDomain() {
+        let defaults = ContainerDNSConfig()
+        let flags = Flags.DNS(
+            domain: nil,
+            nameservers: [],
+            options: [],
+            searchDomains: []
+        )
+
+        let result = Utility.dnsConfiguration(from: flags, defaults: defaults, hostDomainFallback: "host.local")
+
+        #expect(result.domain == "host.local")
+    }
+
+    @Test
+    func testDNSConfigurationContainerDomainWinsOverHostDomain() {
+        let defaults = ContainerDNSConfig(domain: "container.local")
+        let flags = Flags.DNS(
+            domain: nil,
+            nameservers: [],
+            options: [],
+            searchDomains: []
+        )
+
+        let result = Utility.dnsConfiguration(from: flags, defaults: defaults, hostDomainFallback: "host.local")
+
+        #expect(result.domain == "container.local")
+    }
+
+    @Test
     func testPublishPortParser() throws {
         let ports = try Parser.publishPorts([
             "127.0.0.1:8000:9080",

--- a/Tests/ContainerAPIClientTests/UtilityTests.swift
+++ b/Tests/ContainerAPIClientTests/UtilityTests.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerPersistence
 import ContainerResource
 import ContainerizationError
 import Foundation
@@ -88,6 +89,76 @@ struct UtilityTests {
         #expect(throws: Error.self) {
             try Utility.validMACAddress("02.42.ac.11.00.02")  // Wrong separator
         }
+    }
+
+    @Test
+    func testDNSConfigurationUsesDefaultsWhenFlagsAbsent() {
+        let defaults = ContainerDNSConfig(
+            domain: "corp.local",
+            nameservers: ["1.1.1.1"],
+            searchDomains: ["corp.local"],
+            options: ["ndots:2"]
+        )
+
+        let flags = Flags.DNS(
+            domain: nil,
+            nameservers: [],
+            options: [],
+            searchDomains: []
+        )
+
+        let result = Utility.dnsConfiguration(from: flags, defaults: defaults)
+
+        #expect(result.domain == "corp.local")
+        #expect(result.nameservers == ["1.1.1.1"])
+        #expect(result.searchDomains == ["corp.local"])
+        #expect(result.options == ["ndots:2"])
+    }
+
+    @Test
+    func testDNSConfigurationFlagsOverrideDefaults() {
+        let defaults = ContainerDNSConfig(
+            domain: "corp.local",
+            nameservers: ["1.1.1.1"],
+            searchDomains: ["corp.local"],
+            options: ["ndots:2"]
+        )
+        let flags = Flags.DNS(
+            domain: "cli.local",
+            nameservers: ["8.8.8.8"],
+            options: ["debug"],
+            searchDomains: ["cli.local"]
+        )
+
+        let result = Utility.dnsConfiguration(from: flags, defaults: defaults)
+
+        #expect(result.domain == "cli.local")
+        #expect(result.nameservers == ["8.8.8.8"])
+        #expect(result.searchDomains == ["cli.local"])
+        #expect(result.options == ["debug"])
+    }
+
+    @Test
+    func testDNSConfigurationPartialFlagsFallbackToDefaults() {
+        let defaults = ContainerDNSConfig(
+            domain: "corp.local",
+            nameservers: ["1.1.1.1"],
+            searchDomains: ["corp.local"],
+            options: ["ndots:2"]
+        )
+        let flags = Flags.DNS(
+            domain: nil,
+            nameservers: ["8.8.8.8"],
+            options: [],
+            searchDomains: []
+        )
+
+        let result = Utility.dnsConfiguration(from: flags, defaults: defaults)
+
+        #expect(result.domain == "corp.local")
+        #expect(result.nameservers == ["8.8.8.8"])
+        #expect(result.searchDomains == ["corp.local"])
+        #expect(result.options == ["ndots:2"])
     }
 
     @Test

--- a/Tests/ContainerCommandsTests/BuilderStartTests.swift
+++ b/Tests/ContainerCommandsTests/BuilderStartTests.swift
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerResource
+import Testing
+
+@testable import ContainerCommands
+
+struct BuilderStartTests {
+    @Test
+    func dnsConfigurationChangedTreatsMissingAndEmptyAsEquivalent() {
+        let desired = ContainerConfiguration.DNSConfiguration()
+
+        #expect(!Application.BuilderStart.dnsConfigurationChanged(existing: nil, desired: desired))
+    }
+
+    @Test
+    func dnsConfigurationChangedDetectsRemovedConfiguration() {
+        let existing = ContainerConfiguration.DNSConfiguration(
+            nameservers: ["1.1.1.1"],
+            domain: "corp.local",
+            searchDomains: ["corp.local"],
+            options: ["ndots:2"]
+        )
+        let desired = ContainerConfiguration.DNSConfiguration()
+
+        #expect(Application.BuilderStart.dnsConfigurationChanged(existing: existing, desired: desired))
+    }
+
+    @Test
+    func dnsConfigurationChangedDetectsAddedConfiguration() {
+        let desired = ContainerConfiguration.DNSConfiguration(
+            nameservers: ["8.8.8.8"],
+            domain: "lab.local",
+            searchDomains: ["lab.local"],
+            options: ["timeout:1"]
+        )
+
+        #expect(Application.BuilderStart.dnsConfigurationChanged(existing: nil, desired: desired))
+    }
+}

--- a/Tests/ContainerPersistenceTests/ConfigurationLoaderTests.swift
+++ b/Tests/ContainerPersistenceTests/ConfigurationLoaderTests.swift
@@ -90,6 +90,10 @@ struct ConfigurationLoaderTests {
             #expect(config.build.memory == BuildConfig.defaultMemory)
             #expect(config.container.cpus == 4)
             #expect(config.container.memory == ContainerConfig.defaultMemory)
+            #expect(config.container.dns.domain == nil)
+            #expect(config.container.dns.nameservers == [])
+            #expect(config.container.dns.searchDomains == [])
+            #expect(config.container.dns.options == [])
             #expect(config.dns.domain == nil)
             #expect(!config.build.image.isEmpty)
             #expect(!config.vminit.image.isEmpty)
@@ -114,8 +118,14 @@ struct ConfigurationLoaderTests {
                 cpus = 16
                 memory = "8g"
 
+                [container.dns]
+                domain = "container.custom"
+                nameservers = ["1.1.1.1", "8.8.8.8"]
+                searchDomains = ["corp.local", "lab.corp.local"]
+                options = ["ndots:2", "timeout:1"]
+
                 [dns]
-                domain = "custom"
+                domain = "host.custom"
 
                 [kernel]
                 binaryPath = "custom/path"
@@ -142,7 +152,11 @@ struct ConfigurationLoaderTests {
             #expect(config.container.cpus == 16)
             let expectedContainerMemory = try MemorySize("8g")
             #expect(config.container.memory == expectedContainerMemory)
-            #expect(config.dns.domain == "custom")
+            #expect(config.container.dns.domain == "container.custom")
+            #expect(config.container.dns.nameservers == ["1.1.1.1", "8.8.8.8"])
+            #expect(config.container.dns.searchDomains == ["corp.local", "lab.corp.local"])
+            #expect(config.container.dns.options == ["ndots:2", "timeout:1"])
+            #expect(config.dns.domain == "host.custom")
             #expect(config.build.image == "custom-builder:latest")
             #expect(config.vminit.image == "custom-init:latest")
             #expect(config.kernel.binaryPath == "custom/path")
@@ -170,6 +184,24 @@ struct ConfigurationLoaderTests {
             #expect(config.build.memory == BuildConfig.defaultMemory)
             #expect(config.container.cpus == 4)
             #expect(config.container.memory == ContainerConfig.defaultMemory)
+        }
+    }
+
+    @Test func containerDNSArraysLoadFromTomlIndependently() async throws {
+        try await TemporaryStorage.withTempDir { tempDir in
+            let toml = """
+                [container.dns]
+                nameservers = ["1.1.1.1", "8.8.8.8"]
+                """
+            let tmpFile = tempDir.appending("dns.toml")
+            try Self.writeToml(toml, to: tmpFile)
+
+            let config: ContainerSystemConfig = try await ConfigurationLoader.load(configurationFiles: [tmpFile])
+            #expect(config.container.dns.nameservers == ["1.1.1.1", "8.8.8.8"])
+            #expect(config.container.dns.domain == nil)
+            #expect(config.container.dns.searchDomains == [])
+            #expect(config.container.dns.options == [])
+            #expect(config.dns.domain == nil)
         }
     }
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -85,7 +85,7 @@ container run [<options>] <image> [<arguments> ...]
             - `10.*.*.*`
             - `192.168.*.*`
             - `172.16.*.*` through `172.31.*.*`
-        - The host ends with the machine's default container DNS domain (as defined in `DNSConfig.defaultDomain`, located [here](../Sources/ContainerPersistence/ContainerSystemConfig.swift))
+        - The host ends with the machine's configured internal DNS domain from `[dns].domain`
 
         For internal/local registries, the client uses **HTTP**. Otherwise, it uses **HTTPS**.
 
@@ -1276,4 +1276,3 @@ container system property list
 # output as JSON for scripting
 container system property list --format json
 ```
-

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -651,6 +651,12 @@ image = "ghcr.io/apple/container-builder-shim/builder:0.11.0"
 cpus = 4
 memory = "1gb"
 
+[container.dns]
+domain = "corp.local"
+nameservers = ["1.1.1.1", "8.8.8.8"]
+searchDomains = ["corp.local", "lab.corp.local"]
+options = ["ndots:2", "timeout:1"]
+
 [dns]
 domain = "test"
 
@@ -677,6 +683,20 @@ rosetta = false
 ```
 
 This is useful when you want to ensure builds only produce native arm64 images and avoid any x86_64 emulation.
+
+### Example: Set default container DNS settings
+
+To avoid passing `--dns`, `--dns-search`, and `--dns-option` on every `container run`, `container build`, or `container builder start` invocation, set defaults in `~/.config/container/config.toml`:
+
+```toml
+[container.dns]
+domain = "corp.local"
+nameservers = ["1.1.1.1", "8.8.8.8"]
+searchDomains = ["corp.local", "lab.corp.local"]
+options = ["ndots:2", "timeout:1"]
+```
+
+CLI flags override these defaults when provided. Use `container run --no-dns` to skip DNS configuration entirely. The top-level `[dns]` section configures the internal DNS domain used by the host and API server. Restart the daemon (`container system stop && container system start`) for changes to take effect.
 
 ## View system logs
 


### PR DESCRIPTION
## Type of Change
- [x] New feature

## Motivation and Context

Closes #1449. Adds default values for `--dns`, `--dns-search`, `--dns-option`, and `--dns-domain` to the `[dns]` section of `~/.config/container/config.toml`, so users hitting macOS `mDNSResponder` conflicts can set the workaround once instead of repeating it on every invocation. Depends on the merged TOML configuration introduced by #1425.

Defaults are read by `container run`, `container build`, and `container builder start` via a shared `Utility.dnsConfiguration(from:defaults:)` helper. CLI flags take precedence; `--no-dns` still disables DNS. Two pre-existing bugs in the build path were fixed to make the feature work end-to-end: `BuildCommand` was forwarding only `dnsNameservers` to the builder (now forwards all four DNS fields), and `BuilderStart`'s `dnsChanged` check only compared the first non-empty field (now compares all four).

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [x] Added/updated docs