### PR TITLE
Fix `make test` SIGSEGV on Swift 6.2

### DIFF
--- a/Tests/ContainerCommandsTests/HelpCommandTests.swift
+++ b/Tests/ContainerCommandsTests/HelpCommandTests.swift
@@ -32,14 +32,16 @@ struct HelpCommandTests {
             for child in children {
                 guard let name = child.configuration.commandName else { continue }
                 let canonical = path + [name]
+                let canonicalResolved = HelpCommand.resolveSubcommand(path: canonical) != nil
                 #expect(
-                    HelpCommand.resolveSubcommand(path: canonical) != nil,
+                    canonicalResolved,
                     "help should resolve '\(canonical.joined(separator: " "))' but returned nil"
                 )
                 for alias in child.configuration.aliases {
                     let aliasPath = path + [alias]
+                    let aliasResolved = HelpCommand.resolveSubcommand(path: aliasPath) != nil
                     #expect(
-                        HelpCommand.resolveSubcommand(path: aliasPath) != nil,
+                        aliasResolved,
                         "help should resolve alias path '\(aliasPath.joined(separator: " "))' but returned nil"
                     )
                 }
@@ -51,7 +53,9 @@ struct HelpCommandTests {
 
     @Test
     func unknownSubcommandReturnsNil() {
-        #expect(HelpCommand.resolveSubcommand(path: ["nonexistent"]) == nil)
-        #expect(HelpCommand.resolveSubcommand(path: ["image", "nonexistent"]) == nil)
+        let unknownResolved = HelpCommand.resolveSubcommand(path: ["nonexistent"]) == nil
+        #expect(unknownResolved)
+        let nestedUnknownResolved = HelpCommand.resolveSubcommand(path: ["image", "nonexistent"]) == nil
+        #expect(nestedUnknownResolved)
     }
 }


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
`make test` crashed with signal code 11. Root cause: in HelpCommandTests, #expect(...) compares an optional metatype (ParsableCommand.Type?) against nil. #expect decomposes the comparison into a generic helper, forcing the Swift 6.2 runtime to instantiate generic metadata over the metatype — which segfaults in libswiftCore. (Works fine on 6.3; 6.2 is still supported by Container.)

Fix: precompute each comparison into a Bool before passing it to #expect, so it never enters the generic-metadata path. Both crash sites needed it (fixing one moves the crash to the other).

Test: full unit suite now runs to completion on Swift 6.2 — no SIGSEGV.

Closes #1637 

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs
