### PR TITLE
fix(logs): resolve SwiftLog handler deprecation warnings for https://github.com/apple/container/issues/1754

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
-        "version" : "1.10.1"
+        "revision" : "92448c359f00ebe36ae97d3bd9086f13c7692b5a",
+        "version" : "1.13.2"
       }
     },
     {

--- a/Sources/ContainerLog/FileLogHandler.swift
+++ b/Sources/ContainerLog/FileLogHandler.swift
@@ -60,6 +60,14 @@ public struct FileLogHandler: LogHandler {
         self.fileHandle.seekToEndOfFile()
     }
 
+    public func log(event: LogEvent) {
+        self.emit(
+            level: event.level,
+            message: event.message,
+            metadata: event.metadata
+        )
+    }
+
     public func log(
         level: Logger.Level,
         message: Logger.Message,
@@ -68,6 +76,18 @@ public struct FileLogHandler: LogHandler {
         file: String,
         function: String,
         line: UInt
+    ) {
+        self.emit(
+            level: level,
+            message: message,
+            metadata: metadata
+        )
+    }
+
+    private func emit(
+        level: Logger.Level,
+        message: Logger.Message,
+        metadata: Logger.Metadata?
     ) {
         let timestampFormatter: ISO8601DateFormatter = {
             let formatter = ISO8601DateFormatter()

--- a/Sources/ContainerLog/OSLogHandler.swift
+++ b/Sources/ContainerLog/OSLogHandler.swift
@@ -47,6 +47,14 @@ public struct OSLogHandler: LogHandler {
 }
 
 extension OSLogHandler {
+    public func log(event: LogEvent) {
+        self.emit(
+            level: event.level,
+            message: event.message,
+            metadata: event.metadata
+        )
+    }
+
     public func log(
         level: Logger.Level,
         message: Logger.Message,
@@ -55,6 +63,18 @@ extension OSLogHandler {
         file: String,
         function: String,
         line: UInt
+    ) {
+        self.emit(
+            level: level,
+            message: message,
+            metadata: metadata
+        )
+    }
+
+    private func emit(
+        level: Logger.Level,
+        message: Logger.Message,
+        metadata: Logger.Metadata?
     ) {
         var formattedMetadata = self.formattedMetadata
         if let metadataOverride = metadata, !metadataOverride.isEmpty {

--- a/Sources/ContainerLog/StderrLogHandler.swift
+++ b/Sources/ContainerLog/StderrLogHandler.swift
@@ -34,6 +34,14 @@ public struct StderrLogHandler: LogHandler {
 
     public init() {}
 
+    public func log(event: LogEvent) {
+        self.emit(
+            level: event.level,
+            message: event.message,
+            metadata: event.metadata
+        )
+    }
+
     public func log(
         level: Logger.Level,
         message: Logger.Message,
@@ -42,6 +50,18 @@ public struct StderrLogHandler: LogHandler {
         file: String,
         function: String,
         line: UInt
+    ) {
+        self.emit(
+            level: level,
+            message: message,
+            metadata: metadata
+        )
+    }
+
+    private func emit(
+        level: Logger.Level,
+        message: Logger.Message,
+        metadata: Logger.Metadata?
     ) {
         let data: Data
         switch logLevel {


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Fixes #1754.

Downstream packages can resolve a newer SwiftLog than this repository's current lockfile. SwiftLog 1.13.2 makes `log(event:)` the primary `LogHandler` entry point, so relying on the compatibility bridge emits deprecation warnings for all three `ContainerLog` handlers.

This change updates the lockfile to SwiftLog 1.13.2 and implements the primary event entry point without changing the existing output format. Both SwiftLog entry points share the same private emission path, including handler metadata and per-event metadata merging.

## What Changed

- Updates SwiftLog from 1.10.1 to 1.13.2.
- Implements `log(event:)` for `FileLogHandler`, `OSLogHandler`, and `StderrLogHandler`.
- Preserves the existing `log(level:message:metadata:source:file:function:line:)` compatibility entry point.
- Adds `ContainerLogTests` and exercises all three primary event paths.
- Verifies that file output preserves the level and message and that event metadata overrides handler metadata.

The branch keeps dependency, implementation, and test changes in separate commits.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

Validation:

- `make swift-fmt-check`
- `make test`: 94 XCTest cases and 559 Swift Testing cases passed
- `swift test --disable-automatic-resolution --enable-code-coverage --filter ContainerLogHandlerTests`
- `swift build --disable-automatic-resolution --target ContainerLog`
- `git diff --check origin/main..HEAD`

The coverage run executes each new `log(event:)` entry point and asserts the observable file-handler behavior.
