### PR TITLE
test: 添加测试环境设置脚本和文档 / Add test environment setup script and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,17 @@ install-kernel:
 	@echo Starting system to install kernel
 	@bin/container --debug system start --timeout 60 --enable-kernel-install $(SYSTEM_START_OPTS)
 
+# Setup test environment: build, install kernel, start system
+.PHONY: setup-test-env
+setup-test-env:
+	@echo "Setting up test environment..."
+	@scripts/setup-test-env.sh $(SYSTEM_START_OPTS)
+
+# Run integration tests (requires system to be running with kernel installed)
+.PHONY: integration-test
+integration-test:
+	@$(SWIFT) test -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter "$(INTEGRATION_FILTER)"
+
 
 # Coverage report generation helpers
 # Directory that swift test spits out raw coverage data

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,187 @@
+# Testing / 测试指南
+
+> [!IMPORTANT]
+> This file contains documentation for the CURRENT BRANCH.
+
+This guide explains how to set up and run tests for the `container` project.
+
+本文档说明如何设置和运行 `container` 项目的测试。
+
+## Prerequisites / 前提条件
+
+- Mac with Apple silicon
+- macOS 26 (recommended) or macOS 15
+- Xcode 26, set as the [active developer directory](https://developer.apple.com/library/archive/technotes/tn2339/_index.html#//apple_ref/doc/uid/DTS40014588-CH1-HOW_DO_I_SELECT_THE_DEFAULT_VERSION_OF_XCODE_TO_USE_FOR_MY_COMMAND_LINE_TOOLS_)
+
+## Quick Start / 快速开始
+
+### 1. Automated setup (recommended) / 自动设置（推荐）
+
+```bash
+# Full setup: build + install kernel + start system
+./scripts/setup-test-env.sh
+
+# Run all tests
+swift test
+```
+
+### 2. Manual setup / 手动设置
+
+```bash
+# Build the project
+make all
+
+# Install CLI binary to bin/container (required by tests)
+make cli
+
+# Start the system (will prompt for kernel install)
+container system start
+
+# Run unit tests (skips integration tests requiring container system)
+make test
+
+# Run all tests including integration tests
+swift test
+```
+
+### 3. Setup with isolated data directory / 使用隔离数据目录
+
+```bash
+# Use a temporary directory to avoid affecting your system
+./scripts/setup-test-env.sh --app-root /tmp/container-test --log-root /tmp/container-test-logs
+
+# Run tests with custom app-root
+APP_ROOT=/tmp/container-test swift test
+```
+
+## Test Structure / 测试结构
+
+```
+Tests/
+├── CLITests/                    # CLI integration tests (需运行 container system)
+│   ├── Subcommands/
+│   │   ├── Build/               # Build command tests
+│   │   ├── Containers/          # Container lifecycle tests
+│   │   ├── Images/              # Image management tests
+│   │   ├── Machine/             # Container machine tests
+│   │   ├── Networks/            # Network management tests
+│   │   ├── Plugins/             # Plugin system tests
+│   │   ├── Registry/            # Registry operation tests
+│   │   ├── Run/                 # Container run tests
+│   │   ├── System/              # System command tests (kernel, etc.)
+│   │   └── Volumes/             # Volume management tests
+│   ├── Utilities/
+│   │   └── CLITest.swift        # Test base class and helpers
+│   ├── TestCLIHelp.swift        # Help output tests
+│   └── TestCLINoParallelCases.swift
+├── ContainerAPIClientTests/
+├── ContainerAPIServiceTests/
+├── ContainerBuildTests/
+├── ContainerNetworkServerTests/
+├── ContainerPersistenceTests/
+├── ContainerPluginTests/
+├── ContainerResourceTests/
+├── ContainerVersionTests/
+├── DNSServerTests/
+├── SocketForwarderTests/
+└── TerminalProgressTests/
+```
+
+## Test Types / 测试类型
+
+### Unit Tests / 单元测试
+
+Run without any system dependencies:
+
+```bash
+swift test --filter "CLITests" --filter "ContainerResourceTests" --filter "ContainerPersistenceTests"
+```
+
+Or skip all CLI integration tests:
+
+```bash
+make test
+```
+
+### Integration Tests / 集成测试
+
+CLI tests require a running `container system` with a kernel installed. These are run as part of `swift test`.
+
+**Common issues:**
+
+| Symptom / 症状 | Cause / 原因 | Solution / 解决 |
+|---------------|-------------|----------------|
+| `.binaryNotFound` | Kernel not installed | `./scripts/setup-test-env.sh` |
+| `Container not found` | Container system not running | `container system start` |
+| `XPC connection error` | Background services not started | `container system start` |
+| `Download timeout` | Network issue downloading kernel | Check network or use `--skip-kernel` with pre-installed kernel |
+
+## Configuration / 配置
+
+### Environment Variables / 环境变量
+
+| Variable / 变量 | Purpose / 用途 | Default / 默认值 |
+|---------------|---------------|-----------------|
+| `CONTAINER_CLI_PATH` | Path to container binary for tests | `bin/container` in project root |
+| `CLITEST_LOG_ROOT` | Directory for test logs | Disabled |
+| `APP_ROOT` | Application data root | System default |
+| `LOG_ROOT` | Log file root | System default |
+| `BUILD_CONFIGURATION` | Swift build configuration | `debug` |
+
+### Test-Only Configuration / 仅测试配置
+
+You can override default settings for tests by creating a test-specific TOML config:
+
+```toml
+# ~/.config/container/config.toml (user config)
+# or $APP_ROOT/config.toml (app-root config)
+
+[build]
+cpus = 4
+memory = "4gb"
+
+[container]
+cpus = 2
+memory = "1gb"
+
+[kernel]
+# Custom kernel URL for testing
+url = "https://github.com/kata-containers/kata-containers/releases/download/3.28.0/kata-static-3.28.0-arm64.tar.zst"
+binaryPath = "opt/kata/share/kata-containers/vmlinux-6.18.15-186"
+```
+
+## Debugging Test Failures / 调试测试失败
+
+### Checking Logs / 查看日志
+
+```bash
+# View test logs (if CLITEST_LOG_ROOT is set)
+tail -f $CLITEST_LOG_ROOT/clitests/TestCLIKernelSet/fromLocalTar.log
+
+# View system logs
+container system logs
+```
+
+### Running a Single Test / 运行单个测试
+
+```bash
+swift test --filter "TestCLIKernelSet/fromLocalTar"
+```
+
+### Kernel Test Debugging / 内核测试调试
+
+The kernel set tests (`TestCLIKernelSet`) require:
+
+1. A valid kernel archive (auto-downloaded from GitHub releases)
+2. The correct binary path within the archive
+3. System started with `container system start`
+
+To manually install a kernel for testing:
+
+```bash
+# Download and install the recommended kernel
+container system kernel set --recommended
+
+# Or install from a local tar file
+container system kernel set --force --tar /path/to/kata-static.tar.zst --binary opt/kata/share/kata-containers/vmlinux-<version>
+```

--- a/scripts/setup-test-env.sh
+++ b/scripts/setup-test-env.sh
@@ -1,0 +1,179 @@
+#! /bin/bash -e
+# Copyright © 2026 Apple Inc. and the container project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# =============================================================================
+# setup-test-env.sh — Test environment setup for container project
+#
+# This script prepares the test environment by:
+#   1. Building the container CLI binary
+#   2. Installing it to bin/container (required by CLITest)
+#   3. Installing the recommended Linux kernel
+#   4. Starting the container system service
+#
+# Usage:
+#   ./scripts/setup-test-env.sh                    # Default setup
+#   ./scripts/setup-test-env.sh --app-root /tmp/t   # Custom app root
+#   ./scripts/setup-test-env.sh --skip-build         # Skip Swift build
+#   ./scripts/setup-test-env.sh --skip-kernel        # Skip kernel install
+#   ./scripts/setup-test-env.sh --help               # Show help
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_DIR"
+
+BUILD_CONFIGURATION="${BUILD_CONFIGURATION:-debug}"
+SKIP_BUILD=false
+SKIP_KERNEL=false
+START_ARGS=()
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Prepare the test environment for the container project.
+
+Options:
+    -a, --app-root APP_ROOT    Use custom APP_ROOT for system data
+    -l, --log-root LOG_ROOT    Use custom LOG_ROOT for system logs
+    --skip-build               Skip Swift build step
+    --skip-kernel              Skip kernel download and install
+    -h, --help                 Show this help message
+
+Environment variables:
+    BUILD_CONFIGURATION        Build configuration (debug|release, default: debug)
+    SWIFT                      Swift compiler path (default: /usr/bin/swift)
+
+Examples:
+    # Full setup with isolated test data directory:
+    ./scripts/setup-test-env.sh --app-root /tmp/container-test
+
+    # Quick setup (skip build if already built):
+    ./scripts/setup-test-env.sh --skip-build
+
+    # Setup without kernel (use existing kernel):
+    ./scripts/setup-test-env.sh --skip-kernel
+EOF
+    exit 0
+}
+
+# Parse command line options
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -a|--app-root)
+            if [[ -z "$2" || "$2" == -* ]]; then
+                echo "Error: Option $1 requires an argument." >&2
+                exit 1
+            fi
+            START_ARGS+=(--app-root "$2")
+            shift 2
+            ;;
+        -l|--log-root)
+            if [[ -z "$2" || "$2" == -* ]]; then
+                echo "Error: Option $1 requires an argument." >&2
+                exit 1
+            fi
+            START_ARGS+=(--log-root "$2")
+            shift 2
+            ;;
+        --skip-build)
+            SKIP_BUILD=true
+            shift
+            ;;
+        --skip-kernel)
+            SKIP_KERNEL=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+echo "============================================"
+echo "  Container Test Environment Setup"
+echo "============================================"
+echo "Project: $PROJECT_DIR"
+echo "Config:  $BUILD_CONFIGURATION"
+echo ""
+
+# ---- Step 1: Build ----
+if [[ "$SKIP_BUILD" == "false" ]]; then
+    echo "--- Step 1/4: Building container CLI ---"
+    SWIFT="${SWIFT:-/usr/bin/swift}"
+    $SWIFT build -c "$BUILD_CONFIGURATION"
+
+    BUILD_BIN_DIR=$($SWIFT build -c "$BUILD_CONFIGURATION" --show-bin-path)
+    echo "Build output: $BUILD_BIN_DIR"
+
+    echo "Installing CLI to bin/container..."
+    mkdir -p "$PROJECT_DIR/bin"
+    install "$BUILD_BIN_DIR/container" "$PROJECT_DIR/bin/container"
+    echo "✅ CLI binary installed at bin/container"
+else
+    echo "--- Step 1/4: Build skipped (--skip-build) ---"
+fi
+echo ""
+
+# ---- Step 2: Build background services ----
+if [[ "$SKIP_BUILD" == "false" ]]; then
+    echo "--- Step 2/4: Building background services ---"
+    make container BUILD_CONFIGURATION="$BUILD_CONFIGURATION"
+    echo "✅ Background services built"
+else
+    echo "--- Step 2/4: Services build skipped (--skip-build) ---"
+fi
+echo ""
+
+# ---- Step 3: Stop any running system ----
+echo "--- Step 3/4: Stopping any running container system ---"
+if command -v container &>/dev/null || [[ -f "$PROJECT_DIR/bin/container" ]]; then
+    CONTAINER_BIN="${PROJECT_DIR}/bin/container"
+    $CONTAINER_BIN system stop 2>/dev/null || true
+    echo "✅ System stopped"
+else
+    echo "⚠️  container binary not found, skipping stop"
+fi
+echo ""
+
+# ---- Step 4: Start system and install kernel ----
+echo "--- Step 4/4: Starting system and installing kernel ---"
+CONTAINER_BIN="${PROJECT_DIR}/bin/container"
+
+if [[ "$SKIP_KERNEL" == "false" ]]; then
+    echo "Starting system with kernel auto-install (timeout: 120s)..."
+    # --enable-kernel-install allows auto-install of the recommended kernel
+    $CONTAINER_BIN --debug system start --timeout 120 --enable-kernel-install "${START_ARGS[@]}"
+    echo "✅ System started with kernel installed"
+else
+    echo "Kernel install skipped (--skip-kernel). Starting system without kernel install..."
+    $CONTAINER_BIN system start "${START_ARGS[@]}" 2>/dev/null || true
+    echo "⚠️  System may not have a kernel — some tests will fail"
+fi
+echo ""
+
+echo "============================================"
+echo "  Environment ready!"
+echo "  Binary:     $PROJECT_DIR/bin/container"
+echo "  Config:     $BUILD_CONFIGURATION"
+echo "  Kernel:     $([[ "$SKIP_KERNEL" == "false" ]] && echo 'Installed' || echo 'Skipped')"
+echo ""
+echo "  Run tests:  swift test"
+echo "  Or:         make test"
+echo "============================================"


### PR DESCRIPTION
## 摘要 / Summary

Added a test environment setup script and comprehensive testing documentation to address the 345 `.binaryNotFound` test failures caused by missing kernel installation.

添加了测试环境设置脚本和全面的测试文档，解决因内核缺失导致的 345 个 `.binaryNotFound` 测试失败问题。

## 新增文件 / New Files

### `scripts/setup-test-env.sh`
Automated test environment setup script that:
- Builds the container CLI binary and installs it to `bin/container`
- Installs the recommended Linux kernel (with `--enable-kernel-install`)
- Starts the container system service
- Supports `--skip-build`, `--skip-kernel`, `--app-root`, `--log-root` options

自动化的测试环境设置脚本：
- 构建 CLI 二进制并安装到 `bin/container`
- 安装推荐的 Linux 内核
- 启动 container 系统服务
- 支持跳过构建/内核安装、自定义数据/日志目录

### `docs/testing.md`
Bilingual (中文/English) testing guide covering:
- Quick start setup instructions
- Test structure overview
- Common issues and solutions table
- Environment variables reference
- Single test execution examples
- Kernel test debugging guide

双语测试指南：
- 快速开始设置说明
- 测试结构概览
- 常见问题及解决方案表
- 环境变量参考
- 单个测试执行示例
- 内核测试调试指南

## 修改文件 / Modified Files

### `Makefile`
- Added `setup-test-env` target (wraps `scripts/setup-test-env.sh`)
- Added `integration-test` target (runs integration tests with proper filter)

- 新增 `setup-test-env` 目标
- 新增 `integration-test` 目标

## 验证 / Verification
- ✅ `swift build` passes
- ✅ Shell syntax checked with `bash -n scripts/setup-test-env.sh`
- ✅ Makefile syntax verified

## Related Issue / 相关 Issue
Closes #1729