### PR TITLE
fix(cp): resolve relative host paths against current directory

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -28,6 +28,8 @@ jobs:
     permissions:
       contents: read
       packages: read
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode_swift_6.3.app/Contents/Developer"
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -55,8 +57,6 @@ jobs:
             git diff --name-only -- .
             false
           fi
-        env:
-          DEVELOPER_DIR: "/Applications/Xcode_swift_6.3.app/Contents/Developer"
 
       - name: Set build configuration
         env:
@@ -71,8 +71,6 @@ jobs:
         run: |
           make container dsym docs
           tar cfz _site.tgz _site
-        env:
-          DEVELOPER_DIR: "/Applications/Xcode_swift_6.3.app/Contents/Developer"
 
       - name: Validate coverage inputs
         if: ${{ inputs.coverage }}
@@ -106,14 +104,10 @@ jobs:
       - name: Test the container project
         if: ${{ !inputs.coverage }}
         run: make APP_ROOT="${APP_ROOT}" LOG_ROOT="${LOG_ROOT}" test install-kernel integration
-        env:
-          DEVELOPER_DIR: "/Applications/Xcode_swift_6.3.app/Contents/Developer"
 
       - name: Test the container project with coverage
         if: ${{ inputs.coverage }}
         run: make APP_ROOT="${APP_ROOT}" LOG_ROOT="${LOG_ROOT}" install-kernel coverage
-        env:
-          DEVELOPER_DIR: "/Applications/Xcode_swift_6.3.app/Contents/Developer"
 
       - name: Extract coverage percentages
         if: ${{ inputs.coverage }}

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -56,7 +56,7 @@ jobs:
             false
           fi
         env:
-          DEVELOPER_DIR: "/Applications/Xcode-latest.app/Contents/Developer"
+          DEVELOPER_DIR: "/Applications/Xcode_swift_6.3.app/Contents/Developer"
 
       - name: Set build configuration
         env:
@@ -72,7 +72,7 @@ jobs:
           make container dsym docs
           tar cfz _site.tgz _site
         env:
-          DEVELOPER_DIR: "/Applications/Xcode-latest.app/Contents/Developer"
+          DEVELOPER_DIR: "/Applications/Xcode_swift_6.3.app/Contents/Developer"
 
       - name: Validate coverage inputs
         if: ${{ inputs.coverage }}
@@ -107,13 +107,13 @@ jobs:
         if: ${{ !inputs.coverage }}
         run: make APP_ROOT="${APP_ROOT}" LOG_ROOT="${LOG_ROOT}" test install-kernel integration
         env:
-          DEVELOPER_DIR: "/Applications/Xcode-latest.app/Contents/Developer"
+          DEVELOPER_DIR: "/Applications/Xcode_swift_6.3.app/Contents/Developer"
 
       - name: Test the container project with coverage
         if: ${{ inputs.coverage }}
         run: make APP_ROOT="${APP_ROOT}" LOG_ROOT="${LOG_ROOT}" install-kernel coverage
         env:
-          DEVELOPER_DIR: "/Applications/Xcode-latest.app/Contents/Developer"
+          DEVELOPER_DIR: "/Applications/Xcode_swift_6.3.app/Contents/Developer"
 
       - name: Extract coverage percentages
         if: ${{ inputs.coverage }}

--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,8 @@ INTEGRATION_TEST_SUITES ?= \
 	TestCLISystemDF \
 	TestCLIMachineCommand \
 	TestCLIMachineRuntime \
-	TestCLINoParallelCases
+	TestCLINoParallelCases \
+	TestCLICopyCommand
 
 empty :=
 space := $(empty) $(empty)

