### PR TITLE
Add an error message for dockerfile >= 16KB until #735 is resolved

### DIFF
--- a/Sources/ContainerCommands/BuildCommand.swift
+++ b/Sources/ContainerCommands/BuildCommand.swift
@@ -251,6 +251,20 @@ extension Application {
                     ignoreFileData = try? Data(contentsOf: ignoreFileURL)
                 }
 
+                // BUG: See https://github.com/apple/container/issues/735.
+                // Reject dockerfiles larger than 16kb before attempting to build.
+                // TODO: Remove when #735 was been resolved.
+                let maxDockerfileSize = 16 * 1024  // 16 KiB
+                guard buildFileData.count < maxDockerfileSize else {
+                    throw ContainerizationError(
+                        .invalidArgument,
+                        message: """
+                            Dockerfile size (\(buildFileData.count) bytes) exceeds the maximum allowed size of \(maxDockerfileSize) bytes. \
+                            See https://github.com/apple/container/issues/735.
+                            """
+                    )
+                }
+
                 let secretsData: [String: Data] = try self.secrets.mapValues { secret in
                     switch secret {
                     case .data(let data):


### PR DESCRIPTION
## Type of Change
- [x] New feature  

## Motivation and Context
Closes https://github.com/apple/container/issues/1633. We have a known issue https://github.com/apple/container/issues/735 where Dockerfiles over the size 16kb will fail to build due to "Transport became inactive" or "Stream unexpectedly closed" errors. While we wait for a fix for https://github.com/apple/container/issues/735, this PR adds an error message if a user tries to build an image using a dockerfile >= 16kb.

## Testing
- [x] Tested locally
