### PR TITLE
Fix TestCLIVersion build-type check for release CI

### DIFF
--- a/Tests/CLITests/Subcommands/System/TestCLIVersion.swift
+++ b/Tests/CLITests/Subcommands/System/TestCLIVersion.swift
@@ -36,15 +36,12 @@ final class TestCLIVersion: CLITest {
         let server: VersionInfo?
     }
 
-    private func expectedBuildType() throws -> String {
-        let path = try executablePath
-        if path.path.contains("/debug/") {
-            return "debug"
-        } else if path.path.contains("/release/") {
-            return "release"
-        }
-        // Fallback: prefer debug when ambiguous (matches SwiftPM default for tests)
+    private func expectedBuildType() -> String {
+        #if DEBUG
         return "debug"
+        #else
+        return "release"
+        #endif
     }
 
     @Test func defaultDisplaysTable() throws {
@@ -60,7 +57,7 @@ final class TestCLIVersion: CLITest {
         #expect(lines[1].hasPrefix("container"))
 
         // Build should reflect the binary we are running (debug/release)
-        let expected = try expectedBuildType()
+        let expected = expectedBuildType()
         #expect(lines.joined(separator: "\n").contains(" \(expected) "))
         _ = data  // silence unused warning if assertions short-circuit
     }
@@ -75,7 +72,7 @@ final class TestCLIVersion: CLITest {
         #expect(!decoded[0].version.isEmpty)
         #expect(!decoded[0].commit.isEmpty)
 
-        let expected = try expectedBuildType()
+        let expected = expectedBuildType()
         #expect(decoded[0].buildType == expected)
     }
 
@@ -89,7 +86,7 @@ final class TestCLIVersion: CLITest {
         #expect(!decoded[0].version.isEmpty)
         #expect(!decoded[0].commit.isEmpty)
 
-        let expected = try expectedBuildType()
+        let expected = expectedBuildType()
         #expect(decoded[0].buildType == expected)
     }
 
@@ -110,7 +107,7 @@ final class TestCLIVersion: CLITest {
         #expect(status == 0, "version --format json should succeed, stderr: \(err)")
         let decoded = try JSONDecoder().decode([VersionOutput].self, from: data)
 
-        let expected = try expectedBuildType()
+        let expected = expectedBuildType()
         #expect(decoded[0].buildType == expected, "Expected build type \(expected) but got \(decoded[0].buildType)")
     }
 }


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Refer to https://github.com/apple/container/issues/1626

Fix by using the expected build from the test's compile config.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

Tested Result:
<img width="3234" height="1060" alt="Screenshot 2569-06-02 at 16 39 05@2x" src="https://github.com/user-attachments/assets/726eb349-67a3-4ee3-bff9-6302e9c2aca5" />

