### PR TITLE
Allow custom kernel boot args via --kernel-arg

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/Flags.swift
+++ b/Sources/Services/ContainerAPIService/Client/Flags.swift
@@ -176,6 +176,7 @@ public struct Flags {
             entrypoint: String?,
             initImage: String?,
             kernel: String?,
+            kernelArgs: [String],
             labels: [String],
             mounts: [String],
             name: String?,
@@ -205,6 +206,7 @@ public struct Flags {
             self.entrypoint = entrypoint
             self.initImage = initImage
             self.kernel = kernel
+            self.kernelArgs = kernelArgs
             self.labels = labels
             self.mounts = mounts
             self.name = name
@@ -276,6 +278,15 @@ public struct Flags {
             }
         )
         public var kernel: String?
+
+        @Option(
+            name: .customLong("kernel-arg"),
+            help: .init(
+                "Append a raw boot argument to the kernel command line (repeatable).",
+                valueName: "arg"
+            )
+        )
+        public var kernelArgs: [String] = []
 
         @Option(name: [.short, .customLong("label")], help: "Add a key=value label to the container")
         public var labels: [String] = []

--- a/Sources/Services/ContainerAPIService/Client/Utility.swift
+++ b/Sources/Services/ContainerAPIService/Client/Utility.swift
@@ -330,14 +330,20 @@ public struct Utility {
         // For the image itself we'll take the user input and try with it as we can do userspace
         // emulation for x86, but for the kernel we need it to match the hosts architecture.
         let s: SystemPlatform = .current
+        var kernel: Kernel
         if let userKernel = management.kernel {
             guard FileManager.default.fileExists(atPath: userKernel) else {
                 throw ContainerizationError(.notFound, message: "kernel file not found at path \(userKernel)")
             }
             let p = URL(filePath: userKernel)
-            return .init(path: p, platform: s)
+            kernel = .init(path: p, platform: s)
+        } else {
+            kernel = try await ClientKernel.getDefaultKernel(for: s)
         }
-        return try await ClientKernel.getDefaultKernel(for: s)
+        // Persist any user-supplied boot args onto the kernel command line. A key supplied
+        // here overrides the runtime's matching built-in default (see RuntimeService.bootstrap).
+        kernel.commandLine.kernelArgs.append(contentsOf: management.kernelArgs)
+        return kernel
     }
 
     /// Parses key-value pairs from command line arguments.

--- a/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
+++ b/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
@@ -160,8 +160,18 @@ public actor RuntimeService {
             var config = try bundle.configuration
 
             var kernel = try bundle.kernel
-            kernel.commandLine.kernelArgs.append("oops=panic")
-            kernel.commandLine.kernelArgs.append("lsm=lockdown,capability,landlock,yama,apparmor")
+            // Built-in defaults keyed by arg name. Each is applied only if the user did not already
+            // supply the same key via --kernel-arg, letting custom kernels override them (e.g. lsm=...,bpf).
+            let defaultKernelArgs: KeyValuePairs = [
+                "oops": "panic",
+                "lsm": "lockdown,capability,landlock,yama,apparmor",
+            ]
+            for (key, value) in defaultKernelArgs {
+                guard !kernel.commandLine.kernelArgs.contains(where: { $0.hasPrefix("\(key)=") }) else {
+                    continue
+                }
+                kernel.commandLine.kernelArgs.append("\(key)=\(value)")
+            }
             let vmm = VZVirtualMachineManager(
                 kernel: kernel,
                 initialFilesystem: bundle.initialFilesystem.asMount,


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [X] New feature  
- [ ] Breaking change
- [ ] Documentation update

## What

Adds a repeatable `--kernel-arg` flag to `container run`/`container create` for appending arbitrary boot arguments to the kernel command line.

```
container run --kernel /path/to/custom-bzImage \
  --kernel-arg lsm=lockdown,capability,landlock,yama,apparmor,bpf \
  ...
```

## Why

The runtime hardcodes `lsm=lockdown,capability,landlock,yama,apparmor` (and `oops=panic`) onto every kernel command line in `RuntimeService.bootstrap`. With a custom kernel there is no way to adjust this — e.g. to enable **BPF LSM** you need `lsm=...,bpf`, which is currently impossible. More generally there is no escape hatch for any boot-time kernel argument.

## How

- New `--kernel-arg <arg>` option (repeatable) on `Flags.Management`.
- `Utility.getKernel` appends the user args onto `kernel.commandLine.kernelArgs`, which is persisted into the container bundle.
- `RuntimeService.bootstrap` now applies its built-in defaults **per-key**, skipping any default whose key the user already supplied. Defaults are expressed as a small keyed table, so this also lets `oops=` be overridden and makes future defaults easy to add.

Default behavior is unchanged for anyone who does not pass `--kernel-arg` — the same `oops=panic` and `lsm=...` args are applied.

## Testing

- `swift build` clean.
- `container run --help` renders the new flag.