### PR TITLE
Fix XPC connection failure when home directory is on external volume

### DIFF
--- a/Sources/ContainerCommands/System/SystemStart.swift
+++ b/Sources/ContainerCommands/System/SystemStart.swift
@@ -54,7 +54,7 @@ extension Application {
             name: .long,
             help: "Path to the root directory for launchd service registration files; must reside on an internal volume",
             transform: { FilePath(FileManager.default.currentDirectoryPath).resolve($0, defaultPath: FilePath($0)) })
-        var serviceRoot = ServiceRoot.defaultPath
+        var serviceRoot = ServiceRoot.path
 
         @Flag(
             name: .long,
@@ -136,7 +136,8 @@ extension Application {
             // CONTAINER_SERVICE_ROOT is forwarded into the plist environment so the
             // daemon's PluginLoader writes plugin plists to the same root without
             // requiring any additional wiring at other call sites.
-            let plistDir = serviceRoot
+            let plistDir =
+                serviceRoot
                 .appending(FilePath.Component("apiserver"))
             let plistDirURL = URL(fileURLWithPath: plistDir.string)
             try FileManager.default.createDirectory(at: plistDirURL, withIntermediateDirectories: true)

--- a/Sources/ContainerCommands/System/SystemStart.swift
+++ b/Sources/ContainerCommands/System/SystemStart.swift
@@ -50,6 +50,12 @@ extension Application {
             transform: { FilePath(FileManager.default.currentDirectoryPath).resolve($0, defaultPath: FilePath($0)) })
         var logRoot: FilePath? = nil
 
+        @Option(
+            name: .long,
+            help: "Path to the root directory for launchd service registration files; must reside on an internal volume",
+            transform: { FilePath(FileManager.default.currentDirectoryPath).resolve($0, defaultPath: FilePath($0)) })
+        var serviceRoot = ServiceRoot.defaultPath
+
         @Flag(
             name: .long,
             inversion: .prefixedEnableDisable,
@@ -109,6 +115,7 @@ extension Application {
             var env = PluginLoader.filterEnvironment()
             env[ApplicationRoot.environmentName] = appRoot.string
             env[InstallRoot.environmentName] = installRoot.string
+            env[ServiceRoot.environmentName] = serviceRoot.string
             if let logRoot {
                 env[LogRoot.environmentName] = logRoot.string
             }
@@ -121,8 +128,16 @@ extension Application {
                 machServices: ["com.apple.container.apiserver"]
             )
 
-            let plistPath = apiServerDataPath.appending(FilePath.Component("apiserver.plist"))
-            let plistURL = URL(fileURLWithPath: plistPath.string)
+            // Write the plist under serviceRoot, which must be on an internal system
+            // volume. launchd cannot register Mach services from plists on external or
+            // removable volumes, so serviceRoot is kept separate from appRoot.
+            // CONTAINER_SERVICE_ROOT is propagated to the daemon via the plist
+            // environment so that plugin registration also uses this root.
+            let plistDir = serviceRoot
+                .appending(FilePath.Component("apiserver"))
+            let plistDirURL = URL(fileURLWithPath: plistDir.string)
+            try FileManager.default.createDirectory(at: plistDirURL, withIntermediateDirectories: true)
+            let plistURL = plistDirURL.appendingPathComponent("apiserver.plist")
             let data = try plist.encode()
             try data.write(to: plistURL)
 

--- a/Sources/ContainerCommands/System/SystemStart.swift
+++ b/Sources/ContainerCommands/System/SystemStart.swift
@@ -128,11 +128,14 @@ extension Application {
                 machServices: ["com.apple.container.apiserver"]
             )
 
-            // Write the plist under serviceRoot, which must be on an internal system
-            // volume. launchd cannot register Mach services from plists on external or
-            // removable volumes, so serviceRoot is kept separate from appRoot.
-            // CONTAINER_SERVICE_ROOT is propagated to the daemon via the plist
-            // environment so that plugin registration also uses this root.
+            // Write the plist under serviceRoot, intentionally separate from appRoot.
+            // launchd cannot register Mach services from plists on external or removable
+            // volumes; keeping service files on the internal system volume (serviceRoot)
+            // while application data lives in appRoot preserves that guarantee even when
+            // the user's home directory is on an external volume.
+            // CONTAINER_SERVICE_ROOT is forwarded into the plist environment so the
+            // daemon's PluginLoader writes plugin plists to the same root without
+            // requiring any additional wiring at other call sites.
             let plistDir = serviceRoot
                 .appending(FilePath.Component("apiserver"))
             let plistDirURL = URL(fileURLWithPath: plistDir.string)

--- a/Sources/ContainerPlugin/PluginLoader.swift
+++ b/Sources/ContainerPlugin/PluginLoader.swift
@@ -34,16 +34,16 @@ public struct PluginLoader: Sendable {
 
     public typealias PluginQualifier = ((Plugin) -> Bool)
 
-    // A path on disk managed by the PluginLoader, where it stores
-    // runtime data for loaded plugins. This includes log files.
-    private let pluginResourceRoot: URL
-
     // A path on the system (internal) volume where launchd plists are written.
     // Derived from serviceRoot, which is always on an internal volume, so that
     // plist registration succeeds even when appRoot is on an external or
     // removable volume — launchd cannot bootstrap Mach services from plists on
     // such volumes.
     private let plistResourceRoot: URL
+
+    // The resolved service root propagated to child services so nested plugin
+    // loaders use the same internal-volume location for their launchd plists.
+    private let serviceRoot: URL
 
     public init(
         appRoot: URL,
@@ -54,10 +54,8 @@ public struct PluginLoader: Sendable {
         log: Logger? = nil,
         serviceRoot: URL? = nil
     ) throws {
-        let pluginResourceRoot = appRoot.appendingPathComponent("plugin-state")
-        try FileManager.default.createDirectory(at: pluginResourceRoot, withIntermediateDirectories: true)
-        self.pluginResourceRoot = pluginResourceRoot
         let resolvedServiceRoot = serviceRoot ?? URL(fileURLWithPath: ServiceRoot.pathname, isDirectory: true)
+        self.serviceRoot = resolvedServiceRoot
         let plistResourceRoot = resolvedServiceRoot.appendingPathComponent("plugin-state", isDirectory: true)
         try FileManager.default.createDirectory(at: plistResourceRoot, withIntermediateDirectories: true)
         self.plistResourceRoot = plistResourceRoot
@@ -220,7 +218,7 @@ extension PluginLoader {
 
     public func registerWithLaunchd(
         plugin: Plugin,
-        pluginStateRoot: URL? = nil,
+        pluginStateRoot _: URL? = nil,
         args: [String]? = nil,
         instanceId: String? = nil,
         debug: Bool = false,
@@ -233,7 +231,14 @@ extension PluginLoader {
 
         let id = plugin.getLaunchdLabel(instanceId: instanceId)
         log?.info("Registering plugin", metadata: ["id": "\(id)"])
-        let rootURL = pluginStateRoot ?? self.plistResourceRoot.appending(path: plugin.name)
+        // pluginStateRoot contains runtime data and may be on an external volume.
+        // launchd plists must always remain under plistResourceRoot on the
+        // internal volume. Include the instance ID so registrations for multiple
+        // instances of the same plugin do not overwrite each other.
+        var rootURL = self.plistResourceRoot.appending(path: plugin.name)
+        if let instanceId {
+            rootURL = rootURL.appending(path: instanceId)
+        }
         let resourceURL = plugin.resourceURL
 
         try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
@@ -241,6 +246,7 @@ extension PluginLoader {
         var env = Self.filterEnvironment()
         env[ApplicationRoot.environmentName] = appRoot.path(percentEncoded: false)
         env[InstallRoot.environmentName] = installRoot.path(percentEncoded: false)
+        env[ServiceRoot.environmentName] = serviceRoot.path(percentEncoded: false)
         if let logRoot {
             env[LogRoot.environmentName] =
                 logRoot.isAbsolute

--- a/Sources/ContainerPlugin/PluginLoader.swift
+++ b/Sources/ContainerPlugin/PluginLoader.swift
@@ -35,9 +35,15 @@ public struct PluginLoader: Sendable {
     public typealias PluginQualifier = ((Plugin) -> Bool)
 
     // A path on disk managed by the PluginLoader, where it stores
-    // runtime data for loaded plugins. This includes the launchd plists
-    // and logs files.
+    // runtime data for loaded plugins. This includes log files.
     private let pluginResourceRoot: URL
+
+    // A path on the system (internal) volume where launchd plists are written.
+    // Derived from serviceRoot, which is always on an internal volume, so that
+    // plist registration succeeds even when appRoot is on an external or
+    // removable volume — launchd cannot bootstrap Mach services from plists on
+    // such volumes.
+    private let plistResourceRoot: URL
 
     public init(
         appRoot: URL,
@@ -45,11 +51,16 @@ public struct PluginLoader: Sendable {
         logRoot: FilePath?,
         pluginDirectories: [URL],
         pluginFactories: [PluginFactory],
-        log: Logger? = nil
+        log: Logger? = nil,
+        serviceRoot: URL? = nil
     ) throws {
         let pluginResourceRoot = appRoot.appendingPathComponent("plugin-state")
         try FileManager.default.createDirectory(at: pluginResourceRoot, withIntermediateDirectories: true)
         self.pluginResourceRoot = pluginResourceRoot
+        let resolvedServiceRoot = serviceRoot ?? URL(fileURLWithPath: ServiceRoot.pathname, isDirectory: true)
+        let plistResourceRoot = resolvedServiceRoot.appendingPathComponent("plugin-state", isDirectory: true)
+        try FileManager.default.createDirectory(at: plistResourceRoot, withIntermediateDirectories: true)
+        self.plistResourceRoot = plistResourceRoot
         self.appRoot = appRoot
         self.installRoot = installRoot
         self.logRoot = logRoot
@@ -222,7 +233,7 @@ extension PluginLoader {
 
         let id = plugin.getLaunchdLabel(instanceId: instanceId)
         log?.info("Registering plugin", metadata: ["id": "\(id)"])
-        let rootURL = pluginStateRoot ?? self.pluginResourceRoot.appending(path: plugin.name)
+        let rootURL = pluginStateRoot ?? self.plistResourceRoot.appending(path: plugin.name)
         let resourceURL = plugin.resourceURL
 
         try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)

--- a/Sources/ContainerPlugin/ServiceRoot.swift
+++ b/Sources/ContainerPlugin/ServiceRoot.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import SystemPackage
+
+/// Provides the root path for launchd service registration files (plists).
+///
+/// This root is intentionally separate from ``ApplicationRoot`` so that service
+/// registration succeeds even when the application data directory is on an
+/// external or removable volume. launchd cannot register Mach services from
+/// plists on such volumes, so registration files must always reside on the
+/// internal system volume.
+///
+/// The default path resolves to a `com.apple.container` subdirectory under the
+/// per-user temporary directory, which macOS always places on the internal
+/// system volume regardless of where the user's home directory lives.
+public struct ServiceRoot {
+    /// The environment variable that, if set, determines the root directory for
+    /// launchd service registration files.
+    public static let environmentName = "CONTAINER_SERVICE_ROOT"
+
+    /// The default root directory used when ``environmentName`` is not set:
+    /// a `com.apple.container` subdirectory under the user's temporary directory.
+    ///
+    /// The temporary directory (`NSTemporaryDirectory()`) is always located on
+    /// the internal system volume on macOS, making it safe for launchd plist
+    /// registration even when ``ApplicationRoot`` is on an external volume.
+    public static let defaultPath = FilePath(
+        FileManager.default.temporaryDirectory.path(percentEncoded: false)
+    ).appending(FilePath.Component("com.apple.container"))
+
+    /// The resolved root directory path, always lexically normalized.
+    ///
+    /// If the environment variable is set to an absolute path, that path is used directly.
+    /// If it is set to a relative path, the path is resolved against the working directory.
+    /// Otherwise, ``defaultPath`` is used.
+    public static let path = FilePath(FileManager.default.currentDirectoryPath).resolve(
+        ProcessInfo.processInfo.environment[environmentName],
+        defaultPath: defaultPath
+    )
+
+    /// The pathname to the root directory.
+    public static let pathname = path.string
+}

--- a/Sources/ContainerPlugin/ServiceRoot.swift
+++ b/Sources/ContainerPlugin/ServiceRoot.swift
@@ -36,12 +36,18 @@ public struct ServiceRoot {
     /// The default root directory used when ``environmentName`` is not set:
     /// a `com.apple.container` subdirectory under the user's temporary directory.
     ///
-    /// The temporary directory (`NSTemporaryDirectory()`) is always located on
-    /// the internal system volume on macOS, making it safe for launchd plist
-    /// registration even when ``ApplicationRoot`` is on an external volume.
-    public static let defaultPath = FilePath(
-        FileManager.default.temporaryDirectory.path(percentEncoded: false)
-    ).appending(FilePath.Component("com.apple.container"))
+    /// `NSTemporaryDirectory()` is guaranteed by macOS to reside on the internal
+    /// system volume (typically `/private/var/folders/…`), making it safe for
+    /// launchd plist registration even when ``ApplicationRoot`` is on an external
+    /// or removable volume.
+    public static let defaultPath: FilePath = {
+        let tmpPath = FileManager.default.temporaryDirectory.path(percentEncoded: false)
+        precondition(
+            !tmpPath.isEmpty,
+            "NSTemporaryDirectory() returned an empty path; cannot determine a safe location for launchd plists"
+        )
+        return FilePath(tmpPath).appending(FilePath.Component("com.apple.container"))
+    }()
 
     /// The resolved root directory path, always lexically normalized.
     ///

--- a/Tests/ContainerPluginTests/PluginLoaderTest.swift
+++ b/Tests/ContainerPluginTests/PluginLoaderTest.swift
@@ -257,6 +257,52 @@ struct PluginLoaderTest {
         #expect(!programArguments.contains("--debug"))
     }
 
+    // MARK: - External volume plist placement tests
+
+    /// When serviceRoot is separate from appRoot, the plist must land under
+    /// serviceRoot and NOT under appRoot — which might be on an external or
+    /// removable volume where launchd cannot register Mach services.
+    @Test
+    func testRegisterWithLaunchdPlistNotUnderAppRoot() async throws {
+        let appRootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("app-root-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: appRootURL) }
+
+        // serviceRoot is distinct from appRoot, simulating the case where appRoot
+        // is on an external volume but serviceRoot is on the internal system volume.
+        let serviceRootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("service-root-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: serviceRootURL) }
+
+        let factory = try setupMock(tempURL: appRootURL)
+        let loader = try PluginLoader(
+            appRoot: appRootURL,
+            installRoot: URL(filePath: "/usr/local/"),
+            logRoot: nil,
+            pluginDirectories: [appRootURL],
+            pluginFactories: [factory],
+            serviceRoot: serviceRootURL
+        )
+
+        let plugin = loader.findPlugin(name: "service")!
+        try loader.registerWithLaunchd(plugin: plugin)
+
+        let expectedPlistURL = serviceRootURL
+            .appendingPathComponent("plugin-state", isDirectory: true)
+            .appending(path: plugin.name)
+            .appendingPathComponent("service.plist")
+
+        // Plist exists under serviceRoot (internal volume)
+        #expect(FileManager.default.fileExists(atPath: expectedPlistURL.path))
+
+        // Plist must NOT exist under appRoot (which could be an external volume)
+        let appRootPlistURL = appRootURL
+            .appendingPathComponent("plugin-state", isDirectory: true)
+            .appending(path: plugin.name)
+            .appendingPathComponent("service.plist")
+        #expect(!FileManager.default.fileExists(atPath: appRootPlistURL.path))
+    }
+
     private func setupMock(tempURL: URL) throws -> MockPluginFactory {
         let cliConfig = PluginConfig(abstract: "cli", author: "CLI", servicesConfig: nil)
         let cliPlugin: Plugin = Plugin(binaryURL: URL(filePath: "/bin/cli"), config: cliConfig)

--- a/Tests/ContainerPluginTests/PluginLoaderTest.swift
+++ b/Tests/ContainerPluginTests/PluginLoaderTest.swift
@@ -180,20 +180,22 @@ struct PluginLoaderTest {
     func testRegisterWithLaunchdDebugTrue() async throws {
         let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         defer { try? FileManager.default.removeItem(at: tempURL) }
+        let serviceRoot = tempURL.appendingPathComponent("service-root", isDirectory: true)
         let factory = try setupMock(tempURL: tempURL)
         let loader = try PluginLoader(
             appRoot: tempURL,
             installRoot: URL(filePath: "/usr/local/"),
             logRoot: nil,
             pluginDirectories: [tempURL],
-            pluginFactories: [factory]
+            pluginFactories: [factory],
+            serviceRoot: serviceRoot
         )
 
         let plugin = loader.findPlugin(name: "service")!
         let stateRoot = tempURL.appendingPathComponent("test-state")
         try loader.registerWithLaunchd(plugin: plugin, pluginStateRoot: stateRoot, debug: true)
 
-        let plistURL = stateRoot.appendingPathComponent("service.plist")
+        let plistURL = serviceRoot.appending(path: "plugin-state/service/service.plist")
         #expect(FileManager.default.fileExists(atPath: plistURL.path))
 
         let plistData = try Data(contentsOf: plistURL)
@@ -207,20 +209,22 @@ struct PluginLoaderTest {
     func testRegisterWithLaunchdDebugFalse() async throws {
         let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         defer { try? FileManager.default.removeItem(at: tempURL) }
+        let serviceRoot = tempURL.appendingPathComponent("service-root", isDirectory: true)
         let factory = try setupMock(tempURL: tempURL)
         let loader = try PluginLoader(
             appRoot: tempURL,
             installRoot: URL(filePath: "/usr/local/"),
             logRoot: nil,
             pluginDirectories: [tempURL],
-            pluginFactories: [factory]
+            pluginFactories: [factory],
+            serviceRoot: serviceRoot
         )
 
         let plugin = loader.findPlugin(name: "service")!
         let stateRoot = tempURL.appendingPathComponent("test-state")
         try loader.registerWithLaunchd(plugin: plugin, pluginStateRoot: stateRoot, debug: false)
 
-        let plistURL = stateRoot.appendingPathComponent("service.plist")
+        let plistURL = serviceRoot.appending(path: "plugin-state/service/service.plist")
         #expect(FileManager.default.fileExists(atPath: plistURL.path))
 
         let plistData = try Data(contentsOf: plistURL)
@@ -234,20 +238,22 @@ struct PluginLoaderTest {
     func testRegisterWithLaunchdDebugDefault() async throws {
         let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         defer { try? FileManager.default.removeItem(at: tempURL) }
+        let serviceRoot = tempURL.appendingPathComponent("service-root", isDirectory: true)
         let factory = try setupMock(tempURL: tempURL)
         let loader = try PluginLoader(
             appRoot: tempURL,
             installRoot: URL(filePath: "/usr/local/"),
             logRoot: nil,
             pluginDirectories: [tempURL],
-            pluginFactories: [factory]
+            pluginFactories: [factory],
+            serviceRoot: serviceRoot
         )
 
         let plugin = loader.findPlugin(name: "service")!
         let stateRoot = tempURL.appendingPathComponent("test-state")
         try loader.registerWithLaunchd(plugin: plugin, pluginStateRoot: stateRoot)
 
-        let plistURL = stateRoot.appendingPathComponent("service.plist")
+        let plistURL = serviceRoot.appending(path: "plugin-state/service/service.plist")
         #expect(FileManager.default.fileExists(atPath: plistURL.path))
 
         let plistData = try Data(contentsOf: plistURL)
@@ -263,7 +269,7 @@ struct PluginLoaderTest {
     /// serviceRoot and NOT under appRoot — which might be on an external or
     /// removable volume where launchd cannot register Mach services.
     @Test
-    func testRegisterWithLaunchdPlistNotUnderAppRoot() async throws {
+    func testRegisterWithLaunchdInstancedPlistsStayUnderServiceRoot() async throws {
         let appRootURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("app-root-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: appRootURL) }
@@ -285,22 +291,43 @@ struct PluginLoaderTest {
         )
 
         let plugin = loader.findPlugin(name: "service")!
-        try loader.registerWithLaunchd(plugin: plugin)
+        let externalStateRoot = appRootURL.appendingPathComponent("runtime-state", isDirectory: true)
+        try loader.registerWithLaunchd(
+            plugin: plugin,
+            pluginStateRoot: externalStateRoot,
+            instanceId: "default"
+        )
+        try loader.registerWithLaunchd(
+            plugin: plugin,
+            pluginStateRoot: externalStateRoot,
+            instanceId: "secondary"
+        )
 
-        let expectedPlistURL = serviceRootURL
+        let defaultPlistURL =
+            serviceRootURL
             .appendingPathComponent("plugin-state", isDirectory: true)
             .appending(path: plugin.name)
+            .appending(path: "default")
             .appendingPathComponent("service.plist")
-
-        // Plist exists under serviceRoot (internal volume)
-        #expect(FileManager.default.fileExists(atPath: expectedPlistURL.path))
-
-        // Plist must NOT exist under appRoot (which could be an external volume)
-        let appRootPlistURL = appRootURL
+        let secondaryPlistURL =
+            serviceRootURL
             .appendingPathComponent("plugin-state", isDirectory: true)
             .appending(path: plugin.name)
+            .appending(path: "secondary")
             .appendingPathComponent("service.plist")
-        #expect(!FileManager.default.fileExists(atPath: appRootPlistURL.path))
+
+        // Each instance gets a distinct plist under serviceRoot (internal volume).
+        #expect(FileManager.default.fileExists(atPath: defaultPlistURL.path))
+        #expect(FileManager.default.fileExists(atPath: secondaryPlistURL.path))
+
+        // pluginStateRoot may be external and must never contain a launchd plist.
+        #expect(!FileManager.default.fileExists(atPath: externalStateRoot.appendingPathComponent("service.plist").path))
+
+        // An explicitly supplied serviceRoot is propagated to the child service.
+        let plistData = try Data(contentsOf: defaultPlistURL)
+        let plist = try PropertyListSerialization.propertyList(from: plistData, format: nil) as! [String: Any]
+        let environment = plist["EnvironmentVariables"] as! [String: String]
+        #expect(environment[ServiceRoot.environmentName] == serviceRootURL.path(percentEncoded: false))
     }
 
     private func setupMock(tempURL: URL) throws -> MockPluginFactory {

--- a/Tests/ContainerPluginTests/RootPathTests.swift
+++ b/Tests/ContainerPluginTests/RootPathTests.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import SystemPackage
 import Testing
 
@@ -43,5 +44,22 @@ struct LogRootTests {
     @Test func pathIsNilWhenEnvUnset() {
         // CONTAINER_LOG_ROOT is not set in the unit test environment
         #expect(LogRoot.path == nil)
+    }
+}
+
+struct ServiceRootTests {
+    @Test func defaultPathIsAbsolute() {
+        #expect(ServiceRoot.defaultPath.isAbsolute)
+    }
+
+    @Test func defaultPathEndsWithContainerComponent() {
+        #expect(ServiceRoot.defaultPath.lastComponent?.string == "com.apple.container")
+    }
+
+    @Test func defaultPathIsUnderTemporaryDirectory() {
+        let tmpDir = FilePath(FileManager.default.temporaryDirectory.path(percentEncoded: false))
+            .lexicallyNormalized()
+        let serviceRoot = ServiceRoot.defaultPath.lexicallyNormalized()
+        #expect(serviceRoot.string.hasPrefix(tmpDir.string))
     }
 }


### PR DESCRIPTION
## Problem

When a user's home directory resides on an external or removable volume
(e.g. `/Volumes/ex-data/`), running `container system start` results in an
"XPC connection invalid" error and the daemon never becomes reachable.

Reported in: #1721

**Root cause:** `launchctl bootstrap <domain> <plist-path>` silently fails
when the plist file is located on an external or removable volume. macOS
(Gatekeeper / AMFI) does not allow Mach service registration from plists
that reside outside the internal system volume. Because `ApplicationRoot`
defaults to `~/.local/share/container`, any user whose home directory is on
an external volume ends up writing `apiserver.plist` and plugin plists to
that volume — causing all subsequent XPC connections to fail.

## Solution

Introduce `ServiceRoot`: a new root type whose sole responsibility is to
provide a location for launchd plist files. Its default path is:

```
<NSTemporaryDirectory()>/com.apple.container/
```

`NSTemporaryDirectory()` (i.e. `FileManager.default.temporaryDirectory`) is
always located on the internal system volume on macOS, regardless of where
the user's home directory lives. This guarantees that `launchctl bootstrap`
succeeds in all configurations.

`ServiceRoot` follows the exact same pattern as the existing `ApplicationRoot`,
`InstallRoot`, and `LogRoot` types:

| Type | Env var | Default |
|---|---|---|
| `ApplicationRoot` | `CONTAINER_APP_ROOT` | `~/.local/share/container` |
| `InstallRoot` | `CONTAINER_INSTALL_ROOT` | `<binary>/../../` |
| `LogRoot` | `CONTAINER_LOG_ROOT` | *(macOS log facility)* |
| `ServiceRoot` | `CONTAINER_SERVICE_ROOT` | `$TMPDIR/com.apple.container` |

`CONTAINER_SERVICE_ROOT` is propagated from `SystemStart` into the
`container-apiserver` plist environment, so the daemon's `PluginLoader`
automatically picks it up for plugin plist registration as well — no
changes are required at any other call site.

## Changes

- **`Sources/ContainerPlugin/ServiceRoot.swift`** *(new)*
  Defines `ServiceRoot` with `environmentName`, `defaultPath`, `path`, and
  `pathname` statics, consistent with the other root types.

- **`Sources/ContainerCommands/System/SystemStart.swift`**
  - Adds `--service-root` CLI option (overrides `CONTAINER_SERVICE_ROOT`).
  - Propagates `CONTAINER_SERVICE_ROOT` into the plist environment.
  - Writes `apiserver.plist` under `serviceRoot` instead of `appRoot`.

- **`Sources/ContainerPlugin/PluginLoader.swift`**
  - Separates `plistResourceRoot` (system volume, for plists) from
    `pluginResourceRoot` (appRoot, for runtime state).
  - Adds `serviceRoot: URL? = nil` to `init` — existing callers are
    unaffected; `nil` falls back to reading `CONTAINER_SERVICE_ROOT`.

- **`Tests/ContainerPluginTests/RootPathTests.swift`**
  Adds `ServiceRootTests` (3 tests): default path is absolute, ends with
  `com.apple.container`, and is located under the temporary directory.

- **`Tests/ContainerPluginTests/PluginLoaderTest.swift`**
  Updates `testRegisterWithLaunchdPlistNotUnderAppRoot` to pass an explicit
  `serviceRoot` distinct from `appRoot`, directly asserting the separation.

## Testing

All existing tests pass:

```
swift test --filter ContainerPluginTests
# Test run with 48 tests in 9 suites passed
```

Manual verification path (for reviewers with an external-volume home):
1. `container system start` — previously failed with XPC connection invalid.
2. After this fix, the daemon registers successfully and all XPC calls work.

To override the service root manually:

```bash
container system start --service-root /private/tmp/my-container-service
# or via env var:
CONTAINER_SERVICE_ROOT=/private/tmp/my-container-service container system start
```
