### PR TITLE
fix: sanitize sudoers filename for usernames containing dots

### DIFF
--- a/Sources/Plugins/MachineAPIServer/Resources/create-user.sh
+++ b/Sources/Plugins/MachineAPIServer/Resources/create-user.sh
@@ -44,4 +44,4 @@ chown -R "${CONTAINER_UID}:${CONTAINER_GID}" "${CONTAINER_HOME}"
 mkdir -p /etc/sudoers.d
 SUODOERS_FILE="${CONTAINER_USER//./_}"
 echo "${CONTAINER_USER} ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/${SUODOERS_FILE}"
-chmod 440 "/etc/sudoers.d/${CONTAINER_USER}"
+chmod 440 "/etc/sudoers.d/${SUDOERS_FILE}"

--- a/Sources/Plugins/MachineAPIServer/Resources/create-user.sh
+++ b/Sources/Plugins/MachineAPIServer/Resources/create-user.sh
@@ -42,5 +42,6 @@ fi
 chown -R "${CONTAINER_UID}:${CONTAINER_GID}" "${CONTAINER_HOME}"
 
 mkdir -p /etc/sudoers.d
-echo "${CONTAINER_USER} ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/${CONTAINER_USER}"
+SUODOERS_FILE="${CONTAINER_USER//./_}"
+echo "${CONTAINER_USER} ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/${SUODOERS_FILE}"
 chmod 440 "/etc/sudoers.d/${CONTAINER_USER}"

--- a/Tests/CLITests/Subcommands/Machine/TestCLIMachine.swift
+++ b/Tests/CLITests/Subcommands/Machine/TestCLIMachine.swift
@@ -381,10 +381,11 @@ class TestCLIMachineRuntime: CLITest {
         try waitForMachineStatus(name, status: "running")
 
         let username = NSUserName()
+        let sanitizedUsername = username.replacingOccurrences(of: ".", with: "_")
         let output = try doMachineRun(
             name: name,
             root: true,
-            command: ["cat", "/etc/sudoers.d/\(username)"]
+            command: ["cat", "/etc/sudoers.d/\(sanitizedUsername)"]
         )
         let content = output.trimmingCharacters(in: .whitespacesAndNewlines)
         #expect(


### PR DESCRIPTION
## Type of Change
- [*] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
When a macOS username contains a dot (e.g. user.name), sudo silently ignores /etc/sudoers.d/user.name because sudo skips any drop in file whose name contains a dot. Fix by sanitizing the filename only, keeping the real username intact inside the rule. Fixes #1713 

## Testing
- [ ] Tested locally
- [*] Added/updated tests
- [ ] Added/updated docs
