### PR TITLE
Add backward compat for ContainerConfig `cpuOverhead`.

### DIFF
--- a/Sources/ContainerResource/Container/ContainerConfiguration.swift
+++ b/Sources/ContainerResource/Container/ContainerConfiguration.swift
@@ -160,6 +160,14 @@ public struct ContainerConfiguration: Sendable, Codable {
         public var cpuOverhead: Int = 1
 
         public init() {}
+
+        public init(from decoder: any Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            self.cpus = try c.decodeIfPresent(Int.self, forKey: .cpus) ?? 4
+            self.memoryInBytes = try c.decodeIfPresent(UInt64.self, forKey: .memoryInBytes) ?? 1024.mib()
+            self.storage = try c.decodeIfPresent(UInt64.self, forKey: .storage)
+            self.cpuOverhead = try c.decodeIfPresent(Int.self, forKey: .cpuOverhead) ?? 1
+        }
     }
 
     public init(

--- a/Tests/ContainerResourceTests/ContainerConfigurationTests.swift
+++ b/Tests/ContainerResourceTests/ContainerConfigurationTests.swift
@@ -51,6 +51,28 @@ func makeTestConfiguration(
     return config
 }
 
+struct ContainerConfigurationResourcesTests {
+    @Test func roundTripsCpuOverhead() throws {
+        var config = makeTestConfiguration()
+        config.resources.cpuOverhead = 2
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(ContainerConfiguration.self, from: data)
+        #expect(decoded.resources.cpuOverhead == 2)
+    }
+
+    @Test func decodesMissingCpuOverheadAsDefault() throws {
+        let config = makeTestConfiguration()
+        let data = try JSONEncoder().encode(config)
+        var obj = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        var resources = try #require(obj["resources"] as? [String: Any])
+        resources.removeValue(forKey: "cpuOverhead")
+        obj["resources"] = resources
+        let stripped = try JSONSerialization.data(withJSONObject: obj)
+        let decoded = try JSONDecoder().decode(ContainerConfiguration.self, from: stripped)
+        #expect(decoded.resources.cpuOverhead == 1)
+    }
+}
+
 struct ContainerConfigurationCreationDateTests {
     @Test func roundTripsCreationDate() throws {
         let when = Date(timeIntervalSince1970: 1_700_000_000)


### PR DESCRIPTION
- Closes #1664.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
1.0 data migration requirement

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs
