### PR TITLE
Rearrange shape of JSON output for images

### DIFF
--- a/Sources/ContainerCommands/Image/ImageInspect.swift
+++ b/Sources/ContainerCommands/Image/ImageInspect.swift
@@ -59,8 +59,9 @@ extension Application {
                         initImage: containerSystemConfig.vminit.image
                     )
                 else { continue }
-                let resolved = try await image.resolvedManifests()
-                printable.append(ImageResource(config: image.description, index: resolved.index, manifests: resolved.manifests))
+                printable.append(
+                    try await image.toImageResource(containerSystemConfig: containerSystemConfig)
+                )
             }
 
             try Output.emit(Output.renderJSON(printable, options: .pretty))

--- a/Sources/ContainerCommands/Image/ImageList.swift
+++ b/Sources/ContainerCommands/Image/ImageList.swift
@@ -90,10 +90,9 @@ extension Application {
         private static func buildResources(images: [ClientImage], containerSystemConfig: ContainerSystemConfig) async throws -> [ImageResource] {
             var resources: [ImageResource] = []
             for image in images {
-                let resolved = try await image.resolvedManifests()
-                let displayReference = try ClientImage.denormalizeReference(image.reference, containerSystemConfig: containerSystemConfig)
                 resources.append(
-                    ImageResource(config: image.description, index: resolved.index, manifests: resolved.manifests, displayReference: displayReference))
+                    try await image.toImageResource(containerSystemConfig: containerSystemConfig)
+                )
             }
             return resources
         }
@@ -134,7 +133,7 @@ private struct VerboseImageRow: ListDisplayable {
         let reference = try? ContainerizationOCI.Reference.parse(resource.displayReference)
         let name = reference?.name ?? resource.displayReference
         let tag = reference?.tag ?? "<none>"
-        let indexDigest = Utility.trimDigest(digest: resource.index.digest)
+        let indexDigest = Utility.trimDigest(digest: resource.configuration.descriptor.digest)
         return
             resource.variants
             // Skip attestation manifests, which use the `unknown/unknown` platform.

--- a/Sources/ContainerCommands/Image/ImageResource+ListDisplayable.swift
+++ b/Sources/ContainerCommands/Image/ImageResource+ListDisplayable.swift
@@ -29,7 +29,7 @@ extension ImageResource: ListDisplayable {
         return [
             reference?.name ?? displayReference,
             reference?.tag ?? "<none>",
-            Utility.trimDigest(digest: index.digest),
+            Utility.trimDigest(digest: configuration.descriptor.digest),
         ]
     }
 

--- a/Sources/ContainerResource/Image/ImageResource.swift
+++ b/Sources/ContainerResource/Image/ImageResource.swift
@@ -43,29 +43,20 @@ public struct ImageResource: ManagedResource {
         }
     }
 
-    /// Already-resolved OCI content for a single platform manifest, used as
-    /// input when building an ``ImageResource``. The variant's total size is
-    /// computed from these pieces during initialization.
-    public struct ManifestContent {
-        /// The manifest descriptor as listed in the image index.
-        public let descriptor: Descriptor
-        /// The platform manifest.
-        public let manifest: ContainerizationOCI.Manifest
-        /// The OCI image config for the platform.
-        public let config: ContainerizationOCI.Image
+    public struct ImageConfiguration: Sendable, Codable {
+        public let creationDate: Date
+        public var name: String
+        public var descriptor: Descriptor
 
-        public init(descriptor: Descriptor, manifest: ContainerizationOCI.Manifest, config: ContainerizationOCI.Image) {
-            self.descriptor = descriptor
-            self.manifest = manifest
-            self.config = config
+        public init(description: ImageDescription, creationDate: Date) {
+            self.creationDate = creationDate
+            self.name = description.reference
+            self.descriptor = description.descriptor
         }
     }
 
     /// The image's description — its reference and index descriptor.
-    public let config: ImageDescription
-
-    /// The resolved index descriptor for the image.
-    public let index: Descriptor
+    public let configuration: ImageConfiguration
 
     /// The platform-specific variants contained in the image.
     public let variants: [Variant]
@@ -76,91 +67,30 @@ public struct ImageResource: ManagedResource {
     /// Defaults to the full ``name`` when not supplied.
     public let displayReference: String
 
-    /// The creation date resolved from the OCI image config, if available.
-    private let created: Date?
-
     // MARK: ManagedResource
 
     /// The unique identifier for this image. Identical to the image's index digest.
-    public var id: String { config.digest }
+    public var id: String { configuration.descriptor.digest }
 
     /// The user-facing reference (`name:tag`) for this image.
-    public var name: String { config.reference }
+    public var name: String { configuration.name }
 
     /// The time at which the image was created, resolved from the OCI image
     /// config. Falls back to the Unix epoch when no creation date is recorded.
-    public var creationDate: Date { created ?? Date(timeIntervalSince1970: 0) }
+    public var creationDate: Date { configuration.creationDate }
 
     /// Key-value labels for this image, derived from the index descriptor's
     /// annotations. Returns an empty label set if the annotations fail
     /// ``ResourceLabels`` validation.
     public var labels: ResourceLabels {
-        (try? ResourceLabels(config.descriptor.annotations ?? [:])) ?? ResourceLabels()
+        (try? ResourceLabels(configuration.descriptor.annotations ?? [:])) ?? ResourceLabels()
     }
 
     // MARK: Initialization
-
-    /// Creates an image resource.
-    ///
-    /// - Parameters:
-    ///   - config: The image's description (reference and index descriptor).
-    ///   - index: The resolved index descriptor.
-    ///   - variants: The per-platform variants contained in the image.
-    ///   - created: The creation date resolved from the OCI image config, if any.
-    ///   - displayReference: The denormalized reference for human-facing
-    ///     listings. Defaults to the full reference when `nil`.
-    public init(config: ImageDescription, index: Descriptor, variants: [Variant], created: Date? = nil, displayReference: String? = nil) {
-        self.config = config
-        self.index = index
+    public init(configuration: ImageConfiguration, variants: [Variant], displayReference: String? = nil) {
+        self.configuration = configuration
         self.variants = variants
-        self.created = created
-        self.displayReference = displayReference ?? config.reference
-    }
-}
-
-extension ImageResource {
-    /// Creates an image resource from already-resolved index and manifest
-    /// content.
-    ///
-    /// This initializer performs the variant resolution: it computes each
-    /// platform variant's total size (manifest descriptor + config + layers)
-    /// and derives the image's creation date from the earliest variant's OCI
-    /// config `created` timestamp.
-    ///
-    /// - Parameters:
-    ///   - config: The image's description (reference and index descriptor).
-    ///   - index: The resolved index descriptor.
-    ///   - manifests: The already-resolved per-platform manifest content.
-    ///   - displayReference: The denormalized reference for human-facing
-    ///     listings. Defaults to the full reference when `nil`.
-    public init(config: ImageDescription, index: Descriptor, manifests: [ManifestContent], displayReference: String? = nil) {
-        var variants: [Variant] = []
-        var created: Date?
-        for content in manifests {
-            guard let platform = content.descriptor.platform else {
-                continue
-            }
-            let size =
-                content.descriptor.size + content.manifest.config.size
-                + content.manifest.layers.reduce(0) { $0 + $1.size }
-            variants.append(Variant(platform: platform, digest: content.descriptor.digest, size: size, config: content.config))
-            // Use the earliest variant's creation timestamp as the image's date.
-            if let createdString = content.config.created, let date = Self.parseCreated(createdString) {
-                created = created.map { min($0, date) } ?? date
-            }
-        }
-        self.init(config: config, index: index, variants: variants, created: created, displayReference: displayReference)
-    }
-
-    private static func parseCreated(_ value: String) -> Date? {
-        let withFractional = ISO8601DateFormatter()
-        withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        if let date = withFractional.date(from: value) {
-            return date
-        }
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime]
-        return formatter.date(from: value)
+        self.displayReference = displayReference ?? configuration.name
     }
 }
 
@@ -177,10 +107,7 @@ extension ImageResource {
     enum CodingKeys: String, CodingKey {
         case id
         case name
-        case creationDate
-        case labels
         case configuration
-        case index
         case variants
     }
 
@@ -188,20 +115,15 @@ extension ImageResource {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
         try container.encode(name, forKey: .name)
-        try container.encode(creationDate, forKey: .creationDate)
-        try container.encode(labels, forKey: .labels)
-        try container.encode(config, forKey: .configuration)
-        try container.encode(index, forKey: .index)
+        try container.encode(configuration, forKey: .configuration)
         try container.encode(variants, forKey: .variants)
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.config = try container.decode(ImageDescription.self, forKey: .configuration)
-        self.index = try container.decode(Descriptor.self, forKey: .index)
+        self.configuration = try container.decode(ImageConfiguration.self, forKey: .configuration)
         self.variants = try container.decode([Variant].self, forKey: .variants)
-        self.created = try container.decodeIfPresent(Date.self, forKey: .creationDate)
         // `displayReference` is a display-only value and is not serialized.
-        self.displayReference = self.config.reference
+        self.displayReference = self.configuration.name
     }
 }

--- a/Sources/Services/ContainerAPIService/Client/ClientImage+ImageResource.swift
+++ b/Sources/Services/ContainerAPIService/Client/ClientImage+ImageResource.swift
@@ -14,19 +14,21 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerPersistence
 import ContainerResource
 import ContainerizationOCI
+import Foundation
 
 extension ClientImage {
-    /// Resolves, from the content store, the index descriptor and per-platform
+    /// Resolves, from the content store, the index descriptor and per-variant
     /// manifest content needed to build an ``ImageResource``.
     ///
     /// Manifests without a platform, or whose config/manifest cannot be
-    /// fetched, are skipped. The returned content is the input expected by
-    /// ``ImageResource/init(config:index:manifests:)``.
-    public func resolvedManifests() async throws -> (index: Descriptor, manifests: [ImageResource.ManifestContent]) {
-        let index = try await self.resolved()
-        var manifests: [ImageResource.ManifestContent] = []
+    /// fetched, are skipped.
+    public func toImageResource(containerSystemConfig: ContainerSystemConfig) async throws -> ImageResource {
+        var variants: [ImageResource.Variant] = []
+        var earliest: Date?
+
         for desc in try await self.index().manifests {
             guard let platform = desc.platform else {
                 continue
@@ -39,8 +41,32 @@ extension ClientImage {
             } catch {
                 continue
             }
-            manifests.append(.init(descriptor: desc, manifest: manifest, config: config))
+            let size =
+                desc.size + manifest.config.size
+                + manifest.layers.reduce(0) { $0 + $1.size }
+
+            variants.append(.init(platform: platform, digest: desc.digest, size: size, config: config))
+
+            // Use the earliest variant's creation timestamp as the image's date.
+            if let date = config.created.flatMap(Self.parseCreated) {
+                earliest = min(earliest ?? date, date)
+            }
         }
-        return (index, manifests)
+
+        let created = earliest ?? Date(timeIntervalSince1970: 0)
+        let displayName = try Self.denormalizeReference(self.description.reference, containerSystemConfig: containerSystemConfig)
+        let configuration = ImageResource.ImageConfiguration(description: self.description, creationDate: created)
+        return ImageResource(configuration: configuration, variants: variants, displayReference: displayName)
+    }
+
+    private static func parseCreated(_ value: String) -> Date? {
+        let withFractional = ISO8601DateFormatter()
+        withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = withFractional.date(from: value) {
+            return date
+        }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: value)
     }
 }


### PR DESCRIPTION
## Motivation and Context
This PR changes the shape of the JSON output for image resources to align closer with `VolumeResource` and `NetworkResource`. This includes adding "creationDate" in the `configuration` section of the image output. This PR additionally cleans up some of the logic around the `ImageResource` struct construction. 

## Testing
- [x] Tested locally
