### PR TITLE
Fix duplicate "(default: 3)" in --max-concurrent-downloads help text

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/Flags.swift
+++ b/Sources/Services/ContainerAPIService/Client/Flags.swift
@@ -389,7 +389,7 @@ public struct Flags {
             self.maxConcurrentDownloads = maxConcurrentDownloads
         }
 
-        @Option(name: .long, help: "Maximum number of concurrent downloads (default: 3)")
+        @Option(name: .long, help: "Maximum number of concurrent downloads")
         public var maxConcurrentDownloads: Int = 3
     }
 }


### PR DESCRIPTION
Remove manually specified default value from help string since ArgumentParser already appends it automatically from the property's default value.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Running `container machine create -h` displays "(default: 3)" twice for the `--max-concurrent-downloads` option. This is because the help string manually includes "(default: 3)" while ArgumentParser also automatically appends the default value from the property initializer.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs