### PR TITLE
Make pre-commit hook installation and execution work in git worktrees

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,12 +319,13 @@ check-licenses:
 
 .PHONY: pre-commit
 pre-commit:
-	cp scripts/pre-commit.fmt .git/hooks
-	touch .git/hooks/pre-commit
-	cat .git/hooks/pre-commit | grep -v 'hooks/pre-commit\.fmt' > /tmp/pre-commit.new || true
-	echo 'PRECOMMIT_NOFMT=$${PRECOMMIT_NOFMT} $$(git rev-parse --show-toplevel)/.git/hooks/pre-commit.fmt' >> /tmp/pre-commit.new
-	mv /tmp/pre-commit.new .git/hooks/pre-commit
-	chmod +x .git/hooks/pre-commit
+	$(eval HOOKS_DIR := $(shell git rev-parse --git-path hooks))
+	cp scripts/pre-commit.fmt $(HOOKS_DIR)/
+	touch $(HOOKS_DIR)/pre-commit
+	cat $(HOOKS_DIR)/pre-commit | grep -v 'hooks/pre-commit\.fmt' > /tmp/pre-commit.new || true
+	echo 'PRECOMMIT_NOFMT=$${PRECOMMIT_NOFMT} $$(git rev-parse --git-path hooks/pre-commit.fmt)' >> /tmp/pre-commit.new
+	mv /tmp/pre-commit.new $(HOOKS_DIR)/pre-commit
+	chmod +x $(HOOKS_DIR)/pre-commit
 
 .PHONY: serve-docs
 serve-docs:


### PR DESCRIPTION
## Summary

`make pre-commit` and the hook it installs both assume the current directory is the main repo checkout. In a git worktree both assumptions fail:

- `git rev-parse --show-toplevel` returns the worktree's checkout path (e.g. `/tmp/wt-test`).
- `.git` inside a worktree is a *file* containing `gitdir: ...`, not a directory.
- So `cp scripts/pre-commit.fmt .git/hooks` and the generated wrapper's `$(show-toplevel)/.git/hooks/pre-commit.fmt` both reference a path that does not exist, and any commit attempt from a worktree fails with `bash: ...: Not a directory`.

This PR replaces the path computation with `git rev-parse --git-path hooks/...`, which resolves to the shared hooks directory in both the main checkout and any worktree.

Fixes #1641.

## Test plan

- [x] `make pre-commit` succeeds in the main checkout; generated hook content shows `$(git rev-parse --git-path hooks/pre-commit.fmt)`.
- [x] `git worktree add /tmp/wt && cd /tmp/wt && git commit --allow-empty -m "test"` now runs the hook successfully (gets through swift-format and into hawkeye, instead of failing in the wrapper).
- [x] Existing behavior in the main checkout unchanged.