### PR TITLE
Validate container system stop --prefix to prevent accidental logout

### DIFF
--- a/Sources/ContainerCommands/System/SystemStop.swift
+++ b/Sources/ContainerCommands/System/SystemStop.swift
@@ -41,6 +41,21 @@ extension Application {
 
         public init() {}
 
+        public mutating func validate() throws {
+            guard !prefix.isEmpty, prefix.unicodeScalars.allSatisfy(Self.isValidLaunchdLabelPrefixScalar) else {
+                throw ValidationError("invalid --prefix \"\(prefix)\": must be a launchd label prefix (letters, digits, '.', '-', '_'), e.g. com.apple.container.")
+            }
+        }
+
+        private static func isValidLaunchdLabelPrefixScalar(_ scalar: Unicode.Scalar) -> Bool {
+            switch scalar.value {
+            case 48...57, 65...90, 97...122, 45, 46, 95:
+                return true
+            default:
+                return false
+            }
+        }
+
         public func run() async throws {
             let log = Logger(
                 label: "com.apple.container.cli",

--- a/Tests/ContainerCommandsTests/SystemStopValidationTests.swift
+++ b/Tests/ContainerCommandsTests/SystemStopValidationTests.swift
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import Foundation
+import Testing
+
+@testable import ContainerCommands
+
+struct SystemStopValidationTests {
+    @Test
+    func rejectsPathPrefix() {
+        #expect {
+            try Self.parseAndValidate(["--prefix", "/usr/local/container"])
+        } throws: { error in
+            String(describing: error).contains("invalid --prefix \"/usr/local/container\"")
+        }
+    }
+
+    @Test
+    func rejectsInvalidCharacters() {
+        #expect {
+            try Self.parseAndValidate(["--prefix", "foo bar"])
+        } throws: { error in
+            String(describing: error).contains("invalid --prefix \"foo bar\"")
+        }
+    }
+
+    @Test
+    func acceptsDefaultPrefix() throws {
+        try Self.parseAndValidate([])
+    }
+
+    @Test
+    func acceptsCustomReverseDNSPrefix() throws {
+        try Self.parseAndValidate(["--prefix", "com.example.svc."])
+    }
+
+    private static func parseAndValidate(_ args: [String]) throws {
+        var command = try Application.SystemStop.parse(args)
+        try command.validate()
+    }
+}


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
`container system stop` accepts a `--prefix` / `-p` option (default `com.apple.container.`). A user reported in #1672 that `container system stop -p /usr/local/container` logs them out of macOS.

The value is interpolated unvalidated into launchd label and domain-target strings that are handed to `launchctl bootout` (`SystemStop.swift` builds `"\(launchdDomainString)/\(prefix)apiserver"` and re-maps enumerated labels, then `ServiceManager.deregister` runs `launchctl bootout <label>`). A path value produces a malformed bootout target, and `launchctl bootout` of a malformed or bare domain target tears down the entire GUI session (`gui/<uid>`), which ends the user's login.

This adds a `validate()` guard that rejects any `--prefix` that is empty or contains characters outside `[A-Za-z0-9._-]` (including `/`), with a clear error naming the bad value and the expected form. All valid usage, including the default and any real reverse-DNS prefix, is unchanged. Scope is limited to `system stop`; `system status` declares the same option but only uses it for read-only `launchctl list` / `isRegistered` calls, so it cannot log the user out.

Fixes #1672

## Testing
- [x] Tested locally
- [x] Added/updated tests

Added `Tests/ContainerCommandsTests/SystemStopValidationTests.swift` (swift-testing): rejects `/usr/local/container` and `foo bar`, accepts the default `com.apple.container.` and a custom `com.example.svc.`.

```
swift test --filter SystemStopValidationTests
✔ Test run with 4 tests in 1 suite passed
```

`swift format lint --strict --configuration .swift-format-nolint` on the changed files reports no findings.

AI was used for assistance.
