### PR TITLE
Auto-install hawkeye in ensure-hawkeye-exists.sh

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -35,6 +35,8 @@ jobs:
           fetch-depth: 0
 
       - name: Check formatting
+        env:
+          HAWKEYE_AUTO_INSTALL: "1"
         run: |
           ./scripts/install-hawkeye.sh
           make fmt

--- a/Makefile
+++ b/Makefile
@@ -326,6 +326,7 @@ pre-commit:
 	echo 'PRECOMMIT_NOFMT=$${PRECOMMIT_NOFMT} $$(git rev-parse --git-path hooks/pre-commit.fmt)' >> /tmp/pre-commit.new
 	mv /tmp/pre-commit.new $(HOOKS_DIR)/pre-commit
 	chmod +x $(HOOKS_DIR)/pre-commit
+	@./scripts/ensure-hawkeye-exists.sh
 
 .PHONY: serve-docs
 serve-docs:

--- a/scripts/ensure-hawkeye-exists.sh
+++ b/scripts/ensure-hawkeye-exists.sh
@@ -13,12 +13,79 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
+auto_install=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --auto-install|-y)
+            auto_install=1
+            ;;
+        -h|--help)
+            cat <<EOF
+Usage: $(basename "$0") [--auto-install|-y]
+
+Checks for a working hawkeye installation under .local/bin/.
+If hawkeye is missing, prompts before running scripts/install-hawkeye.sh.
+
+Skip the prompt non-interactively in either of two ways:
+  --auto-install, -y      pass on the command line
+  HAWKEYE_AUTO_INSTALL=1  set in the environment
+EOF
+            exit 0
+            ;;
+        *)
+            echo "unknown argument: $arg" >&2
+            echo "see '$(basename "$0") --help' for usage" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ "${HAWKEYE_AUTO_INSTALL:-}" == "1" ]]; then
+    auto_install=1
+fi
+
 echo "Checking existence of hawkeye..."
 
 if command -v .local/bin/hawkeye >/dev/null 2>&1; then
     echo "hawkeye found!"
-else
-    echo "hawkeye not found in PATH"
-    echo "please install hawkeye. For convenience, you can run scripts/install-hawkeye.sh"
-    exit 1
+    exit 0
 fi
+
+cat <<EOF
+
+hawkeye is not installed.
+
+scripts/install-hawkeye.sh will install it by running:
+
+    curl -LsSf https://github.com/korandoru/hawkeye/releases/download/<version>/hawkeye-installer.sh | sh
+
+and performs the installation by passing the downloaded content to \`sh\`.
+
+(See scripts/install-hawkeye.sh for the pinned version.)
+EOF
+
+if [[ "$auto_install" -eq 1 ]]; then
+    echo
+    echo "Auto-install enabled; proceeding."
+elif [[ ! -t 0 ]]; then
+    echo
+    echo "Non-interactive context detected. Refusing to install silently." >&2
+    echo "Set HAWKEYE_AUTO_INSTALL=1 or pass --auto-install to proceed." >&2
+    exit 1
+else
+    echo
+    read -r -p "Proceed with install? [y/N] " response
+    case "$response" in
+        [yY][eE][sS]|[yY])
+            ;;
+        *)
+            echo "please install hawkeye. For convenience, you can run scripts/install-hawkeye.sh"
+            exit 1
+            ;;
+    esac
+fi
+
+exec "$(dirname "$0")/install-hawkeye.sh"


### PR DESCRIPTION
## Summary

`scripts/ensure-hawkeye-exists.sh` previously checked for hawkeye and exited 1 with a message asking the contributor to install it manually. Since `make pre-commit` doesn't run the installer either, every fresh contributor hits the same wall on their first commit — `make pre-commit` succeeds, but the very next commit attempt fails on `make check` with no signal from the earlier step that anything was missing.

This change makes `ensure-hawkeye-exists.sh` install hawkeye when it's missing, by `exec`-ing the existing `scripts/install-hawkeye.sh`. "Ensure" now does what the name suggests.

If you'd prefer the install to stay opt-in (e.g. so contributors stay in explicit control of `curl | sh` flows), I'm happy to convert this to an alternative shape — having `make pre-commit` depend on a target that installs hawkeye, or having `make pre-commit` print a clear note that hawkeye must be installed separately.

Fixes #1642.

## Test plan

- [x] Delete `.local/bin/hawkeye`, run `scripts/ensure-hawkeye-exists.sh` — installs hawkeye and exits 0.
- [x] Run `scripts/ensure-hawkeye-exists.sh` when hawkeye is already present — prints "hawkeye found!" and exits 0 (unchanged).
- [x] `make check` succeeds after a single end-to-end `make pre-commit` + commit cycle on a fresh checkout.