### PR TITLE
Resolve relative host paths in `container cp`

### DIFF
--- a/Sources/ContainerCommands/Container/ContainerCopy.swift
+++ b/Sources/ContainerCommands/Container/ContainerCopy.swift
@@ -29,6 +29,21 @@ extension Application {
             case container(id: String, path: String)
         }
 
+        /// Resolve a local filesystem path to an absolute, standardized path.
+        ///
+        /// Expands a leading tilde and resolves relative paths against the current
+        /// working directory before standardizing. Without this, a relative path such
+        /// as `file` is forwarded verbatim to the API server, which resolves it
+        /// against its own working directory (`/`) and fails to find the source.
+        static func resolveLocalPath(_ path: String) -> String {
+            let expanded = (path as NSString).expandingTildeInPath
+            let absolute =
+                expanded.hasPrefix("/")
+                ? expanded
+                : "\(FileManager.default.currentDirectoryPath)/\(expanded)"
+            return (absolute as NSString).standardizingPath
+        }
+
         static func parsePathRef(_ ref: String) throws -> PathRef {
             let parts = ref.components(separatedBy: ":")
             switch parts.count {
@@ -65,7 +80,7 @@ extension Application {
             switch (srcRef, dstRef) {
             case (.container(let id, let path), .local(let localPath)):
                 let srcPath = FilePath(path)
-                let destPath = FilePath((localPath as NSString).standardizingPath)
+                let destPath = FilePath(Self.resolveLocalPath(localPath))
                 var isDirectory: ObjCBool = false
                 let exists = FileManager.default.fileExists(atPath: destPath.string, isDirectory: &isDirectory)
 
@@ -90,7 +105,7 @@ extension Application {
                     try await client.copyOut(id: id, source: path, destination: destPath.string)
                 }
             case (.local(let localPath), .container(let id, let path)):
-                let srcPath = FilePath((localPath as NSString).standardizingPath)
+                let srcPath = FilePath(Self.resolveLocalPath(localPath))
                 var isDirectory: ObjCBool = false
                 guard FileManager.default.fileExists(atPath: srcPath.string, isDirectory: &isDirectory) else {
                     throw ContainerizationError(.notFound, message: "source path does not exist: \(localPath)")


### PR DESCRIPTION
## Summary

`container cp <relative-path> <id>:<dest>` failed with "source not found" because the local path was passed to the API server unmodified. The server runs with a working directory of `/`, so a relative path such as `file` was resolved to `/file` instead of the user's intended file. Only absolute host paths worked.

This resolves local paths to absolute, standardized paths before handing them to the API server: it expands a leading tilde and joins relative paths to the caller's current working directory. Applied to both the copy-in source and the copy-out destination so the two directions behave consistently.

## Fixes
Fixes #1738

## Testing
- Full `make all` build passes; `swift format lint --strict` clean.
- Verified the resolution logic: `file`, `./sub/x`, `../x` now resolve to absolute paths against the cwd, while absolute paths (`/etc/hosts`) and tilde paths (`~/z`) are preserved; the previous code left relative paths relative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)