### PR TITLE
Fix --format yaml and toml output

### DIFF
--- a/Sources/ContainerCommands/Builder/BuilderStatus.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStatus.swift
@@ -46,24 +46,20 @@ extension Application {
                 let client = ContainerClient()
                 let container = try await client.get(id: "buildkit")
 
-                if format == .json {
-                    try Output.emit(Output.renderJSON([PrintableContainer(container)]))
+                if format == .table && quiet && container.status != .running {
                     return
                 }
 
-                if quiet && container.status != .running {
-                    return
+                try Output.render(
+                    payload: [PrintableContainer(container)],
+                    display: [PrintableBuilder(container)],
+                    format: format,
+                    quiet: quiet
+                )
+            } catch let error as ContainerizationError where error.code == .notFound {
+                try Output.render(payload: [PrintableContainer](), format: format) {
+                    quiet ? "" : "builder is not running"
                 }
-
-                Output.emit(Output.renderList([PrintableBuilder(container)], quiet: quiet))
-            } catch {
-                if let czError = error as? ContainerizationError, czError.code == .notFound {
-                    if !quiet {
-                        log.warning("builder is not running")
-                        return
-                    }
-                }
-                throw error
             }
         }
     }

--- a/Sources/ContainerCommands/Container/ContainerList.swift
+++ b/Sources/ContainerCommands/Container/ContainerList.swift
@@ -47,7 +47,7 @@ extension Application {
             let filters = self.all ? ContainerListFilters.all : ContainerListFilters(status: .running)
             let containers = try await client.list(filters: filters)
             let items = containers.map { PrintableContainer($0) }
-            try Output.render(json: items, display: items, format: format, quiet: quiet)
+            try Output.render(payload: items, display: items, format: format, quiet: quiet)
         }
     }
 }

