### PR TITLE
[Actions] Use commit sha for imported gh actions

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -197,7 +197,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
       - name: Download a single artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -209,6 +209,6 @@ jobs:
           tar xfz _site.tgz
 
       - name: Upload Artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: "./_site"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -44,7 +44,7 @@ jobs:
           test -e outputs/container-package/*.pkg || (echo "Missing .pkg file!" && exit 1)
 
       - name: Create release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           token: ${{ github.token }}
           name: ${{ github.ref_name }}-prerelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           test -e outputs/container-package/*.pkg || (echo "Missing .pkg file!" && exit 1)
 
       - name: Create release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           token: ${{ github.token }}
           name: ${{ github.ref_name }}-prerelease


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context
This PR updates the GitHub workflows to ensure all imported actions are referenced by commit SHA. 