### PR TITLE
Remove lost+found from named volume EXT4 images

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -414,6 +414,7 @@ let package = Package(
             name: "ContainerResourceTests",
             dependencies: [
                 .product(name: "Containerization", package: "containerization"),
+                .product(name: "ContainerizationEXT4", package: "containerization"),
                 .product(name: "ContainerizationExtras", package: "containerization"),
                 "ContainerAPIService",
                 "ContainerResource",

--- a/Sources/Services/ContainerAPIService/Server/Volumes/VolumesService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Volumes/VolumesService.swift
@@ -288,16 +288,17 @@ public actor VolumesService {
     }
 
     private func createVolumeImage(for name: String, sizeInBytes: UInt64 = VolumeStorage.defaultVolumeSizeBytes, journal: EXT4.JournalConfig? = nil) throws {
-        let blockPath = blockPath(for: name)
+        try Self.formatVolumeImage(at: FilePath(blockPath(for: name)), size: sizeInBytes, journal: journal)
+    }
 
-        // Use the containerization library's EXT4 formatter
-        let formatter = try EXT4.Formatter(
-            FilePath(blockPath),
-            blockSize: 4096,
-            minDiskSize: sizeInBytes,
-            journal: journal
-        )
-
+    /// Formats a new EXT4 image at `path` and removes `lost+found`.
+    ///
+    /// Named container volumes are never checked with e2fsck, and many database
+    /// images (Postgres, MySQL, etc.) refuse to initialize in a non-empty directory.
+    /// e2fsck recreates `lost+found` automatically if a consistency check is ever run.
+    static func formatVolumeImage(at path: FilePath, size: UInt64 = VolumeStorage.defaultVolumeSizeBytes, journal: EXT4.JournalConfig? = nil) throws {
+        let formatter = try EXT4.Formatter(path, blockSize: 4096, minDiskSize: size, journal: journal)
+        try formatter.unlink(path: FilePath("/lost+found"))
         try formatter.close()
     }
 

--- a/Tests/ContainerResourceTests/VolumeImageTests.swift
+++ b/Tests/ContainerResourceTests/VolumeImageTests.swift
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerizationEXT4
+import Foundation
+import SystemPackage
+import Testing
+
+@testable import ContainerAPIService
+
+struct VolumeImageTests {
+
+    private func makeTempImagePath() -> FilePath {
+        FilePath(
+            FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: false))
+    }
+
+    @Test("formatVolumeImage produces an EXT4 image without lost+found")
+    func formatVolumeImageHasNoLostAndFound() throws {
+        let imagePath = makeTempImagePath()
+        defer { try? FileManager.default.removeItem(at: imagePath.url) }
+
+        try VolumesService.formatVolumeImage(at: imagePath)
+
+        let reader = try EXT4.EXT4Reader(blockDevice: imagePath)
+        let rootEntries = try reader.listDirectory(FilePath("/"))
+        #expect(!rootEntries.contains("lost+found"))
+    }
+
+    @Test("Default EXT4 formatter creates lost+found (baseline)")
+    func defaultFormatterCreatesLostAndFound() throws {
+        let imagePath = makeTempImagePath()
+        defer { try? FileManager.default.removeItem(at: imagePath.url) }
+
+        let formatter = try EXT4.Formatter(imagePath)
+        try formatter.close()
+
+        let reader = try EXT4.EXT4Reader(blockDevice: imagePath)
+        let rootEntries = try reader.listDirectory(FilePath("/"))
+        #expect(rootEntries.contains("lost+found"))
+    }
+}


### PR DESCRIPTION
## What

Remove `lost+found` from freshly created named volume EXT4 images by calling
`formatter.unlink(path: FilePath("/lost+found"))` before `formatter.close()` in
`VolumesService.createVolumeImage`.

## Why

The `EXT4.Formatter` in `containerization` correctly creates `lost+found` for
general-purpose e2fsck compatibility. Named container volumes, however, are never
checked with e2fsck — and many widely-used database images treat a non-empty
volume root as a fatal error at initialization time:

```
initdb: error: directory "/var/lib/postgresql/data" exists but is not empty
initdb: detail: It contains a lost+found directory, perhaps due to it being a mount point.
```

Affected images include Postgres, MySQL, Elasticsearch, MongoDB, and any image
whose entrypoint runs `initdb`-style initialization against the raw volume mount point.

Docker Desktop, Colima, and OrbStack all present fresh named volumes as empty
directories. This fix restores that parity and unblocks a broad class of
real-world use cases.

## Safety

`lost+found` is not required for EXT4 to function. If e2fsck is ever run on a
volume, it recreates `lost+found` automatically when it finds it missing. No data
loss, no corruption risk. Only newly created volumes are affected; existing
volume images are unchanged.

The fix is at the right semantic layer: `VolumesService` is where the decision
that "this EXT4 image is for a container named volume" belongs. The
`containerization` library comment ("required for e2fsck to pass") remains
correct for its own scope.

## Tests

Two new tests in `Tests/ContainerResourceTests/VolumeImageTests.swift`:

- `formatterCreatesLostAndFoundByDefault` — baseline confirming the default
  formatter behaviour that this fix deliberately overrides
- `volumeImageHasNoLostAndFound` — confirms the root directory is empty after
  the unlink, using `EXT4.EXT4Reader.listDirectory`

Fixes #1730