### PR TITLE
Add bridged physical networking via `vmnet-helper`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ $(STAGING_DIR):
 	@mkdir -p "$(join $(STAGING_DIR), bin)"
 	@mkdir -p "$(join $(STAGING_DIR), libexec/container/plugins/container-runtime-linux/bin)"
 	@mkdir -p "$(join $(STAGING_DIR), libexec/container/plugins/container-network-vmnet/bin)"
+	@mkdir -p "$(join $(STAGING_DIR), libexec/container/plugins/container-network-vmnet-helper/bin)"
 	@mkdir -p "$(join $(STAGING_DIR), libexec/container/plugins/container-core-images/bin)"
 	@mkdir -p "$(join $(STAGING_DIR), libexec/container/plugins/machine-apiserver/bin)"
 	@mkdir -p "$(join $(STAGING_DIR), libexec/container/plugins/machine-apiserver/resources)"
@@ -109,6 +110,8 @@ $(STAGING_DIR):
 	@install Sources/Plugins/RuntimeLinux/config.toml "$(join $(STAGING_DIR), libexec/container/plugins/container-runtime-linux/config.toml)"
 	@install "$(BUILD_BIN_DIR)/container-network-vmnet" "$(join $(STAGING_DIR), libexec/container/plugins/container-network-vmnet/bin/container-network-vmnet)"
 	@install Sources/Plugins/NetworkVmnet/config.toml "$(join $(STAGING_DIR), libexec/container/plugins/container-network-vmnet/config.toml)"
+	@install "$(BUILD_BIN_DIR)/container-network-vmnet-helper" "$(join $(STAGING_DIR), libexec/container/plugins/container-network-vmnet-helper/bin/container-network-vmnet-helper)"
+	@install Sources/Plugins/NetworkVmnetHelper/config.toml "$(join $(STAGING_DIR), libexec/container/plugins/container-network-vmnet-helper/config.toml)"
 	@install "$(BUILD_BIN_DIR)/container-core-images" "$(join $(STAGING_DIR), libexec/container/plugins/container-core-images/bin/container-core-images)"
 	@install Sources/Plugins/CoreImages/config.toml "$(join $(STAGING_DIR), libexec/container/plugins/container-core-images/config.toml)"
 	@install "$(BUILD_BIN_DIR)/machine-apiserver" "$(join $(STAGING_DIR), libexec/container/plugins/machine-apiserver/bin/machine-apiserver)"
@@ -130,6 +133,7 @@ installer-pkg: $(STAGING_DIR)
 	@codesign $(CODESIGN_OPTS) --prefix=com.apple.container. --entitlements=signing/container-runtime-linux.entitlements "$(join $(STAGING_DIR), libexec/container/plugins/container-runtime-linux/bin/container-runtime-linux)"
 	@codesign $(CODESIGN_OPTS) --prefix=com.apple.container. --entitlements=signing/container-network-vmnet.entitlements "$(join $(STAGING_DIR), libexec/container/plugins/container-network-vmnet/bin/container-network-vmnet)"
 	@codesign $(CODESIGN_OPTS) --prefix=com.apple.container. "$(join $(STAGING_DIR), libexec/container/plugins/machine-apiserver/bin/machine-apiserver)"
+	@codesign $(CODESIGN_OPTS) --prefix=com.apple.container. "$(join $(STAGING_DIR), libexec/container/plugins/container-network-vmnet-helper/bin/container-network-vmnet-helper)"
 
 	@echo Creating application installer
 	@pkgbuild --root "$(STAGING_DIR)" --identifier com.apple.container-installer --install-location /usr/local --version ${RELEASE_VERSION} $(PKG_PATH)
@@ -142,6 +146,7 @@ dsym:
 	@mkdir -p "$(DSYM_DIR)"
 	@cp -a "$(BUILD_BIN_DIR)/container-runtime-linux.dSYM" "$(DSYM_DIR)"
 	@cp -a "$(BUILD_BIN_DIR)/container-network-vmnet.dSYM" "$(DSYM_DIR)"
+	@cp -a "$(BUILD_BIN_DIR)/container-network-vmnet-helper.dSYM" "$(DSYM_DIR)"
 	@cp -a "$(BUILD_BIN_DIR)/container-core-images.dSYM" "$(DSYM_DIR)"
 	@cp -a "$(BUILD_BIN_DIR)/container-apiserver.dSYM" "$(DSYM_DIR)"
 	@cp -a "$(BUILD_BIN_DIR)/container.dSYM" "$(DSYM_DIR)"

