### PR TITLE
Increase CI timeout to 75 minutes

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -23,7 +23,7 @@ jobs:
   buildAndTest:
     name: Build and test the project
     if: github.repository == 'apple/container'
-    timeout-minutes: 60
+    timeout-minutes: 75
     runs-on: [self-hosted, macos, tahoe, ARM64]
     permissions:
       contents: read


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Increase CI timeout to 75 minutes

## Testing
- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
