### PR TITLE
Remove lost+found from new named volumes

### DIFF
--- a/Sources/Services/ContainerAPIService/Server/Volumes/VolumesService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Volumes/VolumesService.swift
@@ -298,6 +298,14 @@ public actor VolumesService {
             journal: journal
         )
 
+        // Remove the `lost+found` directory that the EXT4 formatter creates so that a
+        // freshly created named volume presents as an empty directory, matching the
+        // behavior of Docker, Colima, and OrbStack. Database images such as Postgres
+        // and MySQL treat a non-empty data directory as a fatal error during first-run
+        // initialization, and `lost+found` is not required for the filesystem to
+        // function (e2fsck recreates it on demand if a consistency check is ever run).
+        try formatter.unlink(path: FilePath("/lost+found"))
+
         try formatter.close()
     }
 


### PR DESCRIPTION
## Summary

The EXT4 formatter creates a `/lost+found` directory at the root of every volume image. Database images such as Postgres, MySQL, MongoDB, and Elasticsearch treat a non-empty data directory as a fatal error during first-run initialization (e.g. Postgres `initdb` aborts because the data directory "is not empty"), so a freshly created named volume cannot be used with these images.

Docker, Colima, and OrbStack all present fresh named volumes as empty directories. `lost+found` is not required for EXT4 to function — `e2fsck` recreates it on demand if a consistency check is ever run — so this removes it when creating the volume image.

## Fixes
Fixes #1730

## Testing
- Full `make all` build passes; `swift format lint --strict` clean.
- Verified against the real `ContainerizationEXT4` library: a default-formatted image has root entries `["lost+found"]`; with this change the root is empty (`[]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)