--- a/Sources/ContainerCommands/Container/ContainerCopy.swift
+++ b/Sources/ContainerCommands/Container/ContainerCopy.swift
@@ -69,12 +69,13 @@ extension Application {
                 var isDirectory: ObjCBool = false
                 let exists = FileManager.default.fileExists(atPath: destPath.string, isDirectory: &isDirectory)
 
+                var finalDestPath = destPath
                 if exists && isDirectory.boolValue {
                     guard let lastComponent = srcPath.lastComponent else {
                         throw ContainerizationError(.invalidArgument, message: "source path has no last component: \(path)")
                     }
-                    let finalDest = destPath.appending(lastComponent)
-                    try await client.copyOut(id: id, source: path, destination: finalDest.string)
+                    finalDestPath = destPath.appending(lastComponent)
+                    try await client.copyOut(id: id, source: path, destination: finalDestPath.string)
                 } else if localPath.hasSuffix("/") {
                     try await client.copyOut(id: id, source: path, destination: destPath.string)
                     var resultIsDir: ObjCBool = false
@@ -89,6 +90,7 @@ extension Application {
                 } else {
                     try await client.copyOut(id: id, source: path, destination: destPath.string)
                 }
+                print(finalDestPath.string)
             case (.local(let localPath), .container(let id, let path)):
                 let srcPath = FilePath(URL(fileURLWithPath: localPath, relativeTo: .currentDirectory()).absoluteURL.path(percentEncoded: false))
                 var isDirectory: ObjCBool = false
@@ -100,6 +102,8 @@ extension Application {
                 }
 
                 try await client.copyIn(id: id, source: srcPath.string, destination: path, createParents: true)
+                let printedDest = path.hasSuffix("/") ? "\(id):\(path)\(srcPath.lastComponent!)" : "\(id):\(path)"
+                print(printedDest)
             case (.container, .container):
                 throw ContainerizationError(.invalidArgument, message: "copying between containers is not supported")
             case (.local, .local):

--- a/Sources/ContainerCommands/Container/ContainerCopy.swift
+++ b/Sources/ContainerCommands/Container/ContainerCopy.swift
@@ -94,6 +94,11 @@ extension Application {
             case (.local(let localPath), .container(let id, let path)):
                 let srcPath = FilePath(URL(fileURLWithPath: localPath, relativeTo: .currentDirectory()).absoluteURL.path(percentEncoded: false))
                 var isDirectory: ObjCBool = false
+
+                guard let lastComponent = srcPath.lastComponent else {
+                    throw ContainerizationError(.invalidArgument, message: "source path has no last component: \(localPath)")
+                }
+
                 guard FileManager.default.fileExists(atPath: srcPath.string, isDirectory: &isDirectory) else {
                     throw ContainerizationError(.notFound, message: "source path does not exist: \(localPath)")
                 }
@@ -102,7 +107,7 @@ extension Application {
                 }
 
                 try await client.copyIn(id: id, source: srcPath.string, destination: path, createParents: true)
-                let printedDest = path.hasSuffix("/") ? "\(id):\(path)\(srcPath.lastComponent!)" : "\(id):\(path)"
+                let printedDest = path.hasSuffix("/") ? "\(id):\(path)\(lastComponent.string)" : "\(id):\(path)"
                 print(printedDest)
             case (.container, .container):
                 throw ContainerizationError(.invalidArgument, message: "copying between containers is not supported")

--- a/Sources/ContainerCommands/Container/ContainerCopy.swift
+++ b/Sources/ContainerCommands/Container/ContainerCopy.swift
@@ -65,7 +65,7 @@ extension Application {
             switch (srcRef, dstRef) {
             case (.container(let id, let path), .local(let localPath)):
                 let srcPath = FilePath(path)
-                let destPath = FilePath((localPath as NSString).standardizingPath)
+                let destPath = FilePath(URL(fileURLWithPath: localPath, relativeTo: .currentDirectory()).absoluteURL.path(percentEncoded: false))
                 var isDirectory: ObjCBool = false
                 let exists = FileManager.default.fileExists(atPath: destPath.string, isDirectory: &isDirectory)
 
@@ -90,7 +90,7 @@ extension Application {
                     try await client.copyOut(id: id, source: path, destination: destPath.string)
                 }
             case (.local(let localPath), .container(let id, let path)):
-                let srcPath = FilePath((localPath as NSString).standardizingPath)
+                let srcPath = FilePath(URL(fileURLWithPath: localPath, relativeTo: .currentDirectory()).absoluteURL.path(percentEncoded: false))
                 var isDirectory: ObjCBool = false
                 guard FileManager.default.fileExists(atPath: srcPath.string, isDirectory: &isDirectory) else {
                     throw ContainerizationError(.notFound, message: "source path does not exist: \(localPath)")

--- a/Tests/CLITests/Subcommands/Containers/TestCLICopy.swift
+++ b/Tests/CLITests/Subcommands/Containers/TestCLICopy.swift
@@ -905,4 +905,54 @@ class TestCLICopyCommand: CLITest {
             Issue.record("testCopyInDirectoryContentsToExistingDirectoryTrailingSlash failed: \(error)")
         }
     }
+
+    // MARK: - Relative path resolution
+
+    @Test func testCopyInRelativeSourcePath() throws {
+        do {
+            let name = getTestName()
+            try doCreate(name: name)
+            defer { try? doStop(name: name) }
+            try doStart(name: name)
+            try waitForContainerRunning(name)
+
+            let content = "relative source"
+            try content.write(to: testDir.appendingPathComponent("relfile.txt"), atomically: true, encoding: .utf8)
+
+            let (_, _, error, status) = try run(
+                arguments: ["copy", "./relfile.txt", "\(name):/tmp/"],
+                currentDirectory: testDir)
+            if status != 0 { throw CLIError.executionFailed("copy failed: \(error)") }
+
+            let result = try doExec(name: name, cmd: ["cat", "/tmp/relfile.txt"])
+            #expect(result.trimmingCharacters(in: .whitespacesAndNewlines) == content)
+            try doStop(name: name)
+        } catch {
+            Issue.record("testCopyInRelativeSourcePath failed: \(error)")
+        }
+    }
+
+    @Test func testCopyOutRelativeDestinationPath() throws {
+        do {
+            let name = getTestName()
+            try doCreate(name: name)
+            defer { try? doStop(name: name) }
+            try doStart(name: name)
+            try waitForContainerRunning(name)
+
+            let content = "relative dest"
+            _ = try doExec(name: name, cmd: ["sh", "-c", "echo -n '\(content)' > /tmp/relfile.txt"])
+
+            let (_, _, error, status) = try run(
+                arguments: ["copy", "\(name):/tmp/relfile.txt", "./"],
+                currentDirectory: testDir)
+            if status != 0 { throw CLIError.executionFailed("copy failed: \(error)") }
+
+            let result = try String(contentsOfFile: testDir.appendingPathComponent("relfile.txt").path, encoding: .utf8)
+            #expect(result == content)
+            try doStop(name: name)
+        } catch {
+            Issue.record("testCopyOutRelativeDestinationPath failed: \(error)")
+        }
+    }
 }


### PR DESCRIPTION
Fixes #1738

`container cp` fails when the host source path is relative (e.g. `container cp file foo:/root/`), because `NSString.standardizingPath` only canonicalizes paths but does not make them absolute. The unchanged relative path is then interpreted as `/file` (root-absolute) by `URL(fileURLWithPath:)` on the runtime side.

Fixed by resolving relative paths against the current working directory before use, matching the pattern already used by `container export`, `container image save`, and `container image load`.

The same fix was also applied to the copy-out destination path (line 68), which had the same issue.

## Type of Change

- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

`container cp file foo:/root/` fails with `"copyIn: source not found '/file'"` because the relative path `file` is never expanded to an absolute path. Using `$PWD/file` works, but relative paths should work too — every other command in the codebase handles this correctly.

## Testing

- [x] Tested locally — builds and all existing tests pass
- [ ] Added/updated tests
- [ ] Added/updated docs