--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,7 @@ let package = Package(
         .library(name: "ContainerImagesService", targets: ["ContainerImagesService", "ContainerImagesServiceClient"]),
         .library(name: "ContainerNetworkClient", targets: ["ContainerNetworkClient"]),
         .library(name: "ContainerNetworkServer", targets: ["ContainerNetworkServer"]),
+        .library(name: "ContainerNetworkVmnetHelperServer", targets: ["ContainerNetworkVmnetHelperServer"]),
         .library(name: "ContainerNetworkVmnetServer", targets: ["ContainerNetworkVmnetServer"]),
         .library(name: "ContainerResource", targets: ["ContainerResource"]),
         .library(name: "ContainerLog", targets: ["ContainerLog"]),
@@ -324,6 +325,24 @@ let package = Package(
             path: "Sources/Plugins/NetworkVmnet",
             exclude: ["config.toml"]
         ),
+        .executableTarget(
+            name: "container-network-vmnet-helper",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "ContainerizationExtras", package: "containerization"),
+                "ContainerLog",
+                "ContainerNetworkVmnetHelperServer",
+                "ContainerNetworkClient",
+                "ContainerNetworkServer",
+                "ContainerPlugin",
+                "ContainerResource",
+                "ContainerVersion",
+                "ContainerXPC",
+            ],
+            path: "Sources/Plugins/NetworkVmnetHelper",
+            exclude: ["config.toml"]
+        ),
         .target(
             name: "ContainerNetworkClient",
             dependencies: [
@@ -361,6 +380,24 @@ let package = Package(
                 "ContainerXPC",
             ],
             path: "Sources/Services/NetworkVmnet/Server"
+        ),
+        .target(
+            name: "ContainerNetworkVmnetHelperServer",
+            dependencies: [
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "ContainerizationExtras", package: "containerization"),
+                "ContainerNetworkServer",
+                "ContainerResource",
+                "ContainerXPC",
+            ],
+            path: "Sources/Services/NetworkVmnetHelper/Server"
+        ),
+        .testTarget(
+            name: "ContainerNetworkVmnetHelperServerTests",
+            dependencies: [
+                .product(name: "ContainerizationExtras", package: "containerization"),
+                "ContainerNetworkVmnetHelperServer",
+            ]
         ),
         .target(
             name: "ContainerRuntimeLinuxClient",

--- a/Sources/ContainerCommands/Machine/MachineInspect.swift
+++ b/Sources/ContainerCommands/Machine/MachineInspect.swift
@@ -66,6 +66,8 @@ private struct InspectOutput: Codable {
     let homeMount: MachineConfig.HomeMountOption
     let diskSize: UInt64?
     let ipAddress: String?
+    let networks: [String]
+    let kernelArgs: [String]
 
     init(_ snapshot: MachineSnapshot) {
         self.id = snapshot.id
@@ -81,5 +83,7 @@ private struct InspectOutput: Codable {
         self.homeMount = snapshot.bootConfig.homeMount
         self.diskSize = snapshot.diskSize
         self.ipAddress = snapshot.ipAddress
+        self.networks = snapshot.bootConfig.networks
+        self.kernelArgs = snapshot.bootConfig.kernelArgs
     }
 }

--- a/Sources/ContainerCommands/Machine/MachineSet.swift
+++ b/Sources/ContainerCommands/Machine/MachineSet.swift
@@ -55,17 +55,24 @@ extension Application {
             let resolvedName = try await resolveMachineId(name, client: client)
             let snapshot = try await client.inspect(id: resolvedName)
 
-            let kwargs = Dictionary(
-                try rawArgs.map { arg in
-                    let parts = arg.split(separator: "=", maxSplits: 1)
-                    guard parts.count == 2 else {
-                        throw ContainerizationError(.invalidArgument, message: "invalid argument format '\(arg)'. Expected 'key=value'")
-                    }
+            // `network` and `kernel-arg` are repeatable list settings, which a
+            // flat key/value map cannot express, so collect them separately. An
+            // empty value resets the list; an absent key leaves it unchanged.
+            let pairs = try MachineSetArguments.pairs(rawArgs)
+            let networks = MachineSetArguments.list(forKey: "network", in: pairs)
+            let kernelArgs = MachineSetArguments.list(forKey: "kernel-arg", in: pairs)
 
-                    return (String(parts[0]), String(parts[1]))
-                },
-                uniquingKeysWith: { _, last in last }
-            )
+            // Validate network specs up front: syntax, and that the network
+            // exists, for a clear error before the change is persisted.
+            if let networks {
+                let networkClient = NetworkClient()
+                for spec in networks {
+                    let parsed = try Parser.network(spec)
+                    _ = try await networkClient.get(id: parsed.name)
+                }
+            }
+
+            let kwargs = MachineSetArguments.scalars(pairs, excluding: ["network", "kernel-arg"])
 
             if kwargs["virtualization"] == "true" {
                 try MachineCapabilities.requireNestedVirtualizationSupported()
@@ -75,7 +82,7 @@ extension Application {
                 validatedKwargs["kernel"] = try MachineConfig.validateKernelPath(raw).string
             }
 
-            let newConfig = try snapshot.bootConfig.with(validatedKwargs)
+            let newConfig = try snapshot.bootConfig.with(validatedKwargs, networks: networks, kernelArgs: kernelArgs)
 
             try await client.setConfig(id: resolvedName, bootConfig: newConfig)
 

--- a/Sources/ContainerCommands/Machine/MachineSetArguments.swift
+++ b/Sources/ContainerCommands/Machine/MachineSetArguments.swift
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerizationError
+
+/// Parsing helpers for `container machine set` arguments.
+enum MachineSetArguments {
+    /// Split `key=value` tokens, erroring on malformed entries.
+    ///
+    /// `omittingEmptySubsequences: false` keeps the trailing field so an
+    /// empty value (e.g. `network=`, used to reset a list) parses as
+    /// `("network", "")` rather than being dropped.
+    static func pairs(_ rawArgs: [String]) throws -> [(key: String, value: String)] {
+        try rawArgs.map { arg in
+            let parts = arg.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2 else {
+                throw ContainerizationError(.invalidArgument, message: "invalid argument format '\(arg)'. Expected 'key=value'")
+            }
+            return (String(parts[0]), String(parts[1]))
+        }
+    }
+
+    /// Collect a repeatable list setting (e.g. `network`, `kernel-arg`).
+    ///
+    /// Returns nil when the key is absent (leave the existing value
+    /// unchanged); otherwise the non-empty values, where an all-empty set
+    /// means reset to the default.
+    static func list(forKey key: String, in pairs: [(key: String, value: String)]) -> [String]? {
+        let matching = pairs.filter { $0.key == key }
+        guard !matching.isEmpty else { return nil }
+        return matching.map(\.value).filter { !$0.isEmpty }
+    }
+
+    /// The scalar (non-list) settings as a deduplicated map, with the given
+    /// list keys removed.
+    static func scalars(_ pairs: [(key: String, value: String)], excluding listKeys: Set<String>) -> [String: String] {
+        Dictionary(
+            pairs.filter { !listKeys.contains($0.key) }.map { ($0.key, $0.value) },
+            uniquingKeysWith: { _, last in last }
+        )
+    }
+}

--- a/Sources/ContainerPersistence/MachineConfig.swift
+++ b/Sources/ContainerPersistence/MachineConfig.swift
@@ -25,7 +25,7 @@ import SystemPackage
 /// "use the container runtime default."
 public struct MachineConfig: Codable, Sendable {
     public static let `default`: MachineConfig = try! .init(
-        cpus: nil, memory: nil, homeMount: nil, virtualization: nil, kernelPath: nil)
+        cpus: nil, memory: nil, homeMount: nil, virtualization: nil, kernelPath: nil, networks: nil, kernelArgs: nil)
 
     public static var defaultCPUs: Int {
         max(ProcessInfo.processInfo.processorCount / 2, 4)
@@ -56,6 +56,15 @@ public struct MachineConfig: Codable, Sendable {
     public let virtualization: Bool
     /// Optional path to a custom kernel binary. nil falls back to the system default.
     public let kernelPath: FilePath?
+    /// Networks the container machine attaches to, each a `container run` style
+    /// attachment spec (`name[,ip=addr][,mac=..][,mtu=..]`). Empty means the
+    /// builtin NAT network. Order matters. Only the first entry gets a gateway,
+    /// so it owns the DNS hostname, default route, and resolver. List the egress
+    /// network such as NAT first. Later entries reach only their own subnet.
+    public let networks: [String]
+    /// Extra kernel command-line arguments appended at boot (e.g. `quiet`,
+    /// `console=ttyS0`). Empty means no additions to the kernel defaults.
+    public let kernelArgs: [String]
 
     private enum CodingKeys: String, CodingKey {
         case cpus
@@ -63,6 +72,8 @@ public struct MachineConfig: Codable, Sendable {
         case homeMount
         case virtualization
         case kernelPath
+        case networks
+        case kernelArgs
     }
 
     /// Settable keys and their descriptions, for CLI help text generation.
@@ -72,6 +83,8 @@ public struct MachineConfig: Codable, Sendable {
         ("home-mount", "<string>", "User home directory mount option (ro, rw, none). Default: rw"),
         ("virtualization", "<bool>", "Enable nested virtualization (true|false). Requires Apple Silicon M3+ and macOS 15+ and kernel with CONFIG_KVM=y."),
         ("kernel", "<path>", "Path to a custom kernel binary. Empty value resets to the system default."),
+        ("network", "<spec>", "Attach to a network: name[,ip=addr][,mac=..][,mtu=..]. Repeatable. First entry owns the default route, so list egress first. Empty resets to NAT."),
+        ("kernel-arg", "<arg>", "Extra kernel command-line argument (e.g. quiet, console=ttyS0). Repeatable; an empty value clears all extra arguments."),
     ]
 
     public init(
@@ -79,13 +92,17 @@ public struct MachineConfig: Codable, Sendable {
         memory: MemorySize?,
         homeMount: HomeMountOption?,
         virtualization: Bool?,
-        kernelPath: FilePath?
+        kernelPath: FilePath?,
+        networks: [String]?,
+        kernelArgs: [String]?
     ) throws {
         self.cpus = cpus ?? Self.defaultCPUs
         self.memory = memory ?? Self.defaultMemory
         self.homeMount = homeMount ?? Self.defaultHomeMount
         self.virtualization = virtualization ?? false
         self.kernelPath = kernelPath
+        self.networks = networks ?? []
+        self.kernelArgs = kernelArgs ?? []
 
         try self.validate()
     }
@@ -101,13 +118,17 @@ public struct MachineConfig: Codable, Sendable {
         // which the project's ConfigSnapshotDecoder can't handle. Persist as a plain String
         // and lift to FilePath in memory.
         let kernelPath = try container.decodeIfPresent(String.self, forKey: .kernelPath).map { FilePath($0) }
+        let networks = try container.decodeIfPresent([String].self, forKey: .networks)
+        let kernelArgs = try container.decodeIfPresent([String].self, forKey: .kernelArgs)
 
         try self.init(
             cpus: cpus,
             memory: memory,
             homeMount: homeMount,
             virtualization: virtualization,
-            kernelPath: kernelPath)
+            kernelPath: kernelPath,
+            networks: networks,
+            kernelArgs: kernelArgs)
     }
 
     public func encode(to encoder: any Encoder) throws {
@@ -117,6 +138,8 @@ public struct MachineConfig: Codable, Sendable {
         try container.encode(homeMount, forKey: .homeMount)
         try container.encode(virtualization, forKey: .virtualization)
         try container.encodeIfPresent(kernelPath?.string, forKey: .kernelPath)
+        try container.encode(networks, forKey: .networks)
+        try container.encode(kernelArgs, forKey: .kernelArgs)
     }
 
     private func validate() throws {
@@ -148,7 +171,12 @@ extension MachineConfig {
 
     /// Create a new MachineConfig from `self`, applying fields defined in `kwargs`
     /// This function is used in both `machine create` and `machine set`
-    public func with(_ kwargs: [String: String]) throws -> MachineConfig {
+    ///
+    /// `networks` and `kernelArgs` are threaded separately from `kwargs`
+    /// because each is a list, which a flat key/value map cannot express.
+    /// `nil` leaves the existing value unchanged; a non-nil value (including
+    /// an empty array) replaces it.
+    public func with(_ kwargs: [String: String], networks: [String]? = nil, kernelArgs: [String]? = nil) throws -> MachineConfig {
         let validKeys = Set(Self.settableKeys.map(\.key))
         let unknownKeys = Set(kwargs.keys).subtracting(validKeys)
         guard unknownKeys.isEmpty else {
@@ -174,7 +202,9 @@ extension MachineConfig {
             memory: memory ?? self.memory,
             homeMount: homeMount ?? self.homeMount,
             virtualization: virtualization ?? self.virtualization,
-            kernelPath: kernelPath
+            kernelPath: kernelPath,
+            networks: networks ?? self.networks,
+            kernelArgs: kernelArgs ?? self.kernelArgs
         )
     }
 

--- a/Sources/ContainerResource/Common/ResourceLabels.swift
+++ b/Sources/ContainerResource/Common/ResourceLabels.swift
@@ -115,3 +115,9 @@ public struct ResourceRoleValues {
     /// Indicates a system-created resource that cannot be deleted by the user.
     public static let builtin = "builtin"
 }
+
+/// System-defined values for the plugin label.
+public struct ResourcePluginValues {
+    /// Indicates a container that backs a container machine.
+    public static let machine = "machine"
+}

--- a/Sources/ContainerResource/Network/AttachmentConfiguration.swift
+++ b/Sources/ContainerResource/Network/AttachmentConfiguration.swift
@@ -41,9 +41,14 @@ public struct AttachmentOptions: Codable, Sendable {
     /// The MTU for the network interface.
     public let mtu: UInt32?
 
-    public init(hostname: String, macAddress: MACAddress? = nil, mtu: UInt32? = nil) {
+    /// A specific IPv4 address requested for the attachment (optional).
+    /// Only supported by network plugins that allow static address assignment.
+    public let ip: IPv4Address?
+
+    public init(hostname: String, macAddress: MACAddress? = nil, mtu: UInt32? = nil, ip: IPv4Address? = nil) {
         self.hostname = hostname
         self.macAddress = macAddress
         self.mtu = mtu
+        self.ip = ip
     }
 }

--- a/Sources/ContainerResource/Network/VmnetHelperNetworkKeys.swift
+++ b/Sources/ContainerResource/Network/VmnetHelperNetworkKeys.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// Constants shared between the bridged network plugin and the runtime
+/// interface strategy.
+public enum VmnetHelperNetwork {
+    /// The name of the bridged network plugin.
+    public static let pluginName = "container-network-vmnet-helper"
+
+    /// Network creation options (`container network create --option key=value`).
+    public enum Option: String {
+        /// The physical host interface to bridge (e.g. `en0`). Required.
+        case interface
+        /// The IPv4 gateway address on the bridged subnet. Required.
+        case gateway
+        /// An optional pool for automatic allocation, formatted as
+        /// `START-END` (e.g. `192.168.1.200-192.168.1.220`).
+        case pool
+        /// An optional override for the vmnet-helper binary path.
+        case helperPath = "helper-path"
+    }
+
+    /// Keys for the additional data message returned with each
+    /// allocation.
+    public enum AdditionalDataKey: String {
+        /// The physical host interface to bridge.
+        case interface
+        /// The vmnet-helper binary path override, if configured.
+        case helperPath
+    }
+}

--- a/Sources/Plugins/NetworkVmnetHelper/NetworkVmnetHelperPlugin+Start.swift
+++ b/Sources/Plugins/NetworkVmnetHelper/NetworkVmnetHelperPlugin+Start.swift
@@ -1,0 +1,155 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ContainerLog
+import ContainerNetworkClient
+import ContainerNetworkServer
+import ContainerNetworkVmnetHelperServer
+import ContainerPlugin
+import ContainerResource
+import ContainerXPC
+import ContainerizationError
+import ContainerizationExtras
+import Foundation
+import Logging
+
+extension NetworkVmnetHelperPlugin {
+    struct Start: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "start",
+            abstract: "Starts the bridged network plugin"
+        )
+
+        @Flag(name: .long, help: "Enable debug logging")
+        var debug = false
+
+        @Option(name: .long, help: "XPC service identifier")
+        var serviceIdentifier: String
+
+        @Option(name: .shortAndLong, help: "Network identifier")
+        var id: String
+
+        // Bridged networks define their own semantics, so the mode
+        // from the API server is accepted and ignored.
+        @Option(name: .long, help: "Network mode (ignored)")
+        var mode: String = "nat"
+
+        @Option(name: .customLong("subnet"), help: "CIDR address of the physical IPv4 subnet")
+        var ipv4Subnet: String?
+
+        @Option(
+            name: .customLong("option"),
+            help: "Plugin option as key=value (interface=NAME, gateway=ADDR, pool=START-END, helper-path=PATH)"
+        )
+        var options: [String] = []
+
+        var logRoot = LogRoot.path
+
+        func run() async throws {
+            let commandName = NetworkVmnetHelperPlugin._commandName
+            let logPath = logRoot.map { $0.appending("\(commandName)-\(id).log") }
+            let log = ServiceLogger.bootstrap(category: "NetworkVmnetHelperPlugin", metadata: ["id": "\(id)"], debug: debug, logPath: logPath)
+            log.info("starting helper", metadata: ["name": "\(commandName)"])
+            defer {
+                log.info("stopping helper", metadata: ["name": "\(commandName)"])
+            }
+
+            do {
+                let configuration = try parseConfiguration()
+                let network = VmnetHelperPhysicalNetwork(configuration: configuration, log: log)
+                try await network.start()
+                let service = VmnetHelperNetworkService(network: network, log: log)
+                let harness = NetworkHarness(service: service)
+                let xpc = XPCServer(
+                    identifier: serviceIdentifier,
+                    routes: [
+                        NetworkRoutes.status.rawValue: XPCServer.route(harness.status),
+                        NetworkRoutes.allocate.rawValue: harness.allocate,
+                        NetworkRoutes.lookup.rawValue: XPCServer.route(harness.lookup),
+                    ],
+                    log: log
+                )
+
+                log.info("starting XPC server")
+                try await xpc.listen()
+            } catch {
+                log.error(
+                    "helper failed",
+                    metadata: [
+                        "name": "\(commandName)",
+                        "error": "\(error)",
+                    ])
+                NetworkVmnetHelperPlugin.exit(withError: error)
+            }
+        }
+
+        private func parseConfiguration() throws -> VmnetHelperPhysicalNetwork.Configuration {
+            guard let subnetText = ipv4Subnet else {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "bridged networks require the physical subnet, create the network with --subnet"
+                )
+            }
+            let subnet = try CIDRv4(subnetText)
+
+            var optionValues: [String: String] = [:]
+            for option in options {
+                let keyVal = option.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+                guard keyVal.count == 2, !keyVal[0].isEmpty else {
+                    throw ContainerizationError(.invalidArgument, message: "invalid option format '\(option)': expected key=value")
+                }
+                optionValues[String(keyVal[0])] = String(keyVal[1])
+            }
+
+            guard let hostInterface = optionValues[VmnetHelperNetwork.Option.interface.rawValue], !hostInterface.isEmpty else {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "bridged networks require the host interface, create the network with --option interface=NAME"
+                )
+            }
+            guard let gatewayText = optionValues[VmnetHelperNetwork.Option.gateway.rawValue] else {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "bridged networks require the gateway address, create the network with --option gateway=ADDR"
+                )
+            }
+            let gateway = try IPv4Address(gatewayText)
+
+            var pool: ClosedRange<UInt32>?
+            if let poolText = optionValues[VmnetHelperNetwork.Option.pool.rawValue] {
+                let bounds = poolText.split(separator: "-", omittingEmptySubsequences: false)
+                guard bounds.count == 2,
+                    let lower = try? IPv4Address(String(bounds[0])),
+                    let upper = try? IPv4Address(String(bounds[1])),
+                    lower.value <= upper.value
+                else {
+                    throw ContainerizationError(.invalidArgument, message: "invalid pool '\(poolText)': expected START-END IPv4 addresses")
+                }
+                pool = lower.value...upper.value
+            }
+
+            return try VmnetHelperPhysicalNetwork.Configuration(
+                id: id,
+                ipv4Subnet: subnet,
+                ipv4Gateway: gateway,
+                hostInterface: hostInterface,
+                pool: pool,
+                helperPath: optionValues[VmnetHelperNetwork.Option.helperPath.rawValue]
+            )
+        }
+    }
+}

--- a/Sources/Plugins/NetworkVmnetHelper/NetworkVmnetHelperPlugin.swift
+++ b/Sources/Plugins/NetworkVmnetHelper/NetworkVmnetHelperPlugin.swift
@@ -14,12 +14,17 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-public enum NetworkKeys: String {
-    case additionalData
-    case attachment
-    case hostname
-    case ip
-    case macAddress
-    case network
-    case status
+import ArgumentParser
+import ContainerVersion
+
+@main
+struct NetworkVmnetHelperPlugin: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "container-network-vmnet-helper",
+        abstract: "XPC service for managing a bridged physical network",
+        version: ReleaseVersion.singleLine(appName: "container-network-vmnet-helper"),
+        subcommands: [
+            Start.self
+        ]
+    )
 }

--- a/Sources/Plugins/NetworkVmnetHelper/config.toml
+++ b/Sources/Plugins/NetworkVmnetHelper/config.toml
@@ -1,0 +1,11 @@
+abstract = "bridged physical network management plugin"
+author = "Apple"
+version = 0.1
+
+[servicesConfig]
+loadAtBoot = false
+runAtLoad = true
+defaultArguments = []
+
+[[servicesConfig.services]]
+type = "network"

--- a/Sources/Plugins/RuntimeLinux/RuntimeLinuxHelper+Start.swift
+++ b/Sources/Plugins/RuntimeLinux/RuntimeLinuxHelper+Start.swift
@@ -65,7 +65,9 @@ extension RuntimeLinuxHelper {
 
                 // FIXME: The network plugins that the runtime supports should be configurable elsewhere
                 var interfaceStrategies: [NetworkInterfaceKey: InterfaceStrategy] = [
-                    NetworkInterfaceKey(plugin: "container-network-vmnet", variant: "allocationOnly"): IsolatedInterfaceStrategy()
+                    NetworkInterfaceKey(plugin: "container-network-vmnet", variant: nil): IsolatedInterfaceStrategy(),
+                    NetworkInterfaceKey(plugin: "container-network-vmnet", variant: "allocationOnly"): IsolatedInterfaceStrategy(),
+                    NetworkInterfaceKey(plugin: VmnetHelperNetwork.pluginName, variant: nil): VmnetHelperInterfaceStrategy(log: log),
                 ]
                 if #available(macOS 26, *) {
                     interfaceStrategies[NetworkInterfaceKey(plugin: "container-network-vmnet", variant: "reserved")] = NonisolatedInterfaceStrategy(log: log)

--- a/Sources/Services/ContainerAPIService/Client/Parser.swift
+++ b/Sources/Services/ContainerAPIService/Client/Parser.swift
@@ -814,17 +814,19 @@ public struct Parser {
         public let name: String
         public let macAddress: String?
         public let mtu: UInt32?
+        public let ip: IPv4Address?
 
-        public init(name: String, macAddress: String? = nil, mtu: UInt32? = nil) {
+        public init(name: String, macAddress: String? = nil, mtu: UInt32? = nil, ip: IPv4Address? = nil) {
             self.name = name
             self.macAddress = macAddress
             self.mtu = mtu
+            self.ip = ip
         }
     }
 
     /// Parse network attachment with optional properties
-    /// Format: network_name[,mac=XX:XX:XX:XX:XX:XX][,mtu=VALUE]
-    /// Example: "backend,mac=02:42:ac:11:00:02,mtu=1500"
+    /// Format: network_name[,mac=XX:XX:XX:XX:XX:XX][,mtu=VALUE][,ip=ADDR]
+    /// Example: "backend,mac=02:42:ac:11:00:02,mtu=1500,ip=192.168.1.50"
     public static func network(_ networkSpec: String) throws -> ParsedNetwork {
         guard !networkSpec.isEmpty else {
             throw ContainerizationError(.invalidArgument, message: "network specification cannot be empty")
@@ -843,6 +845,7 @@ public struct Parser {
 
         var macAddress: String?
         var mtu: UInt32?
+        var ip: IPv4Address?
 
         // Parse properties if any
         for part in parts.dropFirst() {
@@ -877,15 +880,23 @@ public struct Parser {
                     )
                 }
                 mtu = mtuValue
+            case "ip":
+                guard let address = try? IPv4Address(value) else {
+                    throw ContainerizationError(
+                        .invalidArgument,
+                        message: "invalid ip value '\(value)': must be an IPv4 address"
+                    )
+                }
+                ip = address
             default:
                 throw ContainerizationError(
                     .invalidArgument,
-                    message: "unknown network property '\(key)'. Available properties: mac, mtu"
+                    message: "unknown network property '\(key)'. Available properties: mac, mtu, ip"
                 )
             }
         }
 
-        return ParsedNetwork(name: networkName, macAddress: macAddress, mtu: mtu)
+        return ParsedNetwork(name: networkName, macAddress: macAddress, mtu: mtu, ip: ip)
     }
 
     // MARK: DNS

--- a/Sources/Services/ContainerAPIService/Client/Utility.swift
+++ b/Sources/Services/ContainerAPIService/Client/Utility.swift
@@ -313,16 +313,19 @@ public struct Utility {
             // attach the first network using the fqdn, and the rest using just the container ID
             return try networks.enumerated().map { item in
                 let macAddress = try item.element.macAddress.map { try MACAddress($0) }
-                let mtu = item.element.mtu ?? 1280
+                // nil when unspecified, so each interface strategy
+                // applies its own default.
+                let mtu = item.element.mtu
+                let ip = item.element.ip
                 guard item.offset == 0 else {
                     return AttachmentConfiguration(
                         network: item.element.name,
-                        options: AttachmentOptions(hostname: containerId, macAddress: macAddress, mtu: mtu)
+                        options: AttachmentOptions(hostname: containerId, macAddress: macAddress, mtu: mtu, ip: ip)
                     )
                 }
                 return AttachmentConfiguration(
                     network: item.element.name,
-                    options: AttachmentOptions(hostname: fqdn ?? containerId, macAddress: macAddress, mtu: mtu)
+                    options: AttachmentOptions(hostname: fqdn ?? containerId, macAddress: macAddress, mtu: mtu, ip: ip)
                 )
             }
         }
@@ -331,7 +334,7 @@ public struct Utility {
         guard let builtinNetworkId else {
             throw ContainerizationError(.invalidState, message: "builtin network is not present")
         }
-        return [AttachmentConfiguration(network: builtinNetworkId, options: AttachmentOptions(hostname: fqdn ?? containerId, macAddress: nil, mtu: 1280))]
+        return [AttachmentConfiguration(network: builtinNetworkId, options: AttachmentOptions(hostname: fqdn ?? containerId, macAddress: nil, mtu: nil))]
     }
 
     private static func getKernel(management: Flags.Management) async throws -> Kernel {

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -420,10 +420,20 @@ public actor ContainersService {
             let path = self.containerRoot.appendingPathComponent(id)
             let (config, _) = try Self.getContainerConfiguration(at: path)
 
+            // The machine API server tags its VMs with this plugin label.
+            let isMachine = config.labels[ResourceLabelKeys.plugin] == ResourcePluginValues.machine
             var networkBootstrapInfos = [NetworkBootstrapInfo]()
             for n in config.networks {
                 guard let plugin = try await self.networksService?.plugin(for: n.network) else {
                     throw ContainerizationError(.internalError, message: "failed to get plugin for network \(n.network)")
+                }
+                // Bridged vmnet-helper networks are only supported for
+                // container machines, not regular containers.
+                guard plugin != VmnetHelperNetwork.pluginName || isMachine else {
+                    throw ContainerizationError(
+                        .unsupported,
+                        message: "network \(n.network) uses the \(VmnetHelperNetwork.pluginName) plugin, which is only supported for container machines"
+                    )
                 }
                 networkBootstrapInfos.append(NetworkBootstrapInfo(plugin: plugin))
             }

--- a/Sources/Services/ContainerAPIService/Server/Networks/NetworksService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Networks/NetworksService.swift
@@ -314,6 +314,11 @@ public actor NetworksService {
         }
     }
 
+    /// The builtin vmnet plugin predates generic option forwarding. It has
+    /// dedicated arguments instead of `--option`, owns the `variant`
+    /// concept, and is the only plugin whose subnets the apiserver manages.
+    private static let builtinVmnetPlugin = "container-network-vmnet"
+
     public func plugin(for id: String) throws -> String {
         guard let serviceState = serviceStates[id] else {
             throw ContainerizationError(.notFound, message: "no network for id \(id)")
@@ -328,6 +333,25 @@ public actor NetworksService {
     private func registerService(configuration: NetworkConfiguration) async throws {
         guard configuration.mode == .nat || configuration.mode == .hostOnly else {
             throw ContainerizationError(.invalidArgument, message: "unsupported network mode \(configuration.mode.rawValue)")
+        }
+
+        let isBuiltinVmnet = configuration.plugin == Self.builtinVmnetPlugin
+
+        // Only the builtin vmnet plugin accepts the variant and IPv6
+        // subnet arguments. Passing them to another plugin would crash
+        // its launchd service on an unknown argument, so reject them at
+        // creation time instead.
+        guard isBuiltinVmnet || configuration.options["variant"] == nil else {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "the variant option is specific to the \(Self.builtinVmnetPlugin) plugin"
+            )
+        }
+        guard isBuiltinVmnet || configuration.ipv6Subnet == nil else {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "network plugin \(configuration.plugin) does not support IPv6 subnets"
+            )
         }
 
         guard let networkPlugin = self.networkPlugins.first(where: { $0.name == configuration.plugin }) else {
@@ -354,18 +378,23 @@ public actor NetworksService {
         }
 
         if let ipv4Subnet = configuration.ipv4Subnet {
-            var existingCidrs: [CIDRv4] = []
-            for serviceState in serviceStates.values {
-                existingCidrs.append(serviceState.status.ipv4Subnet)
-            }
-            let overlap = existingCidrs.first {
-                $0.contains(ipv4Subnet.lower)
-                    || $0.contains(ipv4Subnet.upper)
-                    || ipv4Subnet.contains($0.lower)
-                    || ipv4Subnet.contains($0.upper)
-            }
-            if let overlap {
-                throw ContainerizationError(.exists, message: "IPv4 subnet \(ipv4Subnet) overlaps an existing network with subnet \(overlap)")
+            // Overlap validation covers managed subnets only. Other
+            // plugins describe external networks that may legitimately
+            // share address space with a managed subnet.
+            if isBuiltinVmnet {
+                var existingCidrs: [CIDRv4] = []
+                for serviceState in serviceStates.values {
+                    existingCidrs.append(serviceState.status.ipv4Subnet)
+                }
+                let overlap = existingCidrs.first {
+                    $0.contains(ipv4Subnet.lower)
+                        || $0.contains(ipv4Subnet.upper)
+                        || ipv4Subnet.contains($0.lower)
+                        || ipv4Subnet.contains($0.upper)
+                }
+                if let overlap {
+                    throw ContainerizationError(.exists, message: "IPv4 subnet \(ipv4Subnet) overlaps an existing network with subnet \(overlap)")
+                }
             }
 
             args += ["--subnet", ipv4Subnet.description]
@@ -393,6 +422,15 @@ public actor NetworksService {
 
         if let variant = configuration.options["variant"] {
             args += ["--variant", variant]
+        }
+
+        // Forward plugin-specific options to plugins other than the builtin
+        // vmnet helper, which predates generic option forwarding and rejects
+        // unknown arguments.
+        if !isBuiltinVmnet {
+            for (key, value) in configuration.options.sorted(by: { $0.key < $1.key }) where key != "variant" {
+                args += ["--option", "\(key)=\(value)"]
+            }
         }
 
         let entityPath = try store.entityPath(configuration.id)

--- a/Sources/Services/MachineAPIService/Server/MachineNetworking.swift
+++ b/Sources/Services/MachineAPIService/Server/MachineNetworking.swift
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationError
+import ContainerizationExtras
+
+/// Resolves the network settings persisted on a container machine into the
+/// attachment configurations its backing container boots with.
+enum MachineNetworking {
+    /// Map `container machine set network=` specs to attachments.
+    ///
+    /// With no specs, the machine attaches to the builtin NAT network.
+    /// Otherwise each `container run`-style spec
+    /// (`name[,ip=ADDR][,mac=..][,mtu=..]`) is resolved to its network id,
+    /// reusing the same parser as regular containers. Order matters. The first
+    /// attachment owns the DNS hostname and is the only one given a gateway
+    /// (default route and resolver), so list the egress network first. The rest
+    /// register under the container id and reach only their own subnet.
+    static func attachments(
+        for networks: [String],
+        dnsHostname: String,
+        containerId: String
+    ) async throws -> [AttachmentConfiguration] {
+        guard !networks.isEmpty else {
+            guard let defaultNetwork = try await NetworkClient().builtin else {
+                throw ContainerizationError(.invalidState, message: "default network is not present")
+            }
+            return [
+                AttachmentConfiguration(
+                    network: defaultNetwork.id,
+                    options: AttachmentOptions(hostname: dnsHostname)
+                )
+            ]
+        }
+
+        let networkClient = NetworkClient()
+        var attachments: [AttachmentConfiguration] = []
+        for (index, spec) in networks.enumerated() {
+            let parsed = try Parser.network(spec)
+            // Confirm the network exists and resolve its id.
+            let resource = try await networkClient.get(id: parsed.name)
+            let macAddress = try parsed.macAddress.map { try MACAddress($0) }
+            let hostname = index == 0 ? dnsHostname : containerId
+            attachments.append(
+                AttachmentConfiguration(
+                    network: resource.id,
+                    options: AttachmentOptions(
+                        hostname: hostname,
+                        macAddress: macAddress,
+                        mtu: parsed.mtu,
+                        ip: parsed.ip
+                    )
+                )
+            )
+        }
+        return attachments
+    }
+}

--- a/Sources/Services/MachineAPIService/Server/MachinesService.swift
+++ b/Sources/Services/MachineAPIService/Server/MachinesService.swift
@@ -364,13 +364,14 @@ public actor MachinesService {
                 initializedFile: path.appending(MachineBundle.initializedFile),
                 homeMountOption: bootConfig.homeMount,
                 virtualization: bootConfig.virtualization,
+                networks: bootConfig.networks,
             )
 
             config.resources.cpus = bootConfig.cpus
             config.resources.cpuOverhead = 0
             config.resources.memoryInBytes = bootConfig.memory.toUInt64(unit: .bytes)
 
-            let kernel: Kernel
+            var kernel: Kernel
             if let kernelPath = bootConfig.kernelPath {
                 let validated = try MachineConfig.validateKernelPath(kernelPath.string)
                 kernel = Kernel(
@@ -380,6 +381,8 @@ public actor MachinesService {
             } else {
                 kernel = try await ClientKernel.getDefaultKernel(for: .current)
             }
+            // Append any user-configured kernel command-line arguments.
+            kernel.commandLine.kernelArgs.append(contentsOf: bootConfig.kernelArgs)
 
             var fhs: [FileHandle] = []
             do {
@@ -639,6 +642,7 @@ extension MachineConfiguration {
         initializedFile: FilePath,
         homeMountOption: MachineConfig.HomeMountOption,
         virtualization: Bool,
+        networks: [String],
     ) async throws -> ContainerConfiguration {
         var config = ContainerConfiguration(
             id: cid,
@@ -676,7 +680,7 @@ extension MachineConfiguration {
 
         config.platform = platform
         config.labels = [
-            ResourceLabelKeys.plugin: "machine"
+            ResourceLabelKeys.plugin: ResourcePluginValues.machine
         ]
         let domain = Self.defaultDNSDomain
         config.dns = ContainerConfiguration.DNSConfiguration(
@@ -684,15 +688,7 @@ extension MachineConfiguration {
             domain: domain,
             searchDomains: [domain],
         )
-        guard let defaultNetwork = try await NetworkClient().builtin else {
-            throw ContainerizationError(.invalidState, message: "default network is not present")
-        }
-        config.networks = [
-            AttachmentConfiguration(
-                network: defaultNetwork.id,
-                options: AttachmentOptions(hostname: dnsHostname)
-            )
-        ]
+        config.networks = try await MachineNetworking.attachments(for: networks, dnsHostname: dnsHostname, containerId: cid)
 
         config.capAdd = ["ALL"]
         config.ssh = true

--- a/Sources/Services/Network/Client/NetworkClient.swift
+++ b/Sources/Services/Network/Client/NetworkClient.swift
@@ -70,12 +70,16 @@ extension NetworkClient {
     public func allocate(
         hostname: String,
         macAddress: MACAddress? = nil,
+        ip: IPv4Address? = nil,
         on session: XPCClientSession
     ) async throws -> (attachment: Attachment, additionalData: XPCMessage?) {
         let request = XPCMessage(route: NetworkRoutes.allocate.rawValue)
         request.set(key: NetworkKeys.hostname.rawValue, value: hostname)
         if let macAddress = macAddress {
             request.set(key: NetworkKeys.macAddress.rawValue, value: macAddress.description)
+        }
+        if let ip {
+            request.set(key: NetworkKeys.ip.rawValue, value: ip.description)
         }
         let response = try await session.send(request)
         let attachment = try response.attachment()

--- a/Sources/Services/Network/Server/DefaultNetworkService.swift
+++ b/Sources/Services/Network/Server/DefaultNetworkService.swift
@@ -57,10 +57,15 @@ public actor DefaultNetworkService: NetworkService {
     public func allocate(
         hostname: String,
         macAddress: MACAddress?,
+        ip: IPv4Address?,
         session: XPCServerSession
     ) async throws -> (attachment: Attachment, additionalData: XPCMessage?) {
         log.debug("enter", metadata: ["func": "\(#function)"])
         defer { log.debug("exit", metadata: ["func": "\(#function)"]) }
+
+        guard ip == nil else {
+            throw ContainerizationError(.unsupported, message: "network \(network.id) does not support static IP assignment")
+        }
 
         guard let status = await network.status else {
             throw ContainerizationError(.invalidState, message: "network \(network.id) must be running")

--- a/Sources/Services/Network/Server/NetworkHarness.swift
+++ b/Sources/Services/Network/Server/NetworkHarness.swift
@@ -41,10 +41,14 @@ public actor NetworkHarness: Sendable {
         let macAddress =
             try message.string(key: NetworkKeys.macAddress.rawValue)
             .map { try MACAddress($0) }
+        let ip =
+            try message.string(key: NetworkKeys.ip.rawValue)
+            .map { try IPv4Address($0) }
 
         let (attachment:attachment, additionalData:additionalData) = try await service.allocate(
             hostname: hostname,
             macAddress: macAddress,
+            ip: ip,
             session: session
         )
 

--- a/Sources/Services/Network/Server/NetworkService.swift
+++ b/Sources/Services/Network/Server/NetworkService.swift
@@ -24,9 +24,14 @@ public protocol NetworkService: Sendable {
     func status() async throws -> NetworkStatus
 
     /// Register a hostname and allocate associated addresses.
+    ///
+    /// The optional `ip` parameter requests a specific IPv4 address.
+    /// Plugins that do not support static assignment must throw when it
+    /// is present.
     func allocate(
         hostname: String,
         macAddress: MACAddress?,
+        ip: IPv4Address?,
         session: XPCServerSession
     ) async throws -> (attachment: Attachment, additionalData: XPCMessage?)
 

--- a/Sources/Services/NetworkVmnetHelper/Server/AddressPool.swift
+++ b/Sources/Services/NetworkVmnetHelper/Server/AddressPool.swift
@@ -1,0 +1,99 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerizationError
+import ContainerizationExtras
+
+/// IPv4 address bookkeeping for a bridged network: which addresses are in
+/// use, which are valid host addresses, and a rotating cursor over the
+/// optional pool.
+///
+/// Split out from `VmnetHelperNetworkService` so the address arithmetic is
+/// pure and unit-testable; the service keeps the hostname and session
+/// ownership that depend on live XPC sessions.
+struct AddressPool {
+    private let configuration: VmnetHelperPhysicalNetwork.Configuration
+    private var allocated: Set<UInt32> = []
+    /// Rotating cursor into the pool. Allocation stays O(1) amortized and a
+    /// released address is not immediately reused.
+    private var cursor: UInt32?
+
+    init(configuration: VmnetHelperPhysicalNetwork.Configuration) {
+        self.configuration = configuration
+        self.cursor = configuration.pool?.lowerBound
+    }
+
+    func isAllocated(_ address: UInt32) -> Bool {
+        allocated.contains(address)
+    }
+
+    mutating func reserve(_ address: UInt32) {
+        allocated.insert(address)
+    }
+
+    mutating func release(_ address: UInt32) {
+        allocated.remove(address)
+    }
+
+    /// Whether `address` is a usable host address: inside the subnet and
+    /// not the gateway, network, or broadcast address.
+    func isAssignable(_ address: IPv4Address) -> Bool {
+        let subnet = configuration.ipv4Subnet
+        return subnet.contains(address)
+            && address != configuration.ipv4Gateway
+            && address != subnet.lower
+            && address != subnet.upper
+    }
+
+    /// Validate an explicitly requested address, throwing a descriptive
+    /// error when it cannot be assigned.
+    func validate(_ address: IPv4Address) throws {
+        let subnet = configuration.ipv4Subnet
+        guard subnet.contains(address) else {
+            throw ContainerizationError(.invalidArgument, message: "address \(address) is not in subnet \(subnet)")
+        }
+        guard address != configuration.ipv4Gateway else {
+            throw ContainerizationError(.invalidArgument, message: "address \(address) is the gateway address")
+        }
+        guard address != subnet.lower, address != subnet.upper else {
+            throw ContainerizationError(.invalidArgument, message: "address \(address) is the network or broadcast address")
+        }
+    }
+
+    /// Find the next free pool address, scanning at most one full rotation
+    /// from the cursor and advancing it. Does not reserve; the caller
+    /// reserves once it commits the allocation.
+    mutating func allocateFromPool() throws -> UInt32 {
+        guard let pool = configuration.pool, var candidate = cursor else {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "network \(configuration.id) has no address pool; request a specific address with the ip= attachment option"
+            )
+        }
+        // `pool.count` is an Int, so a pool spanning the full UInt32 range
+        // cannot overflow the way `upperBound - lowerBound + 1` would.
+        let poolSize = pool.count
+        for _ in 0..<poolSize {
+            let next = candidate == pool.upperBound ? pool.lowerBound : candidate + 1
+            if !allocated.contains(candidate), isAssignable(IPv4Address(candidate)) {
+                cursor = next
+                return candidate
+            }
+            candidate = next
+        }
+        throw ContainerizationError(.invalidState, message: "no free addresses in the pool of network \(configuration.id)")
+    }
+}

--- a/Sources/Services/NetworkVmnetHelper/Server/VmnetHelperNetworkService.swift
+++ b/Sources/Services/NetworkVmnetHelper/Server/VmnetHelperNetworkService.swift
@@ -1,0 +1,180 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerNetworkServer
+import ContainerResource
+import ContainerXPC
+import ContainerizationError
+import ContainerizationExtras
+import Logging
+
+/// A network service that hands out static IPv4 addresses on a bridged
+/// physical network.
+///
+/// Addresses are either requested explicitly per attachment (`ip=`) or
+/// allocated from the optional `pool` configured on the network. The
+/// service performs no DHCP, so the operator must keep assigned addresses
+/// outside the LAN's DHCP range.
+///
+/// ContainerizationExtras' `AddressAllocator` is deliberately not used.
+/// It manages one contiguous span, while this service combines a pool
+/// with explicit addresses anywhere in the subnet plus hostname and
+/// session ownership tracking.
+public actor VmnetHelperNetworkService: NetworkService {
+    private struct Allocation {
+        let address: UInt32
+        let owner: XPCServerSession
+    }
+
+    private let network: VmnetHelperPhysicalNetwork
+    private let log: Logger
+    private var allocationsByHostname: [String: Allocation] = [:]
+    private var hostnamesBySession: [XPCServerSession: [String]] = [:]
+    /// Address bookkeeping (in-use set, pool cursor, validation).
+    private var addresses: AddressPool
+
+    public init(network: VmnetHelperPhysicalNetwork, log: Logger) {
+        self.network = network
+        self.log = log
+        self.addresses = AddressPool(configuration: network.configuration)
+    }
+
+    @Sendable
+    public func status() async throws -> NetworkStatus {
+        guard let status = network.status else {
+            throw ContainerizationError(.invalidState, message: "network \(network.id) is not running")
+        }
+        return status
+    }
+
+    @Sendable
+    public func allocate(
+        hostname: String,
+        macAddress: MACAddress?,
+        ip: IPv4Address?,
+        session: XPCServerSession
+    ) async throws -> (attachment: Attachment, additionalData: XPCMessage?) {
+        log.debug("enter", metadata: ["func": "\(#function)"])
+        defer { log.debug("exit", metadata: ["func": "\(#function)"]) }
+
+        guard macAddress == nil else {
+            throw ContainerizationError(
+                .unsupported,
+                message: "network \(network.id) does not support explicit MAC addresses; vmnet assigns the MAC for bridged interfaces"
+            )
+        }
+
+        let address: UInt32
+        let isNewHostname = allocationsByHostname[hostname] == nil
+
+        if let existing = allocationsByHostname[hostname] {
+            // Repeated allocations for a hostname are valid only from
+            // the owning session. Honoring another session would later
+            // release an address that is still in use.
+            guard existing.owner === session else {
+                throw ContainerizationError(
+                    .exists,
+                    message: "hostname \(hostname) is already allocated by another client on network \(network.id)"
+                )
+            }
+            if let requested = ip {
+                guard requested.value == existing.address else {
+                    throw ContainerizationError(
+                        .invalidArgument,
+                        message: "hostname \(hostname) is already allocated address \(IPv4Address(existing.address)) on network \(network.id)"
+                    )
+                }
+            }
+            address = existing.address
+        } else if let requested = ip {
+            try addresses.validate(requested)
+            guard !addresses.isAllocated(requested.value) else {
+                throw ContainerizationError(.exists, message: "address \(requested) is already allocated on network \(network.id)")
+            }
+            address = requested.value
+        } else {
+            address = try addresses.allocateFromPool()
+        }
+
+        allocationsByHostname[hostname] = Allocation(address: address, owner: session)
+        addresses.reserve(address)
+
+        if hostnamesBySession[session] == nil {
+            await session.onDisconnect { [weak self] in
+                await self?.releaseSession(session)
+            }
+        }
+        // A repeated allocation for an already-owned hostname returns the
+        // same address; only track the hostname once so the session's
+        // release list does not accumulate duplicates.
+        if isNewHostname {
+            hostnamesBySession[session, default: []].append(hostname)
+        }
+
+        let attachment = try makeAttachment(hostname: hostname, address: address)
+        log.info(
+            "allocated attachment",
+            metadata: [
+                "hostname": "\(hostname)",
+                "ipv4Address": "\(attachment.ipv4Address)",
+                "ipv4Gateway": "\(attachment.ipv4Gateway)",
+            ])
+
+        var additionalData: XPCMessage?
+        try network.withAdditionalData {
+            additionalData = $0
+        }
+
+        return (attachment: attachment, additionalData: additionalData)
+    }
+
+    @Sendable
+    public func lookup(hostname: String) async throws -> Attachment? {
+        guard let allocation = allocationsByHostname[hostname] else {
+            return nil
+        }
+        return try makeAttachment(hostname: hostname, address: allocation.address)
+    }
+
+    private func makeAttachment(hostname: String, address: UInt32) throws -> Attachment {
+        let configuration = network.configuration
+        return Attachment(
+            network: network.id,
+            hostname: hostname,
+            ipv4Address: try CIDRv4(IPv4Address(address), prefix: configuration.ipv4Subnet.prefix),
+            ipv4Gateway: configuration.ipv4Gateway,
+            ipv6Address: nil,
+            // The MAC address is assigned by vmnet when the runtime starts
+            // the per-container helper, so it is unknown at allocation time.
+            macAddress: nil
+        )
+    }
+
+    private func releaseSession(_ session: XPCServerSession) {
+        guard let hostnames = hostnamesBySession.removeValue(forKey: session) else {
+            return
+        }
+        for hostname in hostnames {
+            // Release only allocations this session still owns.
+            guard let allocation = allocationsByHostname[hostname], allocation.owner === session else {
+                continue
+            }
+            allocationsByHostname.removeValue(forKey: hostname)
+            addresses.release(allocation.address)
+        }
+        log.info("released session", metadata: ["hostnames": "\(hostnames.count)"])
+    }
+}

--- a/Sources/Services/NetworkVmnetHelper/Server/VmnetHelperPhysicalNetwork.swift
+++ b/Sources/Services/NetworkVmnetHelper/Server/VmnetHelperPhysicalNetwork.swift
@@ -1,0 +1,120 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerNetworkServer
+import ContainerResource
+import ContainerXPC
+import ContainerizationError
+import ContainerizationExtras
+import Foundation
+import Logging
+import XPC
+
+/// Describes an existing physical network that containers join through
+/// vmnet bridged mode.
+///
+/// The subnet, gateway, and address assignments describe the external
+/// LAN. The runtime creates the data path per container by launching a
+/// vmnet-helper process on the configured host interface.
+public final class VmnetHelperPhysicalNetwork: ContainerNetworkServer.Network, Sendable {
+    /// The static configuration describing the external network.
+    public struct Configuration: Sendable {
+        public let id: String
+        public let ipv4Subnet: CIDRv4
+        public let ipv4Gateway: IPv4Address
+        public let hostInterface: String
+        public let pool: ClosedRange<UInt32>?
+        public let helperPath: String?
+
+        public init(
+            id: String,
+            ipv4Subnet: CIDRv4,
+            ipv4Gateway: IPv4Address,
+            hostInterface: String,
+            pool: ClosedRange<UInt32>?,
+            helperPath: String?
+        ) throws {
+            guard ipv4Subnet.contains(ipv4Gateway) else {
+                throw ContainerizationError(.invalidArgument, message: "gateway \(ipv4Gateway) is not in subnet \(ipv4Subnet)")
+            }
+            // The network and broadcast addresses are not usable
+            // gateways. In /31 and /32 networks every address is a
+            // host address.
+            if ipv4Subnet.prefix.length < 31 {
+                guard ipv4Gateway != ipv4Subnet.lower, ipv4Gateway != ipv4Subnet.upper else {
+                    throw ContainerizationError(
+                        .invalidArgument,
+                        message: "gateway \(ipv4Gateway) is the network or broadcast address of \(ipv4Subnet)"
+                    )
+                }
+            }
+            if let pool {
+                guard ipv4Subnet.contains(IPv4Address(pool.lowerBound)), ipv4Subnet.contains(IPv4Address(pool.upperBound)) else {
+                    throw ContainerizationError(.invalidArgument, message: "address pool is not in subnet \(ipv4Subnet)")
+                }
+            }
+            self.id = id
+            self.ipv4Subnet = ipv4Subnet
+            self.ipv4Gateway = ipv4Gateway
+            self.hostInterface = hostInterface
+            self.pool = pool
+            self.helperPath = helperPath
+        }
+    }
+
+    public let configuration: Configuration
+    private let log: Logger
+
+    public init(configuration: Configuration, log: Logger) {
+        self.configuration = configuration
+        self.log = log
+    }
+
+    public var id: String { configuration.id }
+
+    // The vmnet-helper plugin has a single, default interface strategy, so
+    // it reports no variant. The runtime selects its strategy by plugin
+    // name alone (see NetworkInterfaceKey registration).
+    public nonisolated var variant: String? { nil }
+
+    public var status: NetworkStatus? {
+        NetworkStatus(
+            ipv4Subnet: configuration.ipv4Subnet,
+            ipv4Gateway: configuration.ipv4Gateway,
+            ipv6Subnet: nil
+        )
+    }
+
+    public func withAdditionalData(_ handler: (XPCMessage?) throws -> Void) throws {
+        let message = XPCMessage(object: xpc_dictionary_create(nil, nil, 0))
+        message.set(key: VmnetHelperNetwork.AdditionalDataKey.interface.rawValue, value: configuration.hostInterface)
+        if let helperPath = configuration.helperPath {
+            message.set(key: VmnetHelperNetwork.AdditionalDataKey.helperPath.rawValue, value: helperPath)
+        }
+        try handler(message)
+    }
+
+    public func start() async throws {
+        log.info(
+            "started vmnet-helper network",
+            metadata: [
+                "id": "\(configuration.id)",
+                "subnet": "\(configuration.ipv4Subnet)",
+                "gateway": "\(configuration.ipv4Gateway)",
+                "hostInterface": "\(configuration.hostInterface)",
+            ])
+    }
+}

--- a/Sources/Services/Runtime/RuntimeClient/InterfaceStrategy.swift
+++ b/Sources/Services/Runtime/RuntimeClient/InterfaceStrategy.swift
@@ -41,5 +41,5 @@ public protocol InterfaceStrategy: Sendable {
     ///     specific for the network to which the container will attach.
     ///
     /// - Returns: An XPC message with no parameters.
-    func toInterface(attachment: Attachment, interfaceIndex: Int, additionalData: XPCMessage?) throws -> Interface
+    func toInterface(attachment: Attachment, interfaceIndex: Int, additionalData: XPCMessage?) async throws -> Interface
 }

--- a/Sources/Services/RuntimeLinux/Server/NonisolatedInterfaceStrategy.swift
+++ b/Sources/Services/RuntimeLinux/Server/NonisolatedInterfaceStrategy.swift
@@ -43,6 +43,9 @@ public struct NonisolatedInterfaceStrategy: InterfaceStrategy {
         }
 
         log.info("creating NATNetworkInterface with network reference")
+        // Only the first interface carries a gateway, so the guest installs a
+        // single default route (and resolver) via it. Later interfaces reach
+        // only their own subnet. Egress network must be listed first.
         let ipv4Gateway = interfaceIndex == 0 ? attachment.ipv4Gateway : nil
         return NATNetworkInterface(
             ipv4Address: attachment.ipv4Address,

--- a/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
+++ b/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
@@ -183,6 +183,7 @@ public actor RuntimeService {
                     var (attachment, additionalData) = try await client.allocate(
                         hostname: attachmentConfig.options.hostname,
                         macAddress: attachmentConfig.options.macAddress,
+                        ip: attachmentConfig.options.ip,
                         on: session
                     )
                     if let mtu = attachmentConfig.options.mtu {
@@ -202,7 +203,7 @@ public actor RuntimeService {
                             .internalError,
                             message: "no available interface strategy for network \(attachment.network), plugin=\(info.plugin) variant=\(attachment.variant ?? "nil")")
                     }
-                    let interface = try iStrategy.toInterface(
+                    let interface = try await iStrategy.toInterface(
                         attachment: attachment,
                         interfaceIndex: index,
                         additionalData: additionalData
@@ -211,6 +212,10 @@ public actor RuntimeService {
                     interfaces.append(interface)
                 }
             } catch {
+                // Reap interfaces already created before the failure.
+                for case let managed as ManagedInterface in interfaces {
+                    managed.teardown()
+                }
                 for session in sessions { session.close() }
                 throw error
             }
@@ -1264,6 +1269,13 @@ public actor RuntimeService {
         }
 
         await self.stopSocketForwarders()
+
+        // Reap interfaces backed by external processes. They also clean
+        // up after themselves when their data path closes, so this is
+        // belt and suspenders.
+        for case let managed as ManagedInterface in container.interfaces {
+            managed.teardown()
+        }
 
         for session in networkSessions { session.close() }
         networkSessions = []

--- a/Sources/Services/RuntimeLinux/Server/VmnetHelperInterface.swift
+++ b/Sources/Services/RuntimeLinux/Server/VmnetHelperInterface.swift
@@ -1,0 +1,105 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Containerization
+import ContainerizationError
+import ContainerizationExtras
+import Foundation
+import Synchronization
+import Virtualization
+
+/// A network interface backed by an external resource that needs
+/// explicit teardown.
+///
+/// The runtime calls `teardown()` during container cleanup and on
+/// bootstrap failure, so external resources are reaped deterministically
+/// instead of relying on deallocation order.
+public protocol ManagedInterface: Interface {
+    func teardown()
+}
+
+/// A network interface backed by a datagram socket connected to a
+/// vmnet-helper process that bridges guest traffic onto a physical host
+/// interface.
+///
+/// The interface owns one end of a `SOCK_DGRAM` socketpair and the helper
+/// holds the other. Closing the file handle or terminating the helper
+/// tears down the data path.
+public final class VmnetHelperInterface: ManagedInterface, @unchecked Sendable {
+    public let ipv4Address: CIDRv4
+    public let ipv4Gateway: IPv4Address?
+    public let macAddress: MACAddress?
+    /// The guest link MTU, applied to the interface inside the container.
+    public let mtu: UInt32
+    /// The frame size of the vmnet data path, as reported by
+    /// vmnet-helper. Independent of the guest link MTU.
+    private let vmnetMtu: UInt32
+
+    private let fileHandle: FileHandle
+    private let processMutex: Mutex<Process?>
+
+    init(
+        ipv4Address: CIDRv4,
+        ipv4Gateway: IPv4Address?,
+        macAddress: MACAddress?,
+        mtu: UInt32,
+        vmnetMtu: UInt32,
+        fileHandle: FileHandle,
+        helperProcess: Process
+    ) {
+        self.ipv4Address = ipv4Address
+        self.ipv4Gateway = ipv4Gateway
+        self.macAddress = macAddress
+        self.mtu = mtu
+        self.vmnetMtu = vmnetMtu
+        self.fileHandle = fileHandle
+        self.processMutex = Mutex(helperProcess)
+    }
+
+    /// Terminate the vmnet-helper process. The helper also exits on its
+    /// own when both socket ends close. `terminate()` is documented as a
+    /// no op for a finished process, so no liveness check is needed.
+    public func teardown() {
+        processMutex.withLock { process in
+            guard let p = process else {
+                return
+            }
+            process = nil
+            p.terminate()
+        }
+    }
+}
+
+extension VmnetHelperInterface: VZInterface {
+    public func device() throws -> VZVirtioNetworkDeviceConfiguration {
+        let config = VZVirtioNetworkDeviceConfiguration()
+        if let macAddress = self.macAddress {
+            guard let mac = VZMACAddress(string: macAddress.description) else {
+                throw ContainerizationError(.invalidArgument, message: "invalid mac address \(macAddress)")
+            }
+            config.macAddress = mac
+        }
+        let attachment = VZFileHandleNetworkDeviceAttachment(fileHandle: self.fileHandle)
+        // The frame size ceiling of the data path, not the guest link
+        // MTU. The framework accepts only 1500 through 65535 and rejects
+        // the VM configuration otherwise, so clamp the reported value.
+        if self.vmnetMtu > 1500 {
+            attachment.maximumTransmissionUnit = Int(min(self.vmnetMtu, 65535))
+        }
+        config.attachment = attachment
+        return config
+    }
+}

--- a/Sources/Services/RuntimeLinux/Server/VmnetHelperInterfaceStrategy.swift
+++ b/Sources/Services/RuntimeLinux/Server/VmnetHelperInterfaceStrategy.swift
@@ -1,0 +1,317 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerResource
+import ContainerRuntimeClient
+import ContainerXPC
+import Containerization
+import ContainerizationError
+import ContainerizationExtras
+import CryptoKit
+import Foundation
+import Logging
+
+/// Creates network interfaces for bridged networks by launching a
+/// vmnet-helper process per interface.
+///
+/// vmnet-helper (https://github.com/nirs/vmnet-helper) attaches to the
+/// physical host interface in vmnet bridged mode and relays Ethernet
+/// frames over a `SOCK_DGRAM` socketpair. The strategy spawns the helper,
+/// reads the interface parameters it reports on stdout, and hands the VM
+/// end of the socketpair to the virtual machine. The MAC address comes
+/// from vmnet, not from the caller.
+public struct VmnetHelperInterfaceStrategy: InterfaceStrategy {
+    /// Default helper locations for Homebrew on macOS 26 and newer,
+    /// then the install script location for macOS 15 and earlier.
+    private static let defaultHelperPaths = [
+        "/opt/homebrew/opt/vmnet-helper/libexec/vmnet-helper",
+        "/usr/local/opt/vmnet-helper/libexec/vmnet-helper",
+        "/opt/vmnet-helper/bin/vmnet-helper",
+    ]
+
+    private static let startupTimeout = Duration.seconds(15)
+    // The Virtualization framework requires SO_RCVBUF of at least twice
+    // SO_SNDBUF on the attachment socket and recommends four times.
+    private static let socketSendBufferSize: Int32 = 1024 * 1024
+    private static let socketReceiveBufferSize: Int32 = 4 * 1024 * 1024
+
+    private let log: Logger
+
+    public init(log: Logger) {
+        self.log = log
+    }
+
+    public func toInterface(attachment: Attachment, interfaceIndex: Int, additionalData: XPCMessage?) async throws -> Interface {
+        guard let additionalData else {
+            throw ContainerizationError(.invalidState, message: "bridged network attachment has no additional data")
+        }
+        guard let hostInterface = additionalData.string(key: VmnetHelperNetwork.AdditionalDataKey.interface.rawValue) else {
+            throw ContainerizationError(.invalidState, message: "bridged network attachment does not specify a host interface")
+        }
+        let helperPath = try Self.resolveHelperPath(
+            override: additionalData.string(key: VmnetHelperNetwork.AdditionalDataKey.helperPath.rawValue)
+        )
+
+        // A stable interface ID gives the attachment a stable vmnet MAC
+        // address across container restarts.
+        let interfaceId = Self.stableInterfaceId(network: attachment.network, hostname: attachment.hostname, interfaceIndex: interfaceIndex)
+
+        // The helper gets one end of the socketpair as its stdin and
+        // the VM gets the other.
+        var fds: [Int32] = [-1, -1]
+        guard socketpair(AF_UNIX, SOCK_DGRAM, 0, &fds) == 0 else {
+            throw ContainerizationError(.internalError, message: "socketpair failed with errno \(errno)")
+        }
+        let vmFd = fds[0]
+        let helperFd = fds[1]
+        for fd in fds {
+            var sendSize = Self.socketSendBufferSize
+            var receiveSize = Self.socketReceiveBufferSize
+            // A restrictive kern.ipc.maxsockbuf makes the kernel reject these
+            // sizes rather than clamp them, leaving the socket on its smaller
+            // default buffer. That is not fatal, but it can cause packet drops
+            // under load, so surface it instead of discarding the result.
+            if setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &sendSize, socklen_t(MemoryLayout<Int32>.size)) != 0 {
+                log.warning(
+                    "failed to set vmnet-helper socket send buffer size; check kern.ipc.maxsockbuf",
+                    metadata: ["size": "\(sendSize)", "errno": "\(errno)"]
+                )
+            }
+            if setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &receiveSize, socklen_t(MemoryLayout<Int32>.size)) != 0 {
+                log.warning(
+                    "failed to set vmnet-helper socket receive buffer size; check kern.ipc.maxsockbuf",
+                    metadata: ["size": "\(receiveSize)", "errno": "\(errno)"]
+                )
+            }
+        }
+
+        let stdoutPipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: helperPath)
+        process.arguments = [
+            "--fd", "0",
+            "--operation-mode", "bridged",
+            "--shared-interface", hostInterface,
+            "--interface-id", interfaceId,
+        ]
+        process.standardInput = FileHandle(fileDescriptor: helperFd, closeOnDealloc: false)
+        process.standardOutput = stdoutPipe
+        process.standardError = FileHandle.nullDevice
+
+        log.info(
+            "starting vmnet-helper",
+            metadata: [
+                "path": "\(helperPath)",
+                "hostInterface": "\(hostInterface)",
+                "interfaceId": "\(interfaceId)",
+                "network": "\(attachment.network)",
+            ])
+
+        // The vm end is handed off to the returned interface on
+        // success. Every failure path below reaps the helper and the fd.
+        var handedOff = false
+        var launched = false
+        defer {
+            if !handedOff {
+                if launched {
+                    // A no op when the process has already exited.
+                    process.terminate()
+                }
+                close(vmFd)
+            }
+        }
+
+        do {
+            try process.run()
+            launched = true
+        } catch {
+            close(helperFd)
+            throw ContainerizationError(.internalError, message: "failed to start vmnet-helper at \(helperPath)", cause: error)
+        }
+
+        // The child holds its own copies of the helper end and the
+        // pipe's write end. Close the parent's copies so peer close and
+        // EOF detection work.
+        close(helperFd)
+        try? stdoutPipe.fileHandleForWriting.close()
+
+        // The handshake read blocks for up to `startupTimeout`. Run it
+        // on a GCD queue so it does not stall a concurrency pool thread
+        // and with it the runtime's other XPC routes. A cancellation
+        // handler terminates the helper so the blocking read unblocks on
+        // teardown (the helper's pipe closes, the read sees EOF) instead
+        // of waiting out the startup timeout.
+        let readFd = stdoutPipe.fileHandleForReading.fileDescriptor
+        let parameters: [String: Any] = try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                DispatchQueue.global().async {
+                    let result = Result { try Self.readInterfaceParameters(fd: readFd, process: process) }
+                    continuation.resume(with: result)
+                }
+            }
+        } onCancel: {
+            process.terminate()
+        }
+
+        guard let macString = parameters["vmnet_mac_address"] as? String,
+            let macAddress = try? MACAddress(macString)
+        else {
+            throw ContainerizationError(.internalError, message: "vmnet-helper reported no valid MAC address")
+        }
+        let vmnetMtu = Self.reportedMtu(parameters["vmnet_mtu"]) ?? 1500
+        // The guest link MTU honors the attachment option but cannot
+        // exceed the frame size of the vmnet data path.
+        let mtu = min(attachment.mtu ?? vmnetMtu, vmnetMtu)
+
+        log.info(
+            "started vmnet-helper",
+            metadata: [
+                "macAddress": "\(macAddress)",
+                "mtu": "\(mtu)",
+                "vmnetMtu": "\(vmnetMtu)",
+                "network": "\(attachment.network)",
+            ])
+
+        // Only the first interface carries a gateway, so the guest installs a
+        // single default route (and resolver) via it. Later interfaces reach
+        // only their own subnet. Egress network must be listed first.
+        let ipv4Gateway = interfaceIndex == 0 ? attachment.ipv4Gateway : nil
+        let interface = VmnetHelperInterface(
+            ipv4Address: attachment.ipv4Address,
+            ipv4Gateway: ipv4Gateway,
+            // The guest must use the MAC address vmnet assigned to the
+            // helper's interface. Frames from any other source address
+            // would not pass the bridge.
+            macAddress: macAddress,
+            mtu: mtu,
+            vmnetMtu: vmnetMtu,
+            fileHandle: FileHandle(fileDescriptor: vmFd, closeOnDealloc: true),
+            helperProcess: process
+        )
+        handedOff = true
+        return interface
+    }
+
+    /// The MTU as reported in the helper's parameter JSON. Tolerates a
+    /// string-encoded number rather than silently substituting a default.
+    private static func reportedMtu(_ value: Any?) -> UInt32? {
+        if let number = value as? NSNumber {
+            return number.uint32Value
+        }
+        if let string = value as? String {
+            return UInt32(string)
+        }
+        return nil
+    }
+
+    private static func resolveHelperPath(override: String?) throws -> String {
+        if let override {
+            guard FileManager.default.isExecutableFile(atPath: override) else {
+                throw ContainerizationError(.notFound, message: "vmnet-helper not found at configured path \(override)")
+            }
+            return override
+        }
+        for path in Self.defaultHelperPaths {
+            if FileManager.default.isExecutableFile(atPath: path) {
+                return path
+            }
+        }
+        throw ContainerizationError(
+            .notFound,
+            message: "vmnet-helper not found; install it with `brew install nirs/tap/vmnet-helper` or set the helper-path network option"
+        )
+    }
+
+    /// Derive a stable UUID from the attachment identity so vmnet
+    /// assigns the same MAC address on every container start. The first
+    /// 16 digest bytes form the UUID. vmnet only parses the string, so
+    /// RFC 4122 version bits are not needed.
+    private static func stableInterfaceId(network: String, hostname: String, interfaceIndex: Int) -> String {
+        let digest = SHA256.hash(data: Data("container-bridged:\(network):\(hostname):\(interfaceIndex)".utf8))
+        return digest.withUnsafeBytes { UUID(uuid: $0.load(as: uuid_t.self)) }.uuidString
+    }
+
+    /// Read the single-line JSON interface description that vmnet-helper
+    /// prints to stdout once the vmnet interface starts.
+    private static func readInterfaceParameters(fd: Int32, process: Process) throws -> [String: Any] {
+        var buffer = Data()
+        var scanned = 0
+        let deadline = ContinuousClock.now + Self.startupTimeout
+
+        func parse(_ line: Data) throws -> [String: Any] {
+            guard let object = try? JSONSerialization.jsonObject(with: line),
+                let parameters = object as? [String: Any]
+            else {
+                throw ContainerizationError(.internalError, message: "cannot parse vmnet-helper interface description")
+            }
+            return parameters
+        }
+
+        while true {
+            // Only newly appended bytes need scanning for the terminator.
+            if let newlineIndex = buffer[scanned...].firstIndex(of: UInt8(ascii: "\n")) {
+                return try parse(buffer[..<newlineIndex])
+            }
+            scanned = buffer.count
+
+            let remaining = deadline - ContinuousClock.now
+            guard remaining > .zero else {
+                throw ContainerizationError(.internalError, message: "timed out waiting for vmnet-helper to start")
+            }
+
+            var pollFd = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
+            // Cap each wait at a short interval so the loop revisits its
+            // deadline (and sees the helper's pipe close on teardown)
+            // promptly rather than blocking for up to a full second.
+            let timeoutMs = Int32(min(remaining / .milliseconds(1), 100))
+            let rc = poll(&pollFd, 1, max(timeoutMs, 1))
+            if rc < 0 {
+                if errno == EINTR {
+                    continue
+                }
+                throw ContainerizationError(.internalError, message: "poll on vmnet-helper output failed with errno \(errno)")
+            }
+            if rc == 0 {
+                continue
+            }
+
+            var chunk = [UInt8](repeating: 0, count: 4096)
+            let count = read(fd, &chunk, chunk.count)
+            if count < 0 {
+                if errno == EINTR {
+                    continue
+                }
+                throw ContainerizationError(.internalError, message: "read on vmnet-helper output failed with errno \(errno)")
+            }
+            if count == 0 {
+                // EOF. A complete description may lack a trailing newline,
+                // so try the buffered bytes before failing.
+                if !buffer.isEmpty, let parameters = try? parse(buffer) {
+                    return parameters
+                }
+                // The helper exited before reporting parameters, which
+                // typically means a bad host interface or missing
+                // privileges on macOS 15 and earlier.
+                process.waitUntilExit()
+                throw ContainerizationError(
+                    .internalError,
+                    message: "vmnet-helper exited with status \(process.terminationStatus) before reporting interface parameters"
+                )
+            }
+            buffer.append(contentsOf: chunk[0..<count])
+        }
+    }
+}

--- a/Tests/ContainerAPIClientTests/ParserTest.swift
+++ b/Tests/ContainerAPIClientTests/ParserTest.swift
@@ -909,6 +909,40 @@ struct ParserTest {
         }
     }
 
+    @Test
+    func testParseNetworkWithIP() throws {
+        let result = try Parser.network("backend,ip=192.168.1.50")
+        #expect(result.name == "backend")
+        #expect(result.ip == (try IPv4Address("192.168.1.50")))
+    }
+
+    @Test
+    func testParseNetworkInvalidIP() throws {
+        #expect {
+            _ = try Parser.network("backend,ip=not-an-address")
+        } throws: { error in
+            guard let error = error as? ContainerizationError else {
+                return false
+            }
+            return error.description.contains("invalid ip value")
+        }
+    }
+
+    @Test
+    func testParseNetworkWithIPMacAndMTU() throws {
+        let result = try Parser.network("backend,mac=02:42:ac:11:00:02,mtu=1500,ip=192.168.1.50")
+        #expect(result.name == "backend")
+        #expect(result.macAddress == "02:42:ac:11:00:02")
+        #expect(result.mtu == 1500)
+        #expect(result.ip == (try IPv4Address("192.168.1.50")))
+    }
+
+    @Test
+    func testParseNetworkWithoutIP() throws {
+        let result = try Parser.network("backend,mtu=1500")
+        #expect(result.ip == nil)
+    }
+
     // MARK: - Relative Path Passthrough Tests
 
     @Test

--- a/Tests/ContainerCommandsTests/MachineSetArgumentsTests.swift
+++ b/Tests/ContainerCommandsTests/MachineSetArgumentsTests.swift
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerizationError
+import Testing
+
+@testable import ContainerCommands
+
+struct MachineSetArgumentsTests {
+    // MARK: pairs
+
+    @Test func pairsSplitsKeyValue() throws {
+        let pairs = try MachineSetArguments.pairs(["cpus=4", "memory=2G"])
+        #expect(pairs.count == 2)
+        #expect(pairs[0].key == "cpus")
+        #expect(pairs[0].value == "4")
+        #expect(pairs[1].key == "memory")
+        #expect(pairs[1].value == "2G")
+    }
+
+    @Test func pairsKeepsEqualsInValue() throws {
+        // Only the first `=` separates key from value, so the value may
+        // itself contain `=` (e.g. `console=ttyS0`).
+        let pairs = try MachineSetArguments.pairs(["kernel-arg=console=ttyS0"])
+        #expect(pairs[0].key == "kernel-arg")
+        #expect(pairs[0].value == "console=ttyS0")
+    }
+
+    @Test func pairsAllowsEmptyValue() throws {
+        let pairs = try MachineSetArguments.pairs(["network="])
+        #expect(pairs[0].key == "network")
+        #expect(pairs[0].value == "")
+    }
+
+    @Test func pairsRejectsMissingEquals() {
+        #expect(throws: ContainerizationError.self) {
+            _ = try MachineSetArguments.pairs(["cpus"])
+        }
+    }
+
+    // MARK: list
+
+    @Test func listReturnsNilWhenKeyAbsent() throws {
+        let pairs = try MachineSetArguments.pairs(["cpus=4"])
+        #expect(MachineSetArguments.list(forKey: "network", in: pairs) == nil)
+    }
+
+    @Test func listCollectsRepeatedValuesInOrder() throws {
+        let pairs = try MachineSetArguments.pairs(["network=default", "network=lan,ip=1.2.3.4"])
+        #expect(MachineSetArguments.list(forKey: "network", in: pairs) == ["default", "lan,ip=1.2.3.4"])
+    }
+
+    @Test func listEmptyValueResetsToEmptyArray() throws {
+        let pairs = try MachineSetArguments.pairs(["network="])
+        #expect(MachineSetArguments.list(forKey: "network", in: pairs) == [])
+    }
+
+    @Test func listDropsEmptyAmongNonEmpty() throws {
+        let pairs = try MachineSetArguments.pairs(["network=", "network=lan"])
+        #expect(MachineSetArguments.list(forKey: "network", in: pairs) == ["lan"])
+    }
+
+    // MARK: scalars
+
+    @Test func scalarsExcludesListKeysAndDedups() throws {
+        let pairs = try MachineSetArguments.pairs([
+            "cpus=2", "network=lan", "kernel-arg=quiet", "cpus=4",
+        ])
+        let scalars = MachineSetArguments.scalars(pairs, excluding: ["network", "kernel-arg"])
+        // List keys removed; the later cpus wins.
+        #expect(scalars == ["cpus": "4"])
+    }
+}

--- a/Tests/ContainerNetworkVmnetHelperServerTests/AddressPoolTests.swift
+++ b/Tests/ContainerNetworkVmnetHelperServerTests/AddressPoolTests.swift
@@ -1,0 +1,135 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerizationError
+import ContainerizationExtras
+import Testing
+
+@testable import ContainerNetworkVmnetHelperServer
+
+struct AddressPoolTests {
+    private func config(
+        subnet: String = "192.168.1.0/24",
+        gateway: String = "192.168.1.1",
+        pool: ClosedRange<UInt32>? = nil
+    ) throws -> VmnetHelperPhysicalNetwork.Configuration {
+        try .init(
+            id: "test",
+            ipv4Subnet: try CIDRv4(subnet),
+            ipv4Gateway: try IPv4Address(gateway),
+            hostInterface: "en0",
+            pool: pool,
+            helperPath: nil
+        )
+    }
+
+    private func value(_ s: String) throws -> UInt32 {
+        try IPv4Address(s).value
+    }
+
+    // MARK: validate / isAssignable
+
+    @Test func validateAcceptsHostAddress() throws {
+        let pool = AddressPool(configuration: try config())
+        #expect(throws: Never.self) {
+            try pool.validate(try IPv4Address("192.168.1.50"))
+        }
+    }
+
+    @Test func validateRejectsGatewayNetworkBroadcastAndOutside() throws {
+        let pool = AddressPool(configuration: try config())
+        for bad in ["192.168.1.1", "192.168.1.0", "192.168.1.255", "10.0.0.1"] {
+            #expect(throws: ContainerizationError.self) {
+                try pool.validate(try IPv4Address(bad))
+            }
+        }
+    }
+
+    @Test func isAssignableExcludesBoundaryAndOutsideAddresses() throws {
+        let pool = AddressPool(configuration: try config())
+        #expect(pool.isAssignable(try IPv4Address("192.168.1.50")))
+        #expect(!pool.isAssignable(try IPv4Address("192.168.1.1")))  // gateway
+        #expect(!pool.isAssignable(try IPv4Address("192.168.1.0")))  // network
+        #expect(!pool.isAssignable(try IPv4Address("192.168.1.255")))  // broadcast
+        #expect(!pool.isAssignable(try IPv4Address("10.0.0.1")))  // outside subnet
+    }
+
+    // MARK: reserve / release
+
+    @Test func reserveAndReleaseTrackAllocation() throws {
+        var pool = AddressPool(configuration: try config())
+        let v = try value("192.168.1.50")
+        #expect(!pool.isAllocated(v))
+        pool.reserve(v)
+        #expect(pool.isAllocated(v))
+        pool.release(v)
+        #expect(!pool.isAllocated(v))
+    }
+
+    // MARK: allocateFromPool
+
+    @Test func allocateFromPoolWithoutPoolThrows() throws {
+        var pool = AddressPool(configuration: try config())  // no pool
+        #expect(throws: ContainerizationError.self) {
+            _ = try pool.allocateFromPool()
+        }
+    }
+
+    @Test func allocateFromPoolReturnsSequentialAddresses() throws {
+        let lo = try value("192.168.1.10")
+        var pool = AddressPool(configuration: try config(pool: lo...(lo + 2)))
+        let a = try pool.allocateFromPool()
+        pool.reserve(a)
+        let b = try pool.allocateFromPool()
+        #expect(a == lo)
+        #expect(b == lo + 1)
+    }
+
+    @Test func allocateFromPoolSkipsReservedAddresses() throws {
+        let lo = try value("192.168.1.10")
+        var pool = AddressPool(configuration: try config(pool: lo...(lo + 2)))
+        pool.reserve(lo)
+        #expect(try pool.allocateFromPool() == lo + 1)
+    }
+
+    @Test func allocateFromPoolSkipsUnassignableAddresses() throws {
+        // Pool spans the gateway (.1), which is not assignable and is skipped.
+        let lo = try value("192.168.1.1")
+        var pool = AddressPool(configuration: try config(pool: lo...(lo + 2)))
+        #expect(try pool.allocateFromPool() == (try value("192.168.1.2")))
+    }
+
+    @Test func allocateFromPoolThrowsWhenExhausted() throws {
+        let lo = try value("192.168.1.10")
+        var pool = AddressPool(configuration: try config(pool: lo...(lo + 1)))
+        pool.reserve(try pool.allocateFromPool())
+        pool.reserve(try pool.allocateFromPool())
+        #expect(throws: ContainerizationError.self) {
+            _ = try pool.allocateFromPool()
+        }
+    }
+
+    @Test func allocateFromPoolWrapsAroundCursor() throws {
+        let lo = try value("192.168.1.10")
+        var pool = AddressPool(configuration: try config(pool: lo...(lo + 1)))
+        let a = try pool.allocateFromPool()  // lo, cursor -> lo+1
+        pool.reserve(a)
+        let b = try pool.allocateFromPool()  // lo+1, cursor wraps -> lo
+        pool.reserve(b)
+        pool.release(a)  // free lo again
+        #expect(try pool.allocateFromPool() == lo)  // cursor at lo, reuses it
+    }
+}

--- a/Tests/ContainerNetworkVmnetHelperServerTests/VmnetHelperPhysicalNetworkTests.swift
+++ b/Tests/ContainerNetworkVmnetHelperServerTests/VmnetHelperPhysicalNetworkTests.swift
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerizationError
+import ContainerizationExtras
+import Testing
+
+@testable import ContainerNetworkVmnetHelperServer
+
+struct VmnetHelperPhysicalNetworkTests {
+    private func makeConfig(
+        subnet: String = "192.168.1.0/24",
+        gateway: String = "192.168.1.1",
+        pool: ClosedRange<UInt32>? = nil
+    ) throws -> VmnetHelperPhysicalNetwork.Configuration {
+        try .init(
+            id: "test",
+            ipv4Subnet: try CIDRv4(subnet),
+            ipv4Gateway: try IPv4Address(gateway),
+            hostInterface: "en0",
+            pool: pool,
+            helperPath: nil
+        )
+    }
+
+    @Test func acceptsValidConfiguration() throws {
+        let config = try makeConfig()
+        #expect(config.ipv4Gateway == (try IPv4Address("192.168.1.1")))
+        #expect(config.hostInterface == "en0")
+        #expect(config.pool == nil)
+    }
+
+    @Test func acceptsPoolWithinSubnet() throws {
+        let lower = try IPv4Address("192.168.1.100").value
+        let upper = try IPv4Address("192.168.1.120").value
+        let config = try makeConfig(pool: lower...upper)
+        #expect(config.pool == lower...upper)
+    }
+
+    @Test func rejectsGatewayOutsideSubnet() {
+        #expect(throws: ContainerizationError.self) {
+            _ = try makeConfig(gateway: "10.0.0.1")
+        }
+    }
+
+    @Test func rejectsGatewayAtNetworkAddress() {
+        #expect(throws: ContainerizationError.self) {
+            _ = try makeConfig(gateway: "192.168.1.0")
+        }
+    }
+
+    @Test func rejectsGatewayAtBroadcastAddress() {
+        #expect(throws: ContainerizationError.self) {
+            _ = try makeConfig(gateway: "192.168.1.255")
+        }
+    }
+
+    @Test func rejectsPoolOutsideSubnet() {
+        #expect(throws: ContainerizationError.self) {
+            let lower = try IPv4Address("10.0.0.1").value
+            let upper = try IPv4Address("10.0.0.9").value
+            _ = try makeConfig(pool: lower...upper)
+        }
+    }
+
+    // In a /31 every address is a host address, so the network/broadcast
+    // exclusion does not apply to the gateway.
+    @Test func allowsBoundaryGatewayInSlash31() throws {
+        let config = try makeConfig(subnet: "192.168.1.0/31", gateway: "192.168.1.0")
+        #expect(config.ipv4Gateway == (try IPv4Address("192.168.1.0")))
+    }
+}

--- a/Tests/ContainerPersistenceTests/MachineConfigTests.swift
+++ b/Tests/ContainerPersistenceTests/MachineConfigTests.swift
@@ -91,5 +91,81 @@ struct MachineConfigTests {
         let keys = MachineConfig.settableKeys.map(\.key)
         #expect(keys.contains("virtualization"))
         #expect(keys.contains("kernel"))
+        #expect(keys.contains("network"))
+    }
+
+    @Test func networksDefaultToEmpty() {
+        #expect(MachineConfig.default.networks.isEmpty)
+    }
+
+    @Test func withReplacesNetworks() throws {
+        let updated = try MachineConfig.default.with([:], networks: ["default", "lan,ip=192.168.1.50"])
+        #expect(updated.networks == ["default", "lan,ip=192.168.1.50"])
+    }
+
+    @Test func withNilNetworksPreservesExisting() throws {
+        let withNets = try MachineConfig.default.with([:], networks: ["lan"])
+        // A scalar update (networks omitted) must not clear the network list.
+        let updated = try withNets.with(["cpus": "4"])
+        #expect(updated.networks == ["lan"])
+        #expect(updated.cpus == 4)
+    }
+
+    @Test func withEmptyNetworksResetsToDefault() throws {
+        let withNets = try MachineConfig.default.with([:], networks: ["lan"])
+        let reset = try withNets.with([:], networks: [])
+        #expect(reset.networks.isEmpty)
+    }
+
+    @Test func decodingMissingNetworksUsesEmpty() throws {
+        // Boot-config.json written before machine networking must still load.
+        let legacy = #"{"cpus":4,"memory":"1gb","homeMount":"rw"}"#
+        let decoded = try JSONDecoder().decode(MachineConfig.self, from: Data(legacy.utf8))
+        #expect(decoded.networks.isEmpty)
+    }
+
+    @Test func roundTripJSONNetworks() throws {
+        let config = try MachineConfig.default.with([:], networks: ["lan,ip=192.168.1.50", "default"])
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(MachineConfig.self, from: data)
+        #expect(decoded.networks == ["lan,ip=192.168.1.50", "default"])
+    }
+
+    @Test func settableKeysIncludeKernelArg() {
+        #expect(MachineConfig.settableKeys.map(\.key).contains("kernel-arg"))
+    }
+
+    @Test func kernelArgsDefaultToEmpty() {
+        #expect(MachineConfig.default.kernelArgs.isEmpty)
+    }
+
+    @Test func withReplacesKernelArgs() throws {
+        let updated = try MachineConfig.default.with([:], kernelArgs: ["quiet", "console=ttyS0"])
+        #expect(updated.kernelArgs == ["quiet", "console=ttyS0"])
+    }
+
+    @Test func withNilKernelArgsPreservesExisting() throws {
+        let withArgs = try MachineConfig.default.with([:], kernelArgs: ["quiet"])
+        let updated = try withArgs.with(["cpus": "4"])
+        #expect(updated.kernelArgs == ["quiet"])
+    }
+
+    @Test func withEmptyKernelArgsClears() throws {
+        let withArgs = try MachineConfig.default.with([:], kernelArgs: ["quiet"])
+        let cleared = try withArgs.with([:], kernelArgs: [])
+        #expect(cleared.kernelArgs.isEmpty)
+    }
+
+    @Test func decodingMissingKernelArgsUsesEmpty() throws {
+        let legacy = #"{"cpus":4,"memory":"1gb","homeMount":"rw"}"#
+        let decoded = try JSONDecoder().decode(MachineConfig.self, from: Data(legacy.utf8))
+        #expect(decoded.kernelArgs.isEmpty)
+    }
+
+    @Test func roundTripJSONKernelArgs() throws {
+        let config = try MachineConfig.default.with([:], kernelArgs: ["quiet", "loglevel=3"])
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(MachineConfig.self, from: data)
+        #expect(decoded.kernelArgs == ["quiet", "loglevel=3"])
     }
 }

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1220,6 +1220,8 @@ container machine set [--name <name>] [--debug] <setting> ...
 *   `home-mount=<string>`: User home directory mount option (ro, rw, none). Default: rw
 *   `virtualization=<bool>`: Enable nested virtualization (`true`|`false`). Requires Apple Silicon M3+ and macOS 15+ and kernel with CONFIG_KVM=y.
 *   `kernel=<path>`: Path to a custom kernel binary. An empty value (`kernel=`) clears the override and falls back to the system default.
+*   `network=<spec>`: Attach the machine to a network (format: `<name>[,ip=ADDR][,mac=XX:XX:XX:XX:XX:XX][,mtu=VALUE]`). Repeatable. **Order matters:** only the first network gets a gateway, so it owns the default route and DNS resolver while later networks reach only their own on-link subnet — list the network that should provide egress (e.g. the NAT network) first. An empty value (`network=`) resets to the builtin NAT network.
+*   `kernel-arg=<arg>`: Extra kernel command-line argument (e.g. `quiet`, `console=ttyS0`). Repeatable. An empty value (`kernel-arg=`) clears all extra arguments.
 
 **Options**
 
@@ -1239,6 +1241,13 @@ container machine set virtualization=true kernel=/opt/kernels/vmlinux-kvm
 
 # clear the custom kernel override
 container machine set kernel=
+
+# attach to NAT (egress) plus a bridged network; NAT is listed first so it
+# keeps the default route, the bridge adds on-link reachability to the LAN
+container machine set network=default network=my-bridge
+
+# reset the network configuration back to the builtin NAT network
+container machine set network=
 ```
 
 ### `container machine set-default`


### PR DESCRIPTION
Add bridged physical networking via vmnet-helper

A `container-network-vmnet-helper` plugin bridges container machines
onto a physical interface with static IPv4 and an address pool.
Machines attach via `container machine set network=<spec>` and set
extra kernel command-line args with `kernel-arg=`. Bridged networks
are machine-only; a regular container requesting one is rejected.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
I, as a user, would like to have bridge support in machine containers, this change adds bridge support via external [vmnet-helper](https://github.com/nirs/vmnet-helper) and ability to set kernel args for custom kernels

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [x] Added/updated docs
