### PR TITLE
Clarify app root and install root documentation

### DIFF
--- a/Sources/ContainerCommands/System/SystemStart.swift
+++ b/Sources/ContainerCommands/System/SystemStart.swift
@@ -34,13 +34,13 @@ extension Application {
 
         @Option(
             name: .shortAndLong,
-            help: "Path to the root directory for application data",
+            help: "Path to the root directory for container data, including API server state and plugin state",
             transform: { FilePath(FileManager.default.currentDirectoryPath).resolve($0, defaultPath: FilePath($0)) })
         var appRoot = ApplicationRoot.defaultPath
 
         @Option(
             name: .long,
-            help: "Path to the root directory for application executables and plugins",
+            help: "Path to the root directory for container executables and plugins",
             transform: { FilePath(FileManager.default.currentDirectoryPath).resolve($0, defaultPath: FilePath($0)) })
         var installRoot = InstallRoot.defaultPath
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1318,11 +1318,14 @@ container system start [--app-root <app-root>] [--install-root <install-root>] [
 
 **Options**
 
-*   `-a, --app-root <app-root>`: Path to the root directory for application data
-*   `--install-root <install-root>`: Path to the root directory for application executables and plugins
+*   `-a, --app-root <app-root>`: Path to the root directory for container data, including API server state and plugin state
+*   `--install-root <install-root>`: Path to the root directory for container executables and plugins
 *   `--log-root <log-root>`: Path to the root directory for log data, using macOS log facility if not set
 *   `--enable-kernel-install/--disable-kernel-install`: Specify whether the default kernel should be installed or not (default: prompt user)
 *   `--timeout <timeout>`: Number of seconds to wait for API service to become responsive
+
+> [!NOTE]
+> The application root and installation root serve different purposes. Use `--app-root` when you want `container` to store its runtime data somewhere other than the default location, such as an external APFS volume or a temporary directory for integration tests. Most users do not need to change `--install-root`; it is used to locate installed `container` executables and plugins.
 
 > [!NOTE]
 > The `--log-root` option is principally intended for short-term test and diagnostic purposes. The log handler for this option neither aggregates log messages, nor does it rotate logs.

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -33,6 +33,22 @@ container builder delete
 container builder start --cpus 8 --memory 32g
 ```
 
+## Store container data in a different location
+
+By default, `container` stores its runtime data in the application root. This includes data used by the API server and plugins, and other container-managed resources such as containers, images, networks, and volumes.
+
+Use `--app-root` with `container system start` to store this data somewhere else, such as an external APFS volume or a temporary directory for integration tests.
+
+```bash
+container system stop
+container system start --app-root /Volumes/ContainerData
+container system status
+```
+
+The application root is different from the installation root. The installation root is used for installed `container` executables and plugins. Most users do not need to change it.
+
+To share host files with a specific container, use `--volume` or `--mount` with `container run` instead of changing the application root.
+
 ## Share host files with your container
 
 With the `--volume` option of `container run`, you can share data between the host system and one or more containers, and you can persist data across multiple container runs. The volume option allows you to mount a folder on your host to a filesystem path in the container.


### PR DESCRIPTION
## Type of Change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [x] Documentation update

## Motivation and Context

Clarifies the meaning of `--app-root` and `--install-root` for `container system start`.

The existing wording described these as application and installation roots, but did not clearly explain when a user would change each option. This updates the CLI help text, command reference, and how-to documentation to explain that `--app-root` controls container-managed runtime data, while `--install-root` is used for installed `container` executables and plugins.

Closes #622.

## Testing

* [ ] Tested locally
* [ ] Added/updated tests
* [x] Added/updated docs

I ran `git diff --check` to verify there were no whitespace issues.
