### PR TITLE
refactor: enhance CLI robustness, optimize container cleanup, and secure defaults

### DIFF
--- a/Sources/ContainerPersistence/ContainerSystemConfig.swift
+++ b/Sources/ContainerPersistence/ContainerSystemConfig.swift
@@ -80,7 +80,13 @@ public final class ContainerSystemConfig: Codable, Sendable, Initable {
 final public class BuildConfig: Codable, Sendable {
     public static let defaultRosetta = true
     public static let defaultCPUs = 2
-    public static let defaultMemory = try! MemorySize("2048MB")
+    public static let defaultMemory: MemorySize = {
+        do {
+            return try MemorySize("2048MB")
+        } catch {
+            preconditionFailure("Errore nell'inizializzazione statica di defaultMemory: \(error)")
+        }
+    }()
     public static var defaultImage: String {
         let tag = String(cString: get_container_builder_shim_version())
         return "ghcr.io/apple/container-builder-shim/builder:\(tag)"
@@ -114,7 +120,13 @@ final public class BuildConfig: Codable, Sendable {
 
 final public class ContainerConfig: Codable, Sendable {
     public static let defaultCPUs = 4
-    public static let defaultMemory = try! MemorySize("1g")
+    public static let defaultMemory: MemorySize = {
+        do {
+            return try MemorySize("1g")
+        } catch {
+            preconditionFailure("Errore nell'inizializzazione statica di defaultMemory: \(error)")
+        }
+    }()
 
     public let cpus: Int
     public let memory: MemorySize

--- a/Sources/Services/ContainerAPIService/Client/ProcessIO.swift
+++ b/Sources/Services/ContainerAPIService/Client/ProcessIO.swift
@@ -105,7 +105,12 @@ public struct ProcessIO: Sendable {
                     cc.yield()
                     return
                 }
-                try! pout.write(contentsOf: data)
+                do {
+                    try pout.write(contentsOf: data)
+                } catch {
+                    rout.readabilityHandler = nil
+                    cc.yield()
+                }
             }
         }
 
@@ -126,7 +131,12 @@ public struct ProcessIO: Sendable {
                     cc.yield()
                     return
                 }
-                try! perr.write(contentsOf: data)
+                do {
+                    try perr.write(contentsOf: data)
+                } catch {
+                    rerr.readabilityHandler = nil
+                    cc.yield()
+                }
             }
             stdio[2] = stderr.fileHandleForWriting
         }

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -1026,31 +1026,16 @@ public actor ContainersService {
         await self.exitMonitor.stopTracking(id: id)
         let path = self.containerRoot.appendingPathComponent(id)
 
-        // Try to get config for service deregistration
-        // Don't fail if bundle is incomplete
-        var config: ContainerConfiguration?
-        let bundle = ContainerResource.Bundle(path: path)
-        do {
-            config = try bundle.configuration
-        } catch {
-            self.log.warning(
-                "failed to read bundle configuration during cleanup for container",
-                metadata: [
-                    "id": "\(id)",
-                    "error": "\(error)",
-                ])
-        }
-
-        // Only try to deregister service if we have a valid config
-        // TODO: Change this so we don't have to reread the config
-        // possibly store the container ID to service label mapping
-        if let config = config {
+        let containerState = self.containers[id]
+        if let runtimeHandler = containerState?.snapshot.configuration.runtimeHandler {
             let label = Self.fullLaunchdServiceLabel(
-                runtimeName: config.runtimeHandler,
+                runtimeName: runtimeHandler,
                 instanceId: id
             )
             try? ServiceManager.deregister(fullServiceLabel: label)
         }
+
+        let bundle = ContainerResource.Bundle(path: path)
 
         // Always try to delete the bundle directory, even if it's incomplete
         do {


### PR DESCRIPTION
# refactor: enhance CLI robustness, optimize container cleanup, and secure defaults

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Currently, the codebase contains several minor issues and TODOs that impact runtime safety and efficiency:
1. Writing output to stdout/stderr in `ProcessIO` uses `try!`, which crashes the CLI abruptly if the output pipe is closed early (e.g. `container run ... | head -n 5`).
2. Container cleanup in `ContainersService` reads the configuration file from disk unnecessarily to deregister launchd services, even though the state configuration is already loaded in memory.
3. Static defaults for memory sizes utilize force unwraps (`try!`), which are brittle and would cause silent crashes at daemon startup if parsing fails.

This change resolves these items, improving CLI pipeline stability, speeding up container cleanup, and making configuration defaults safer.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