--- a/Sources/ContainerCommands/Container/ContainerStats.swift
+++ b/Sources/ContainerCommands/Container/ContainerStats.swift
@@ -43,7 +43,7 @@ extension Application {
         public init() {}
 
         public func run() async throws {
-            if format == .json || noStream {
+            if format != .table || noStream {
                 // Static mode - get stats once and exit
                 try await runStatic()
             } else {
@@ -102,13 +102,9 @@ extension Application {
 
             let statsData = try await Self.collectStats(client: client, for: containersToShow)
 
-            if format == .json {
-                let jsonStats = statsData.map { $0.stats2 }
-                try Output.emit(Output.renderJSON(jsonStats))
-                return
+            try Output.render(payload: statsData.map { $0.stats2 }, format: format) {
+                Self.statsTable(statsData)
             }
-
-            Self.printStatsTable(statsData)
         }
 
         private static func runStreaming(containerIds: [String]) async throws {
@@ -129,7 +125,7 @@ extension Application {
 
             clearScreen()
             // Show header right away.
-            printStatsTable([])
+            print(statsTable([]))
 
             while true {
                 do {
@@ -144,7 +140,7 @@ extension Application {
 
                     // Clear screen and reprint
                     clearScreen()
-                    printStatsTable(statsData)
+                    print(statsTable(statsData))
 
                     if statsData.isEmpty {
                         try await Task.sleep(for: .seconds(2))
@@ -235,7 +231,7 @@ extension Application {
             }
         }
 
-        private static func printStatsTable(_ statsData: [StatsSnapshot]) {
+        private static func statsTable(_ statsData: [StatsSnapshot]) -> String {
             let headerRow = ["Container ID", "Cpu %", "Memory Usage", "Net Rx/Tx", "Block I/O", "Pids"]
             let notAvailable = "--"
             var rows = [headerRow]
@@ -276,8 +272,7 @@ extension Application {
             }
 
             // Always print header, even if no containers
-            let formatter = TableOutput(rows: rows)
-            print(formatter.format())
+            return TableOutput(rows: rows).format()
         }
 
         private static func clearScreen() {

--- a/Sources/ContainerCommands/Image/ImageList.swift
+++ b/Sources/ContainerCommands/Image/ImageList.swift
@@ -54,8 +54,8 @@ extension Application {
             images.sort { $0.reference < $1.reference }
 
             // Quiet mode prints references directly and skips the more expensive
-            // per-image manifest resolution. `--format json` takes precedence.
-            if quiet && format != .json {
+            // per-image manifest resolution.
+            if quiet && format == .table {
                 for image in images {
                     let processedReferenceString = try ClientImage.denormalizeReference(image.reference, containerSystemConfig: containerSystemConfig)
                     print(processedReferenceString)
@@ -65,18 +65,12 @@ extension Application {
 
             let resources = try await Self.buildResources(images: images, containerSystemConfig: containerSystemConfig)
 
-            if format == .json {
-                try Self.emitJSON(resources: resources)
-                return
+            try Output.render(payload: resources, format: format) {
+                if verbose {
+                    return Output.renderTable(resources.flatMap { VerboseImageRow.rows(for: $0) })
+                }
+                return Output.renderTable(resources)
             }
-
-            if verbose {
-                let rows = resources.flatMap { VerboseImageRow.rows(for: $0) }
-                Output.emit(Output.renderTable(rows))
-                return
-            }
-
-            Output.emit(Output.renderTable(resources))
         }
 
         private static func validate(quiet: Bool, verbose: Bool) throws {
@@ -96,10 +90,6 @@ extension Application {
                     ImageResource(config: image.description, index: resolved.index, manifests: resolved.manifests, displayReference: displayReference))
             }
             return resources
-        }
-
-        private static func emitJSON(resources: [ImageResource]) throws {
-            try Output.emit(Output.renderJSON(resources, options: .compact))
         }
     }
 }

--- a/Sources/ContainerCommands/Network/NetworkList.swift
+++ b/Sources/ContainerCommands/Network/NetworkList.swift
@@ -39,7 +39,7 @@ extension Application {
         public func run() async throws {
             let networkClient = NetworkClient()
             let networks = try await networkClient.list()
-            try Output.render(json: networks, display: networks, format: format, quiet: quiet)
+            try Output.render(payload: networks, display: networks, format: format, quiet: quiet)
         }
     }
 }

--- a/Sources/ContainerCommands/OutputRendering.swift
+++ b/Sources/ContainerCommands/OutputRendering.swift
@@ -37,9 +37,9 @@ public struct JSONOptions: Sendable {
 
 /// Shared rendering helpers for CLI output.
 ///
-/// All list commands route their output through these methods. JSON rendering
-/// is separate from table/quiet rendering because the JSON model often differs
-/// from the display model.
+/// All list commands route their output through these methods. The machine-readable
+/// payload is encoded separately from table/quiet output, since the payload model
+/// often differs from the display model.
 public enum Output {
     /// Renders an `Encodable` value as a JSON string.
     public static func renderJSON<T: Encodable>(_ value: T, options: JSONOptions = .compact) throws -> String {
@@ -57,9 +57,16 @@ public enum Output {
     }
 
     /// Renders an `Encodable` value as a TOML string.
+    ///
+    /// TOML has no top-level array, so array payloads are wrapped under a stable
+    /// `items` key (JSON and YAML emit a top-level array instead); a non-array
+    /// value encodes as a normal top-level table.
     public static func renderTOML<T: Encodable>(_ value: T) throws -> String {
         let encoder = TOMLEncoder()
         encoder.outputFormatting = .sortedKeys
+        if value is [Any] {
+            return try encoder.encodeToString(["items": value])
+        }
         return try encoder.encodeToString(value)
     }
 
@@ -80,18 +87,32 @@ public enum Output {
         return TableOutput(rows: rows).format()
     }
 
-    /// Renders list output in the requested format.
+    /// Renders `payload` in the requested format, encoding it for the
+    /// machine-readable formats and delegating `.table` to the caller.
     ///
-    /// The JSON and display models may be the same type (e.g., `PrintableContainer`)
-    /// or different types.
-    public static func render<J: Encodable, D: ListDisplayable>(
-        json: J, display: [D], format: ListFormat, quiet: Bool, jsonOptions: JSONOptions = .compact
+    /// This is the single place where `ListFormat` is matched exhaustively, so
+    /// adopting commands handle every format by construction: a new `ListFormat`
+    /// case becomes a compile error here until it is given an encoder.
+    public static func render<J: Encodable>(
+        payload: J, format: ListFormat, jsonOptions: JSONOptions = .compact, table: () throws -> String
     ) throws {
         switch format {
-        case .json: try emit(renderJSON(json, options: jsonOptions))
-        case .yaml: try emit(renderYAML(json))
-        case .table: emit(renderList(display, quiet: quiet))
-        case .toml: try emit(renderTOML(json))
+        case .json: try emit(renderJSON(payload, options: jsonOptions))
+        case .yaml: try emit(renderYAML(payload))
+        case .toml: try emit(renderTOML(payload))
+        case .table: try emit(table())
+        }
+    }
+
+    /// Renders list output in the requested format.
+    ///
+    /// The machine-readable payload and the display model may be the same type
+    /// (e.g., `PrintableContainer`) or different types.
+    public static func render<J: Encodable, D: ListDisplayable>(
+        payload: J, display: [D], format: ListFormat, quiet: Bool, jsonOptions: JSONOptions = .compact
+    ) throws {
+        try render(payload: payload, format: format, jsonOptions: jsonOptions) {
+            renderList(display, quiet: quiet)
         }
     }
 

--- a/Sources/ContainerCommands/Registry/RegistryList.swift
+++ b/Sources/ContainerCommands/Registry/RegistryList.swift
@@ -44,7 +44,7 @@ extension Application {
             let registries = registryInfos.map { RegistryResource(from: $0) }
 
             try Output.render(
-                json: registries,
+                payload: registries,
                 display: registries.map { PrintableRegistry($0) },
                 format: format, quiet: quiet
             )

--- a/Sources/ContainerCommands/System/DNS/DNSList.swift
+++ b/Sources/ContainerCommands/System/DNS/DNSList.swift
@@ -43,7 +43,7 @@ extension Application {
             let domains = resolver.listDomains()
 
             try Output.render(
-                json: domains.map { $0.pqdn },
+                payload: domains.map { $0.pqdn },
                 display: domains.map { PrintableDomain($0) },
                 format: format, quiet: quiet
             )

--- a/Sources/ContainerCommands/System/SystemDF.swift
+++ b/Sources/ContainerCommands/System/SystemDF.swift
@@ -35,16 +35,12 @@ extension Application {
 
         public func run() async throws {
             let stats = try await ClientDiskUsage.get()
-
-            if format == .json {
-                try Output.emit(Output.renderJSON(stats, options: .pretty))
-                return
+            try Output.render(payload: stats, format: format, jsonOptions: .pretty) {
+                diskUsageTable(stats: stats)
             }
-
-            printTable(stats: stats)
         }
 
-        private func printTable(stats: DiskUsageStats) {
+        private func diskUsageTable(stats: DiskUsageStats) -> String {
             var rows: [[String]] = []
 
             // Header row
@@ -78,7 +74,7 @@ extension Application {
             ])
 
             let tableFormatter = TableOutput(rows: rows)
-            print(tableFormatter.format())
+            return tableFormatter.format()
         }
 
         private func formatSize(_ bytes: UInt64) -> String {

--- a/Sources/ContainerCommands/System/SystemStatus.swift
+++ b/Sources/ContainerCommands/System/SystemStatus.swift
@@ -48,25 +48,33 @@ extension Application {
             let apiServerCommit: String
             let apiServerBuild: String
             let apiServerAppName: String
+
+            init(
+                status: String,
+                appRoot: String = "",
+                installRoot: String = "",
+                logRoot: String? = nil,
+                apiServerVersion: String = "",
+                apiServerCommit: String = "",
+                apiServerBuild: String = "",
+                apiServerAppName: String = ""
+            ) {
+                self.status = status
+                self.appRoot = appRoot
+                self.installRoot = installRoot
+                self.logRoot = logRoot
+                self.apiServerVersion = apiServerVersion
+                self.apiServerCommit = apiServerCommit
+                self.apiServerBuild = apiServerBuild
+                self.apiServerAppName = apiServerAppName
+            }
         }
 
         public func run() async throws {
             let isRegistered = try ServiceManager.isRegistered(fullServiceLabel: "\(prefix)apiserver")
             if !isRegistered {
-                if format == .json {
-                    let status = PrintableStatus(
-                        status: "unregistered",
-                        appRoot: "",
-                        installRoot: "",
-                        logRoot: nil,
-                        apiServerVersion: "",
-                        apiServerCommit: "",
-                        apiServerBuild: "",
-                        apiServerAppName: ""
-                    )
-                    try Output.emit(Output.renderJSON(status))
-                } else {
-                    print("apiserver is not running and not registered with launchd")
+                try Output.render(payload: PrintableStatus(status: "unregistered"), format: format) {
+                    "apiserver is not running and not registered with launchd"
                 }
                 Application.exit(withError: ExitCode(1))
             }
@@ -74,52 +82,40 @@ extension Application {
             // Now ping our friendly daemon. Fail after 10 seconds with no response.
             do {
                 let systemHealth = try await ClientHealthCheck.ping(timeout: .seconds(10))
-
-                if format == .json {
-                    let status = PrintableStatus(
-                        status: "running",
-                        appRoot: systemHealth.appRoot.path(percentEncoded: false),
-                        installRoot: systemHealth.installRoot.path(percentEncoded: false),
-                        logRoot: systemHealth.logRoot?.string,
-                        apiServerVersion: systemHealth.apiServerVersion,
-                        apiServerCommit: systemHealth.apiServerCommit,
-                        apiServerBuild: systemHealth.apiServerBuild,
-                        apiServerAppName: systemHealth.apiServerAppName
-                    )
-                    try Output.emit(Output.renderJSON(status))
-                } else {
-                    let rows: [[String]] = [
-                        ["FIELD", "VALUE"],
-                        ["status", "running"],
-                        ["appRoot", systemHealth.appRoot.path(percentEncoded: false)],
-                        ["installRoot", systemHealth.installRoot.path(percentEncoded: false)],
-                        ["logRoot", systemHealth.logRoot?.string ?? ""],
-                        ["apiserver.version", systemHealth.apiServerVersion],
-                        ["apiserver.commit", systemHealth.apiServerCommit],
-                        ["apiserver.build", systemHealth.apiServerBuild],
-                        ["apiserver.appName", systemHealth.apiServerAppName],
-                    ]
-                    let formatter = TableOutput(rows: rows)
-                    print(formatter.format())
+                let status = PrintableStatus(
+                    status: "running",
+                    appRoot: systemHealth.appRoot.path(percentEncoded: false),
+                    installRoot: systemHealth.installRoot.path(percentEncoded: false),
+                    logRoot: systemHealth.logRoot?.string,
+                    apiServerVersion: systemHealth.apiServerVersion,
+                    apiServerCommit: systemHealth.apiServerCommit,
+                    apiServerBuild: systemHealth.apiServerBuild,
+                    apiServerAppName: systemHealth.apiServerAppName
+                )
+                try Output.render(payload: status, format: format) {
+                    Self.statusTable(status)
                 }
             } catch {
-                if format == .json {
-                    let status = PrintableStatus(
-                        status: "not running",
-                        appRoot: "",
-                        installRoot: "",
-                        logRoot: nil,
-                        apiServerVersion: "",
-                        apiServerCommit: "",
-                        apiServerBuild: "",
-                        apiServerAppName: ""
-                    )
-                    try Output.emit(Output.renderJSON(status))
-                } else {
-                    print("apiserver is not running")
+                try Output.render(payload: PrintableStatus(status: "not running"), format: format) {
+                    "apiserver is not running"
                 }
                 Application.exit(withError: ExitCode(1))
             }
+        }
+
+        private static func statusTable(_ status: PrintableStatus) -> String {
+            let rows: [[String]] = [
+                ["FIELD", "VALUE"],
+                ["status", status.status],
+                ["appRoot", status.appRoot],
+                ["installRoot", status.installRoot],
+                ["logRoot", status.logRoot ?? ""],
+                ["apiserver.version", status.apiServerVersion],
+                ["apiserver.commit", status.apiServerCommit],
+                ["apiserver.build", status.apiServerBuild],
+                ["apiserver.appName", status.apiServerAppName],
+            ]
+            return TableOutput(rows: rows).format()
         }
     }
 }

--- a/Sources/ContainerCommands/System/SystemVersion.swift
+++ b/Sources/ContainerCommands/System/SystemVersion.swift
@@ -58,24 +58,15 @@ extension Application {
 
             let versions = [cliInfo, serverInfo].compactMap { $0 }
 
-            switch format {
-            case .table:
-                printVersionTable(versions: versions)
-            case .json:
-                try Output.emit(Output.renderJSON(versions))
-            case .yaml:
-                try Output.emit(Output.renderYAML(versions))
-            case .toml:
-                try Output.emit(Output.renderTOML(versions))
+            try Output.render(payload: versions, format: format) {
+                Self.versionTable(versions)
             }
         }
 
-        private func printVersionTable(versions: [VersionInfo]) {
+        private static func versionTable(_ versions: [VersionInfo]) -> String {
             let header = ["COMPONENT", "VERSION", "BUILD", "COMMIT"]
             let rows = [header] + versions.map { [$0.appName, $0.version, $0.buildType, $0.commit] }
-
-            let table = TableOutput(rows: rows)
-            print(table.format())
+            return TableOutput(rows: rows).format()
         }
     }
 

--- a/Sources/ContainerCommands/Volume/VolumeList.swift
+++ b/Sources/ContainerCommands/Volume/VolumeList.swift
@@ -42,7 +42,7 @@ extension Application.VolumeCommand {
         public func run() async throws {
             let volumes = try await ClientVolume.list()
             let volumeResources = volumes.map { VolumeResource(configuration: $0) }
-            try Output.render(json: volumeResources, display: volumeResources, format: format, quiet: quiet)
+            try Output.render(payload: volumeResources, display: volumeResources, format: format, quiet: quiet)
         }
     }
 }

--- a/Tests/ContainerCommandsTests/ListFormattingTests.swift
+++ b/Tests/ContainerCommandsTests/ListFormattingTests.swift
@@ -207,6 +207,32 @@ struct RenderJSONTests {
     }
 }
 
+// MARK: - renderTOML tests
+
+struct RenderTOMLTests {
+    @Test
+    func topLevelArrayProducesNonEmptyTOML() throws {
+        let items = [TestItem(id: "a", name: "first"), TestItem(id: "c", name: "second")]
+        let toml = try Output.renderTOML(items)
+        #expect(!toml.isEmpty)
+        #expect(toml.contains("first"))
+        #expect(toml.contains("second"))
+    }
+
+    @Test
+    func emptyArrayProducesNonEmptyTOML() throws {
+        let toml = try Output.renderTOML([TestItem]())
+        #expect(!toml.isEmpty)
+    }
+
+    @Test
+    func singleValueEncodesAsTopLevelTable() throws {
+        let toml = try Output.renderTOML(TestItem(id: "x", name: "y"))
+        #expect(toml.contains("id"))
+        #expect(toml.contains("x"))
+    }
+}
+
 // MARK: - JSONOptions tests
 
 struct JSONOptionsTests {


### PR DESCRIPTION
- Closes #1528.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Several commands (`builder status, image list, stats, system df, system status`) advertised `--format yaml` and `--format toml` but only handled `json`, and every other format fell through to the table. With this PR, we now route them through one shared renderer with an exhaustive switch over the format enum, so a missing format would now be a compile error, and not just fail silently.

Few more things to note:
- Since TOML has no top level array, TOML output now wraps list payloads under an `items` key, bec otherwise it was returning nothing for lists.
- `stats` now prints one static result for machine readable formats instead of opening its live table view. 
- `builder status` now returns an empty list for json/yaml/toml when no builder is running, instead of the unparseable "builder is not running" text. The table view keeps the message.
- with `-q` and no builder it now exits 0 with no output, earlier it exited non-zero.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs
