### PR TITLE
Fix: race conditions in DefaultNetworkService.lookup by removing async from AttachmentAllocator.lookup

### DIFF
--- a/Sources/Services/Network/Server/AttachmentAllocator.swift
+++ b/Sources/Services/Network/Server/AttachmentAllocator.swift
@@ -1,4 +1,4 @@
-/===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 // Copyright © 2026 Apple Inc. and the container project authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/Sources/Services/Network/Server/AttachmentAllocator.swift
+++ b/Sources/Services/Network/Server/AttachmentAllocator.swift
@@ -1,4 +1,4 @@
-//===----------------------------------------------------------------------===//
+/===----------------------------------------------------------------------===//
 // Copyright © 2026 Apple Inc. and the container project authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,7 +53,7 @@ actor AttachmentAllocator {
     }
 
     /// Retrieve the allocator index for a hostname.
-    func lookup(hostname: String) async throws -> UInt32? {
+    func lookup(hostname: String) throws -> UInt32? {
         hostnames[hostname]
     }
 }

--- a/Sources/Services/Network/Server/DefaultNetworkService.swift
+++ b/Sources/Services/Network/Server/DefaultNetworkService.swift
@@ -127,7 +127,7 @@ public actor DefaultNetworkService: NetworkService {
         }
 
         // Invariant: hostname -> index if and only if index -> MAC address
-        let index = try await allocator.lookup(hostname: hostname)
+        let index = try allocator.lookup(hostname: hostname)
         guard let index else {
             return nil
         }


### PR DESCRIPTION
## Type of Change
- [*] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Removed the async from AttachmentAllocator.lookup, causing the race conditions because the deallocator being called while lookup is running as it overrides the actor's reentrancy protection. Leading to at times mac address being returned as nil and fixes the #1693 

## Testing
- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
