### PR TITLE
Propagate permissions for all host-to-container socket mounts.

### DIFF
--- a/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
+++ b/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
@@ -1004,9 +1004,14 @@ public actor RuntimeService {
 
         for mount in config.mounts {
             if try mount.isSocket() {
+                let attrs = try? FileManager.default.attributesOfItem(atPath: mount.source)
+                let permissions = (attrs?[.posixPermissions] as? NSNumber)
+                    .map { FilePermissions(rawValue: mode_t($0.intValue)) }
                 let socket = UnixSocketConfiguration(
                     source: URL(filePath: mount.source),
-                    destination: URL(filePath: mount.destination)
+                    destination: URL(filePath: mount.destination),
+                    permissions: permissions,
+                    direction: .into,
                 )
                 czConfig.sockets.append(socket)
             } else {

--- a/Tests/CLITests/Subcommands/Run/TestCLIRunCommand.swift
+++ b/Tests/CLITests/Subcommands/Run/TestCLIRunCommand.swift
@@ -339,8 +339,9 @@ class TestCLIRunCommand2: CLITest {
         do {
             let name = getTestName()
             let socketPath = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            let guestSocketPath = "/run/ssh-auth.sock"
 
-            let socketType = try UnixType(path: socketPath.path, unlinkExisting: true)
+            let socketType = try UnixType(path: socketPath.path, perms: 0o766, unlinkExisting: true)
             let socket = try Socket(type: socketType, closeOnDeinit: true)
             try socket.listen()
             defer {
@@ -350,18 +351,26 @@ class TestCLIRunCommand2: CLITest {
 
             try doLongRun(
                 name: name,
-                args: ["-v", "\(socketPath.path):/woo"]
+                args: [
+                    "-v", "\(socketPath.path):\(guestSocketPath)",
+                    "-e", "SSH_AUTH_SOCK=\(guestSocketPath)",
+                ]
             )
             defer {
                 try? doStop(name: name)
             }
-            let output = try doExec(name: name, cmd: ["ls", "-alh", "woo"])
-            let splitOutput = output.components(separatedBy: .whitespaces)
-            #expect(splitOutput.count > 0, "expected split output of 'ls -alh' to be at least 1, instead got \(splitOutput.count)")
 
-            let perms = splitOutput[0]
-            let firstChar = perms[perms.startIndex]
-            #expect(firstChar == "s", "expected file in guest to be of type socket, instead got '\(firstChar)'")
+            _ = try doExec(name: name, cmd: ["apk", "add", "netcat-openbsd"])
+
+            let permsOutput = try doExec(
+                name: name,
+                cmd: ["sh", "-c", "stat -c \"%a\" \"${SSH_AUTH_SOCK}\""],
+                user: "guest"
+            ).trimmingCharacters(in: .whitespacesAndNewlines)
+            #expect(permsOutput == "766", "expected socket permissions 766, got \(permsOutput)")
+
+            _ = try doExec(name: name, cmd: ["sh", "-c", "nc -zU \"${SSH_AUTH_SOCK}\""], user: "guest")
+
             try doStop(name: name)
         } catch {
             Issue.record("failed to run container \(error)")

--- a/Tests/CLITests/Utilities/CLITest.swift
+++ b/Tests/CLITests/Utilities/CLITest.swift
@@ -300,13 +300,16 @@ class CLITest {
         }
     }
 
-    func doExec(name: String, cmd: [String], detach: Bool = false) throws -> String {
+    func doExec(name: String, cmd: [String], detach: Bool = false, user: String? = nil) throws -> String {
         var execArgs = [
             "exec"
         ]
         execArgs.append(contentsOf: getProxyEnvironment())
         if detach {
             execArgs.append("-d")
+        }
+        if let user {
+            execArgs.append(contentsOf: ["-u", user])
         }
         execArgs.append(name)
         execArgs.append(contentsOf: cmd)


### PR DESCRIPTION
- Closes #1750.
- Applies permission code used for the `--ssh` mount to all host-to-container socket mounts.
- Adds a user option to the `doExec` test support function.
- Updates the `testRunCommandUnixSocketMount` to install `nc` in the test container, and check the socket permission, and check the mounted socket using `nc` as the guest user.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Allows socket mounts for non-user workloads.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs
