### PR TITLE
add ID validation to daemon service

### DIFF
--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -283,6 +283,8 @@ public actor ContainersService {
         }
 
         try await self.lock.withLock(logMetadata: ["acquirer": "\(#function)", "id": "\(configuration.id)"]) { context in
+            try Utility.validEntityName(configuration.id)
+
             guard await self.containers[configuration.id] == nil else {
                 throw ContainerizationError(
                     .exists,
@@ -892,6 +894,8 @@ public actor ContainersService {
             )
         }
 
+        try Utility.validEntityName(id)
+
         let containerPath = self.containerRoot.appendingPathComponent(id).path
 
         return FileManager.default.allocatedSize(of: URL(fileURLWithPath: containerPath))
@@ -899,6 +903,8 @@ public actor ContainersService {
 
     public func exportRootfs(id: String, archive: URL) async throws {
         self.log.debug("\(#function)")
+
+        try Utility.validEntityName(id)
 
         let state = try self._getContainerState(id: id)
         guard state.snapshot.status == .stopped else {

--- a/Tests/ContainerAPIClientTests/UtilityTests.swift
+++ b/Tests/ContainerAPIClientTests/UtilityTests.swift
@@ -114,6 +114,27 @@ struct UtilityTests {
     }
 
     @Test
+    func testValidEntityName() throws {
+        try Utility.validEntityName("my-container")
+        try Utility.validEntityName("test.container")
+        try Utility.validEntityName("abc123")
+        try Utility.validEntityName("a1")
+        try Utility.validEntityName("container_1.test-abc")
+    }
+
+    @Test
+    func testInvalidEntityName() {
+        #expect(throws: Error.self) { try Utility.validEntityName("../../tmp/evil") }
+        #expect(throws: Error.self) { try Utility.validEntityName("../foo") }
+        #expect(throws: Error.self) { try Utility.validEntityName("foo/bar") }
+        #expect(throws: Error.self) { try Utility.validEntityName("/tmp/evil") }
+        #expect(throws: Error.self) { try Utility.validEntityName("") }
+        #expect(throws: Error.self) { try Utility.validEntityName(".hidden") }
+        #expect(throws: Error.self) { try Utility.validEntityName("-bad") }
+        #expect(throws: Error.self) { try Utility.validEntityName("a") }
+    }
+
+    @Test
     func testPublishPortParser() throws {
         let ports = try Parser.publishPorts([
             "127.0.0.1:8000:9080",


### PR DESCRIPTION
The CLI validates container IDs via Utility.validEntityName before sending XPC requests, but the daemon never checked the ID itself. Any process talking directly to com.apple.container.apiserver could pass a path-traversal string (../../tmp/foo) as a container ID, causing the daemon to create, measure, or export bundles outside of containerRoot.

I've Added Utility.validEntityName checks in ContainersService at the entry point of create, containerDiskUsage, and exportRootfs -- the three functions that build filesystem paths from the container ID. The daemon now enforces the same naming rules as the CLI regardless of how the XPC service is reached.