### PR TITLE
feat(logs): add tail and until retrieval filters

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -203,9 +203,12 @@ let package = Package(
             name: "ContainerAPIServiceTests",
             dependencies: [
                 .product(name: "Containerization", package: "containerization"),
+                "ContainerAPIClient",
+                "ContainerAPIService",
                 "ContainerResource",
                 "ContainerRuntimeLinuxClient",
                 "ContainerRuntimeClient",
+                "ContainerXPC",
             ]
         ),
         .target(

--- a/Sources/ContainerCommands/Container/ContainerLogs.swift
+++ b/Sources/ContainerCommands/Container/ContainerLogs.swift
@@ -16,6 +16,7 @@
 
 import ArgumentParser
 import ContainerAPIClient
+import ContainerResource
 import ContainerizationError
 import Darwin
 import Dispatch
@@ -36,8 +37,14 @@ extension Application {
         @Flag(name: .shortAndLong, help: "Follow log output")
         var follow: Bool = false
 
-        @Option(name: .short, help: "Number of lines to show from the end of the logs. If not provided this will print all of the logs")
+        @Option(name: [.short, .customLong("tail")], help: "Number of lines to show from the end of the logs. If not provided this will print all of the logs")
         var numLines: Int?
+
+        @Option(name: .long, help: "Show logs after the specified RFC 3339 timestamp")
+        var since: ContainerLogTimestamp?
+
+        @Option(name: .long, help: "Show logs before the specified RFC 3339 timestamp")
+        var until: ContainerLogTimestamp?
 
         @OptionGroup
         public var logOptions: Flags.Logging
@@ -45,15 +52,48 @@ extension Application {
         @Argument(help: "Container ID")
         var containerId: String
 
+        public func validate() throws {
+            try Self.validateLogOptions(follow: follow, since: since, until: until)
+        }
+
         public func run() async throws {
             let client = ContainerClient()
-            let fhs = try await client.logs(id: containerId)
+            let options = Self.retrievalOptions(
+                numLines: numLines,
+                follow: follow,
+                since: since,
+                until: until
+            )
+            let fhs = try await client.logs(id: containerId, options: options)
             let fileHandle = boot ? fhs[1] : fhs[0]
 
             try await Self.tail(
                 fh: fileHandle,
-                n: numLines,
+                n: follow ? numLines : nil,
                 follow: follow
+            )
+        }
+
+        static func validateLogOptions(
+            follow: Bool,
+            since: ContainerLogTimestamp?,
+            until: ContainerLogTimestamp?
+        ) throws {
+            if follow && (since != nil || until != nil) {
+                throw ValidationError("--follow cannot be combined with --since or --until")
+            }
+        }
+
+        static func retrievalOptions(
+            numLines: Int?,
+            follow: Bool,
+            since: ContainerLogTimestamp?,
+            until: ContainerLogTimestamp?
+        ) -> ContainerLogOptions {
+            ContainerLogOptions(
+                tail: follow ? nil : numLines,
+                since: since?.date,
+                until: until?.date
             )
         }
 
@@ -138,5 +178,22 @@ extension Application {
                 print(line)
             }
         }
+    }
+}
+
+struct ContainerLogTimestamp: ExpressibleByArgument, Equatable {
+    let date: Date
+
+    init?(argument: String) {
+        let fractionalFormatter = ISO8601DateFormatter()
+        fractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+
+        if let date = fractionalFormatter.date(from: argument) ?? formatter.date(from: argument) {
+            self.date = date
+            return
+        }
+        return nil
     }
 }

--- a/Sources/ContainerCommands/Container/ContainerLogs.swift
+++ b/Sources/ContainerCommands/Container/ContainerLogs.swift
@@ -72,16 +72,18 @@ extension Application {
             try await LogFileOutput.write(
                 fh: fileHandle,
                 n: follow ? numLines : nil,
-                follow: follow,
-                until: until?.date
+                follow: follow
             )
         }
 
         static func validateLogOptions(
-            follow _: Bool,
-            since _: ContainerLogTimestamp?,
-            until _: ContainerLogTimestamp?
+            follow: Bool,
+            since: ContainerLogTimestamp?,
+            until: ContainerLogTimestamp?
         ) throws {
+            if follow && (since != nil || until != nil) {
+                throw ValidationError("--follow cannot be combined with --since or --until")
+            }
         }
 
         static func retrievalOptions(

--- a/Sources/ContainerCommands/Container/ContainerLogs.swift
+++ b/Sources/ContainerCommands/Container/ContainerLogs.swift
@@ -58,6 +58,7 @@ extension Application {
             let options = Self.retrievalOptions(
                 numLines: numLines,
                 follow: follow,
+                boot: boot,
                 since: since,
                 until: until
             )
@@ -89,13 +90,15 @@ extension Application {
         static func retrievalOptions(
             numLines: Int?,
             follow: Bool,
+            boot: Bool,
             since: ContainerLogTimestamp?,
             until: ContainerLogTimestamp?
         ) -> ContainerLogOptions {
             ContainerLogOptions(
                 tail: follow ? nil : numLines,
                 since: since?.date,
-                until: until?.date
+                until: until?.date,
+                stream: boot ? .boot : .stdio
             )
         }
     }

--- a/Sources/ContainerCommands/Container/ContainerLogs.swift
+++ b/Sources/ContainerCommands/Container/ContainerLogs.swift
@@ -17,9 +17,6 @@
 import ArgumentParser
 import ContainerAPIClient
 import ContainerResource
-import ContainerizationError
-import Darwin
-import Dispatch
 import Foundation
 
 extension Application {
@@ -66,11 +63,16 @@ extension Application {
             )
             let fhs = try await client.logs(id: containerId, options: options)
             let fileHandle = boot ? fhs[1] : fhs[0]
+            defer {
+                for handle in fhs {
+                    try? handle.close()
+                }
+            }
 
-            try await Self.tail(
+            try await LogFileOutput.write(
                 fh: fileHandle,
                 n: follow ? numLines : nil,
-                follow: follow
+                follow: follow,
             )
         }
 
@@ -95,88 +97,6 @@ extension Application {
                 since: since?.date,
                 until: until?.date
             )
-        }
-
-        private static func tail(
-            fh: FileHandle,
-            n: Int?,
-            follow: Bool
-        ) async throws {
-            if let n {
-                var buffer = Data()
-                let size = try fh.seekToEnd()
-                var offset = size
-                var lines: [String] = []
-
-                while offset > 0, lines.count < n {
-                    let readSize = min(1024, offset)
-                    offset -= readSize
-                    try fh.seek(toOffset: offset)
-
-                    let data = fh.readData(ofLength: Int(readSize))
-                    buffer.insert(contentsOf: data, at: 0)
-
-                    if let chunk = String(data: buffer, encoding: .utf8) {
-                        lines = chunk.components(separatedBy: .newlines)
-                        lines = lines.filter { !$0.isEmpty }
-                    }
-                }
-
-                lines = Array(lines.suffix(n))
-                for line in lines {
-                    print(line)
-                }
-            } else {
-                // Fast path if all they want is the full file.
-                guard let data = try fh.readToEnd() else {
-                    // Seems you get nil if it's a zero byte read, or you
-                    // try and read from dev/null.
-                    return
-                }
-                guard let str = String(data: data, encoding: .utf8) else {
-                    throw ContainerizationError(
-                        .internalError,
-                        message: "failed to convert container logs to utf8"
-                    )
-                }
-                print(str.trimmingCharacters(in: .newlines))
-            }
-
-            fflush(stdout)
-            if follow {
-                setbuf(stdout, nil)
-                try await Self.followFile(fh: fh)
-            }
-        }
-
-        private static func followFile(fh: FileHandle) async throws {
-            _ = try fh.seekToEnd()
-            let stream = AsyncStream<String> { cont in
-                fh.readabilityHandler = { handle in
-                    let data = handle.availableData
-                    if data.isEmpty {
-                        // Triggers on container restart - can exit here as well
-                        do {
-                            _ = try fh.seekToEnd()  // To continue streaming existing truncated log files
-                        } catch {
-                            fh.readabilityHandler = nil
-                            cont.finish()
-                            return
-                        }
-                    }
-                    if let str = String(data: data, encoding: .utf8), !str.isEmpty {
-                        var lines = str.components(separatedBy: .newlines)
-                        lines = lines.filter { !$0.isEmpty }
-                        for line in lines {
-                            cont.yield(line)
-                        }
-                    }
-                }
-            }
-
-            for await line in stream {
-                print(line)
-            }
         }
     }
 }

--- a/Sources/ContainerCommands/Container/ContainerLogs.swift
+++ b/Sources/ContainerCommands/Container/ContainerLogs.swift
@@ -73,17 +73,15 @@ extension Application {
                 fh: fileHandle,
                 n: follow ? numLines : nil,
                 follow: follow,
+                until: until?.date
             )
         }
 
         static func validateLogOptions(
-            follow: Bool,
-            since: ContainerLogTimestamp?,
-            until: ContainerLogTimestamp?
+            follow _: Bool,
+            since _: ContainerLogTimestamp?,
+            until _: ContainerLogTimestamp?
         ) throws {
-            if follow && (since != nil || until != nil) {
-                throw ValidationError("--follow cannot be combined with --since or --until")
-            }
         }
 
         static func retrievalOptions(

--- a/Sources/ContainerCommands/LogFileOutput.swift
+++ b/Sources/ContainerCommands/LogFileOutput.swift
@@ -23,6 +23,7 @@ struct LogFileOutput {
         fh: FileHandle,
         n: Int?,
         follow: Bool,
+        until: Date? = nil,
         output: FileHandle = .standardOutput
     ) async throws {
         if let n {
@@ -32,7 +33,7 @@ struct LogFileOutput {
         }
 
         if follow {
-            try await followFile(fh: fh, output: output)
+            try await followFile(fh: fh, output: output, until: until)
         }
     }
 
@@ -108,8 +109,12 @@ struct LogFileOutput {
 
     private static func followFile(
         fh: FileHandle,
-        output: FileHandle
+        output: FileHandle,
+        until: Date?
     ) async throws {
+        guard until.map({ $0 > Date() }) ?? true else {
+            return
+        }
         _ = try? fh.seekToEnd()
         let stream = AsyncStream<Data> { continuation in
             fh.readabilityHandler = { handle in
@@ -125,7 +130,20 @@ struct LogFileOutput {
                 }
                 continuation.yield(data)
             }
+
+            let stopTask = until.map { deadline in
+                Task {
+                    let seconds = deadline.timeIntervalSinceNow
+                    guard seconds > 0 else {
+                        continuation.finish()
+                        return
+                    }
+                    try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                    continuation.finish()
+                }
+            }
             continuation.onTermination = { _ in
+                stopTask?.cancel()
                 fh.readabilityHandler = nil
             }
         }

--- a/Sources/ContainerCommands/LogFileOutput.swift
+++ b/Sources/ContainerCommands/LogFileOutput.swift
@@ -36,14 +36,6 @@ struct LogFileOutput {
         }
     }
 
-    /// Writes existing raw log data without binding output to a specific file handle.
-    static func write(data: Data, n: Int?, output: FileHandle = .standardOutput) {
-        let selected = n.map { tailData(data, lineCount: $0) } ?? data
-        if !selected.isEmpty {
-            output.write(selected)
-        }
-    }
-
     /// Returns the final `lineCount` log records from `data`.
     static func tailData(_ data: Data, lineCount: Int) -> Data {
         guard lineCount != 0 else {

--- a/Sources/ContainerCommands/LogFileOutput.swift
+++ b/Sources/ContainerCommands/LogFileOutput.swift
@@ -1,0 +1,162 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Writes log file data while preserving the stored byte stream.
+struct LogFileOutput {
+    /// Writes all requested log data and optionally continues streaming appended bytes.
+    static func write(
+        fh: FileHandle,
+        n: Int?,
+        follow: Bool,
+        output: FileHandle = .standardOutput
+    ) async throws {
+        if let n {
+            try writeTail(fh: fh, lineCount: n, output: output)
+        } else {
+            try writeAll(fh: fh, output: output)
+        }
+
+        if follow {
+            try await followFile(fh: fh, output: output)
+        }
+    }
+
+    /// Writes existing raw log data without binding output to a specific file handle.
+    static func write(data: Data, n: Int?, output: FileHandle = .standardOutput) {
+        let selected = n.map { tailData(data, lineCount: $0) } ?? data
+        if !selected.isEmpty {
+            output.write(selected)
+        }
+    }
+
+    /// Returns the final `lineCount` log records from `data`.
+    static func tailData(_ data: Data, lineCount: Int) -> Data {
+        guard lineCount != 0 else {
+            return Data()
+        }
+        guard lineCount > 0 else {
+            return data
+        }
+
+        var index = data.endIndex
+        if index > data.startIndex, data[data.index(before: index)] == LogByte.lineFeed {
+            index = data.index(before: index)
+        }
+
+        var foundLines = 0
+        while index > data.startIndex {
+            let previous = data.index(before: index)
+            if data[previous] == LogByte.lineFeed {
+                foundLines += 1
+                if foundLines == lineCount {
+                    return Data(data[data.index(after: previous)..<data.endIndex])
+                }
+            }
+            index = previous
+        }
+
+        return data
+    }
+
+    private static func writeTail(
+        fh: FileHandle,
+        lineCount: Int,
+        output: FileHandle
+    ) throws {
+        guard lineCount != 0 else {
+            return
+        }
+        guard lineCount > 0 else {
+            try writeAll(fh: fh, output: output)
+            return
+        }
+
+        let size = try fh.seekToEnd()
+        var offset = size
+        var buffer = Data()
+
+        while offset > 0, countedLines(in: buffer) <= lineCount {
+            let readSize = min(1024, offset)
+            offset -= readSize
+            try fh.seek(toOffset: offset)
+            let data = fh.readData(ofLength: Int(readSize))
+            buffer.insert(contentsOf: data, at: 0)
+        }
+
+        let data = tailData(buffer, lineCount: lineCount)
+        if !data.isEmpty {
+            output.write(data)
+        }
+    }
+
+    private static func writeAll(
+        fh: FileHandle,
+        output: FileHandle
+    ) throws {
+        guard let data = try fh.readToEnd(), !data.isEmpty else {
+            return
+        }
+        output.write(data)
+    }
+
+    private static func followFile(
+        fh: FileHandle,
+        output: FileHandle
+    ) async throws {
+        _ = try? fh.seekToEnd()
+        let stream = AsyncStream<Data> { continuation in
+            fh.readabilityHandler = { handle in
+                let data = handle.availableData
+                if data.isEmpty {
+                    do {
+                        _ = try handle.seekToEnd()
+                    } catch {
+                        handle.readabilityHandler = nil
+                        continuation.finish()
+                    }
+                    return
+                }
+                continuation.yield(data)
+            }
+            continuation.onTermination = { _ in
+                fh.readabilityHandler = nil
+            }
+        }
+
+        for await data in stream {
+            output.write(data)
+        }
+    }
+
+    private static func countedLines(in data: Data) -> Int {
+        guard !data.isEmpty else {
+            return 0
+        }
+        let separatorCount = data.reduce(0) { count, byte in
+            byte == LogByte.lineFeed ? count + 1 : count
+        }
+        if data.last == LogByte.lineFeed {
+            return separatorCount
+        }
+        return separatorCount + 1
+    }
+}
+
+private enum LogByte {
+    static let lineFeed = UInt8(ascii: "\n")
+}

--- a/Sources/ContainerCommands/LogFileOutput.swift
+++ b/Sources/ContainerCommands/LogFileOutput.swift
@@ -23,7 +23,6 @@ struct LogFileOutput {
         fh: FileHandle,
         n: Int?,
         follow: Bool,
-        until: Date? = nil,
         output: FileHandle = .standardOutput
     ) async throws {
         if let n {
@@ -33,7 +32,7 @@ struct LogFileOutput {
         }
 
         if follow {
-            try await followFile(fh: fh, output: output, until: until)
+            try await followFile(fh: fh, output: output)
         }
     }
 
@@ -109,12 +108,8 @@ struct LogFileOutput {
 
     private static func followFile(
         fh: FileHandle,
-        output: FileHandle,
-        until: Date?
+        output: FileHandle
     ) async throws {
-        guard until.map({ $0 > Date() }) ?? true else {
-            return
-        }
         _ = try? fh.seekToEnd()
         let stream = AsyncStream<Data> { continuation in
             fh.readabilityHandler = { handle in
@@ -130,20 +125,7 @@ struct LogFileOutput {
                 }
                 continuation.yield(data)
             }
-
-            let stopTask = until.map { deadline in
-                Task {
-                    let seconds = deadline.timeIntervalSinceNow
-                    guard seconds > 0 else {
-                        continuation.finish()
-                        return
-                    }
-                    try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-                    continuation.finish()
-                }
-            }
             continuation.onTermination = { _ in
-                stopTask?.cancel()
                 fh.readabilityHandler = nil
             }
         }

--- a/Sources/ContainerResource/Container/ContainerLogOptions.swift
+++ b/Sources/ContainerResource/Container/ContainerLogOptions.swift
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Options that refine how `ContainerClient.logs(id:options:)` returns
+/// container log file handles.
+///
+/// Both fields are optional / additive; ``default`` is the zero-value
+/// equivalent to the original `logs(id:)` behavior.
+public struct ContainerLogOptions: Sendable, Codable {
+    /// If non-nil, log lines whose ISO-8601 timestamp prefix is older than
+    /// this date are filtered out before the file handle is returned to the
+    /// client. Lines without a parseable timestamp are passed through
+    /// unchanged.
+    public let since: Date?
+
+    /// If true, the client wants timestamps preserved on the returned lines.
+    /// At present this is a hint only — the daemon does not decorate raw log
+    /// lines that lack a timestamp prefix; line decoration is a follow-up.
+    public let timestamps: Bool
+
+    public static let `default` = ContainerLogOptions(since: nil, timestamps: false)
+
+    public init(since: Date? = nil, timestamps: Bool = false) {
+        self.since = since
+        self.timestamps = timestamps
+    }
+}

--- a/Sources/ContainerResource/Container/ContainerLogOptions.swift
+++ b/Sources/ContainerResource/Container/ContainerLogOptions.swift
@@ -21,7 +21,10 @@ import Foundation
 /// ``default`` is the zero-option equivalent to the original `logs(id:)`
 /// behavior.
 public struct ContainerLogOptions: Codable, Equatable, Sendable {
-    /// If non-nil and non-negative, return only the last `tail` log lines.
+    /// If non-nil, refine how many log lines are returned.
+    ///
+    /// Positive values return the last `tail` lines, zero returns no lines,
+    /// and negative values follow Docker's behavior of returning all lines.
     public let tail: Int?
 
     /// If non-nil, return log lines whose timestamp prefix is not older than

--- a/Sources/ContainerResource/Container/ContainerLogOptions.swift
+++ b/Sources/ContainerResource/Container/ContainerLogOptions.swift
@@ -16,6 +16,14 @@
 
 import Foundation
 
+/// Identifies which stored log stream should receive filtering options.
+public enum ContainerLogStream: String, Codable, Equatable, Sendable {
+    /// Workload stdio logs.
+    case stdio
+    /// VM boot logs.
+    case boot
+}
+
 /// Options that refine how container logs are returned.
 ///
 /// ``default`` is the zero-option equivalent to the original `logs(id:)`
@@ -44,17 +52,24 @@ public struct ContainerLogOptions: Codable, Equatable, Sendable {
     /// behavior as the log implementation evolves.
     public let timestamps: Bool
 
+    /// The log stream that should receive filtering options.
+    ///
+    /// When nil, filtering applies to every returned stream.
+    public let stream: ContainerLogStream?
+
     public static let `default` = ContainerLogOptions()
 
     public init(
         tail: Int? = nil,
         since: Date? = nil,
         until: Date? = nil,
-        timestamps: Bool = false
+        timestamps: Bool = false,
+        stream: ContainerLogStream? = nil
     ) {
         self.tail = tail
         self.since = since
         self.until = until
         self.timestamps = timestamps
+        self.stream = stream
     }
 }

--- a/Sources/ContainerResource/Container/ContainerLogOptions.swift
+++ b/Sources/ContainerResource/Container/ContainerLogOptions.swift
@@ -16,27 +16,40 @@
 
 import Foundation
 
-/// Options that refine how `ContainerClient.logs(id:options:)` returns
-/// container log file handles.
+/// Options that refine how container logs are returned.
 ///
-/// Both fields are optional / additive; ``default`` is the zero-value
-/// equivalent to the original `logs(id:)` behavior.
-public struct ContainerLogOptions: Sendable, Codable {
-    /// If non-nil, log lines whose ISO-8601 timestamp prefix is older than
-    /// this date are filtered out before the file handle is returned to the
-    /// client. Lines without a parseable timestamp are passed through
-    /// unchanged.
+/// ``default`` is the zero-option equivalent to the original `logs(id:)`
+/// behavior.
+public struct ContainerLogOptions: Codable, Equatable, Sendable {
+    /// If non-nil and non-negative, return only the last `tail` log lines.
+    public let tail: Int?
+
+    /// If non-nil, return log lines whose timestamp prefix is not older than
+    /// this date. Lines without a parseable timestamp prefix are preserved.
     public let since: Date?
 
-    /// If true, the client wants timestamps preserved on the returned lines.
-    /// At present this is a hint only — the daemon does not decorate raw log
-    /// lines that lack a timestamp prefix; line decoration is a follow-up.
+    /// If non-nil, return log lines whose timestamp prefix is not newer than
+    /// this date. Lines without a parseable timestamp prefix are preserved.
+    public let until: Date?
+
+    /// If true, callers want timestamps preserved on returned log lines.
+    ///
+    /// The current log files are already returned as stored; this value is
+    /// carried through the API boundary for callers that need stable timestamp
+    /// behavior as the log implementation evolves.
     public let timestamps: Bool
 
-    public static let `default` = ContainerLogOptions(since: nil, timestamps: false)
+    public static let `default` = ContainerLogOptions()
 
-    public init(since: Date? = nil, timestamps: Bool = false) {
+    public init(
+        tail: Int? = nil,
+        since: Date? = nil,
+        until: Date? = nil,
+        timestamps: Bool = false
+    ) {
+        self.tail = tail
         self.since = since
+        self.until = until
         self.timestamps = timestamps
     }
 }

--- a/Sources/ContainerResource/Container/ContainerLogOptions.swift
+++ b/Sources/ContainerResource/Container/ContainerLogOptions.swift
@@ -25,11 +25,13 @@ public struct ContainerLogOptions: Codable, Equatable, Sendable {
     public let tail: Int?
 
     /// If non-nil, return log lines whose timestamp prefix is not older than
-    /// this date. Lines without a parseable timestamp prefix are preserved.
+    /// this date. Logs without parseable timestamp prefixes cannot be filtered
+    /// safely and cause the request to fail.
     public let since: Date?
 
     /// If non-nil, return log lines whose timestamp prefix is not newer than
-    /// this date. Lines without a parseable timestamp prefix are preserved.
+    /// this date. Logs without parseable timestamp prefixes cannot be filtered
+    /// safely and cause the request to fail.
     public let until: Date?
 
     /// If true, callers want timestamps preserved on returned log lines.

--- a/Sources/ContainerXPC/XPCMessage.swift
+++ b/Sources/ContainerXPC/XPCMessage.swift
@@ -117,6 +117,7 @@ extension XPCMessage {
         return Data(bytes: bytes, count: length)
     }
 
+    /// Returns true when the message contains a value for the provided key.
     public func contains(key: String) -> Bool {
         lock.withLock {
             xpc_dictionary_get_value(self.object, key) != nil

--- a/Sources/ContainerXPC/XPCMessage.swift
+++ b/Sources/ContainerXPC/XPCMessage.swift
@@ -117,6 +117,12 @@ extension XPCMessage {
         return Data(bytes: bytes, count: length)
     }
 
+    public func contains(key: String) -> Bool {
+        lock.withLock {
+            xpc_dictionary_get_value(self.object, key) != nil
+        }
+    }
+
     /// dataNoCopy is similar to data, except the data is not copied
     /// to a new buffer. What this means in practice is the second the
     /// underlying xpc_object_t gets released by ARC the data will be

--- a/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
+++ b/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
@@ -267,18 +267,19 @@ public struct ContainerClient: Sendable {
         try await logs(id: id, options: .default)
     }
 
-    /// Get the log file handles for a container, refined by ``ContainerLogOptions``.
-    ///
-    /// `options.since` filters out log lines whose ISO-8601 timestamp prefix
-    /// predates the given date; lines without a parseable timestamp are
-    /// passed through. `options.timestamps` is forwarded to the daemon as a
-    /// hint; line-level timestamp decoration is a deferred follow-up.
+    /// Get the log file handles for a container.
     public func logs(id: String, options: ContainerLogOptions) async throws -> [FileHandle] {
         do {
             let request = XPCMessage(route: .containerLogs)
             request.set(key: .id, value: id)
+            if let tail = options.tail {
+                request.set(key: .logTail, value: Int64(tail))
+            }
             if let since = options.since {
                 request.set(key: .logSince, value: since)
+            }
+            if let until = options.until {
+                request.set(key: .logUntil, value: until)
             }
             request.set(key: .logTimestamps, value: options.timestamps)
 

--- a/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
+++ b/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
@@ -282,6 +282,9 @@ public struct ContainerClient: Sendable {
                 request.set(key: .logUntil, value: until)
             }
             request.set(key: .logTimestamps, value: options.timestamps)
+            if let stream = options.stream {
+                request.set(key: .logStream, value: stream.rawValue)
+            }
 
             let response = try await xpcClient.send(request)
             let fds = response.fileHandles(key: .logs)

--- a/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
+++ b/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
@@ -264,9 +264,23 @@ public struct ContainerClient: Sendable {
 
     /// Get the log file handles for a container.
     public func logs(id: String) async throws -> [FileHandle] {
+        try await logs(id: id, options: .default)
+    }
+
+    /// Get the log file handles for a container, refined by ``ContainerLogOptions``.
+    ///
+    /// `options.since` filters out log lines whose ISO-8601 timestamp prefix
+    /// predates the given date; lines without a parseable timestamp are
+    /// passed through. `options.timestamps` is forwarded to the daemon as a
+    /// hint; line-level timestamp decoration is a deferred follow-up.
+    public func logs(id: String, options: ContainerLogOptions) async throws -> [FileHandle] {
         do {
             let request = XPCMessage(route: .containerLogs)
             request.set(key: .id, value: id)
+            if let since = options.since {
+                request.set(key: .logSince, value: since)
+            }
+            request.set(key: .logTimestamps, value: options.timestamps)
 
             let response = try await xpcClient.send(request)
             let fds = response.fileHandles(key: .logs)

--- a/Sources/Services/ContainerAPIService/Client/XPC+.swift
+++ b/Sources/Services/ContainerAPIService/Client/XPC+.swift
@@ -156,6 +156,8 @@ public enum XPCKeys: String {
     case logUntil
     /// Timestamp preference for container logs.
     case logTimestamps
+    /// Stream selected for container log filtering.
+    case logStream
 }
 
 public enum XPCRoute: String {

--- a/Sources/Services/ContainerAPIService/Client/XPC+.swift
+++ b/Sources/Services/ContainerAPIService/Client/XPC+.swift
@@ -148,9 +148,13 @@ public enum XPCKeys: String {
     case fileMode
     case createParents
 
-    /// Optional `since: Date` filter on `logs`.
+    /// Optional tail line limit for container logs.
+    case logTail
+    /// Optional lower timestamp bound for container logs.
     case logSince
-    /// Optional `timestamps: Bool` flag on `logs`.
+    /// Optional upper timestamp bound for container logs.
+    case logUntil
+    /// Timestamp preference for container logs.
     case logTimestamps
 }
 

--- a/Sources/Services/ContainerAPIService/Client/XPC+.swift
+++ b/Sources/Services/ContainerAPIService/Client/XPC+.swift
@@ -147,6 +147,11 @@ public enum XPCKeys: String {
     case destinationPath
     case fileMode
     case createParents
+
+    /// Optional `since: Date` filter on `logs`.
+    case logSince
+    /// Optional `timestamps: Bool` flag on `logs`.
+    case logTimestamps
 }
 
 public enum XPCRoute: String {
@@ -205,6 +210,10 @@ extension XPCMessage {
 
     public func dataNoCopy(key: XPCKeys) -> Data? {
         dataNoCopy(key: key.rawValue)
+    }
+
+    public func contains(key: XPCKeys) -> Bool {
+        contains(key: key.rawValue)
     }
 
     public func set(key: XPCKeys, value: Data) {

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift
@@ -289,10 +289,19 @@ public struct ContainersHarness: Sendable {
                 message: "id cannot be empty"
             )
         }
-        let fds = try await service.logs(id: id)
+
+        let options = Self.logOptions(from: message)
+
+        let fds = try await service.logs(id: id, options: options)
         let reply = message.reply()
         try reply.set(key: .logs, value: fds)
         return reply
+    }
+
+    static func logOptions(from message: XPCMessage) -> ContainerLogOptions {
+        let since = message.contains(key: .logSince) ? message.date(key: .logSince) : nil
+        let timestamps = message.bool(key: .logTimestamps)
+        return ContainerLogOptions(since: since, timestamps: timestamps)
     }
 
     @Sendable

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift
@@ -289,22 +289,37 @@ public struct ContainersHarness: Sendable {
                 message: "id cannot be empty"
             )
         }
-        let options = Self.logOptions(from: message)
+        let options = try Self.logOptions(from: message)
         let fds = try await service.logs(id: id, options: options)
         let reply = message.reply()
         try reply.set(key: .logs, value: fds)
         return reply
     }
 
-    static func logOptions(from message: XPCMessage) -> ContainerLogOptions {
+    static func logOptions(from message: XPCMessage) throws -> ContainerLogOptions {
         let tail = message.contains(key: .logTail) ? Int(message.int64(key: .logTail)) : nil
         let since = message.contains(key: .logSince) ? message.date(key: .logSince) : nil
         let until = message.contains(key: .logUntil) ? message.date(key: .logUntil) : nil
+        let stream: ContainerLogStream?
+        if message.contains(key: .logStream) {
+            guard let value = message.string(key: .logStream),
+                let decoded = ContainerLogStream(rawValue: value)
+            else {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "invalid container log stream"
+                )
+            }
+            stream = decoded
+        } else {
+            stream = nil
+        }
         return ContainerLogOptions(
             tail: tail,
             since: since,
             until: until,
-            timestamps: message.bool(key: .logTimestamps)
+            timestamps: message.bool(key: .logTimestamps),
+            stream: stream
         )
     }
 

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift
@@ -289,9 +289,7 @@ public struct ContainersHarness: Sendable {
                 message: "id cannot be empty"
             )
         }
-
         let options = Self.logOptions(from: message)
-
         let fds = try await service.logs(id: id, options: options)
         let reply = message.reply()
         try reply.set(key: .logs, value: fds)
@@ -299,9 +297,15 @@ public struct ContainersHarness: Sendable {
     }
 
     static func logOptions(from message: XPCMessage) -> ContainerLogOptions {
+        let tail = message.contains(key: .logTail) ? Int(message.int64(key: .logTail)) : nil
         let since = message.contains(key: .logSince) ? message.date(key: .logSince) : nil
-        let timestamps = message.bool(key: .logTimestamps)
-        return ContainerLogOptions(since: since, timestamps: timestamps)
+        let until = message.contains(key: .logUntil) ? message.date(key: .logUntil) : nil
+        return ContainerLogOptions(
+            tail: tail,
+            since: since,
+            until: until,
+            timestamps: message.bool(key: .logTimestamps)
+        )
     }
 
     @Sendable

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -764,21 +764,10 @@ public actor ContainersService {
             let path = self.containerRoot.appendingPathComponent(id)
             let bundle = ContainerResource.Bundle(path: path)
             let handles = [
-                try FileHandle(forReadingFrom: bundle.containerLog),
-                try FileHandle(forReadingFrom: bundle.bootlog),
+                LogHandle(stream: .stdio, handle: try FileHandle(forReadingFrom: bundle.containerLog)),
+                LogHandle(stream: .boot, handle: try FileHandle(forReadingFrom: bundle.bootlog)),
             ]
-            var filteredHandles: [FileHandle] = []
-            do {
-                for handle in handles {
-                    filteredHandles.append(try Self.applyLogOptions(to: handle, options: options))
-                }
-                return filteredHandles
-            } catch {
-                for handle in handles + filteredHandles {
-                    try? handle.close()
-                }
-                throw error
-            }
+            return try Self.applyLogOptions(to: handles, options: options)
         } catch let error as ContainerizationError {
             throw error
         } catch {
@@ -786,6 +775,28 @@ public actor ContainersService {
                 .internalError,
                 message: "failed to open container logs: \(error)"
             )
+        }
+    }
+
+    static func applyLogOptions(
+        to handles: [LogHandle],
+        options: ContainerLogOptions
+    ) throws -> [FileHandle] {
+        var filteredHandles: [FileHandle] = []
+        do {
+            for logHandle in handles {
+                guard options.stream == nil || options.stream == logHandle.stream else {
+                    filteredHandles.append(logHandle.handle)
+                    continue
+                }
+                filteredHandles.append(try Self.applyLogOptions(to: logHandle.handle, options: options))
+            }
+            return filteredHandles
+        } catch {
+            for handle in handles.map(\.handle) + filteredHandles {
+                try? handle.close()
+            }
+            throw error
         }
     }
 
@@ -925,7 +936,7 @@ public actor ContainersService {
         timestampParser: LogTimestampParser
     ) throws -> Bool {
         guard let timestamp = timestampParser.timestampPrefix(from: line.data) else {
-            guard (options.since == nil && options.until == nil) || line.data.isEmpty else {
+            guard options.since == nil && options.until == nil else {
                 throw ContainerizationError(
                     .invalidArgument,
                     message: "cannot apply timestamp filters to container logs without timestamp prefixes"
@@ -1041,6 +1052,11 @@ public actor ContainersService {
     private struct LogDataLine {
         var data: Data
         var terminated: Bool
+    }
+
+    struct LogHandle {
+        var stream: ContainerLogStream
+        var handle: FileHandle
     }
 
     /// Fixed-size tail retention for filtered replay.

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -27,6 +27,7 @@ import ContainerizationError
 import ContainerizationExtras
 import ContainerizationOCI
 import ContainerizationOS
+import Darwin
 import Foundation
 import Logging
 import SystemPackage
@@ -729,8 +730,11 @@ public actor ContainersService {
         try await client.resize(processID, size: size)
     }
 
-    // Get the logs for the container.
     public func logs(id: String) async throws -> [FileHandle] {
+        try await logs(id: id, options: .default)
+    }
+
+    public func logs(id: String, options: ContainerLogOptions) async throws -> [FileHandle] {
         log.debug(
             "ContainersService: enter",
             metadata: [
@@ -748,18 +752,22 @@ public actor ContainersService {
             )
         }
 
-        // Logs doesn't care if the container is running or not, just that
-        // the bundle is there, and that the files actually exist. We do
-        // first try and get the container state so we get a nicer error message
-        // (container foo not found) however.
         do {
             _ = try _getContainerState(id: id)
             let path = self.containerRoot.appendingPathComponent(id)
             let bundle = ContainerResource.Bundle(path: path)
-            return [
+            var handles = [
                 try FileHandle(forReadingFrom: bundle.containerLog),
                 try FileHandle(forReadingFrom: bundle.bootlog),
             ]
+
+            if let since = options.since {
+                handles = handles.map { fh in
+                    Self.filterFileHandleSince(fh, since: since)
+                }
+            }
+
+            return handles
         } catch {
             throw ContainerizationError(
                 .internalError,
@@ -790,6 +798,92 @@ public actor ContainersService {
         }
         let client = try state.getClient()
         try await client.copyOut(source: source, destination: destination, createParents: createParents)
+    }
+
+    static func filterFileHandleSince(_ fh: FileHandle, since: Date) -> FileHandle {
+        guard let data = try? fh.readToEnd() else {
+            return fh
+        }
+        guard let result = Self.filteredLogData(data, since: since) else {
+            try? fh.seek(toOffset: 0)
+            return fh
+        }
+
+        if let filteredHandle = Self.temporaryFileHandle(containing: result) {
+            return filteredHandle
+        }
+        try? fh.seek(toOffset: 0)
+        return fh
+    }
+
+    static func filteredLogData(_ data: Data, since: Date) -> Data? {
+        guard let content = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        let iso8601 = ISO8601DateFormatter()
+        iso8601.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let fallbackFormatter = ISO8601DateFormatter()
+        fallbackFormatter.formatOptions = [.withInternetDateTime]
+
+        let lines = content.components(separatedBy: "\n")
+        var filtered: [String] = []
+        for line in lines {
+            guard !line.isEmpty else {
+                filtered.append(line)
+                continue
+            }
+            let parts = line.split(separator: " ", maxSplits: 1)
+            guard let timestampStr = parts.first else {
+                filtered.append(line)
+                continue
+            }
+            if let date = iso8601.date(from: String(timestampStr)) ?? fallbackFormatter.date(from: String(timestampStr)) {
+                if date >= since {
+                    filtered.append(line)
+                }
+            } else {
+                filtered.append(line)
+            }
+        }
+
+        let result = filtered.joined(separator: "\n")
+        return result.data(using: .utf8)
+    }
+
+    private static func temporaryFileHandle(containing data: Data) -> FileHandle? {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("container-log-filter-")
+            .appendingPathExtension(UUID().uuidString)
+        let fd = open(url.path, O_CREAT | O_EXCL | O_RDWR, S_IRUSR | S_IWUSR)
+        guard fd >= 0 else {
+            return nil
+        }
+
+        let success = data.withUnsafeBytes { buffer in
+            guard let baseAddress = buffer.baseAddress else {
+                return true
+            }
+            var remaining = buffer.count
+            var pointer = baseAddress
+            while remaining > 0 {
+                let written = write(fd, pointer, remaining)
+                guard written > 0 else {
+                    return false
+                }
+                remaining -= written
+                pointer += written
+            }
+            return true
+        }
+
+        guard success, lseek(fd, 0, SEEK_SET) >= 0 else {
+            close(fd)
+            try? FileManager.default.removeItem(at: url)
+            return nil
+        }
+
+        try? FileManager.default.removeItem(at: url)
+        return FileHandle(fileDescriptor: fd, closeOnDealloc: true)
     }
 
     /// Get statistics for the container.

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -766,8 +766,17 @@ public actor ContainersService {
                 try FileHandle(forReadingFrom: bundle.containerLog),
                 try FileHandle(forReadingFrom: bundle.bootlog),
             ]
-            return handles.map { handle in
-                Self.applyLogOptions(to: handle, options: options)
+            var filteredHandles: [FileHandle] = []
+            do {
+                for handle in handles {
+                    filteredHandles.append(try Self.applyLogOptions(to: handle, options: options))
+                }
+                return filteredHandles
+            } catch {
+                for handle in handles + filteredHandles {
+                    try? handle.close()
+                }
+                throw error
             }
         } catch {
             throw ContainerizationError(
@@ -777,7 +786,11 @@ public actor ContainersService {
         }
     }
 
-    static func applyLogOptions(to handle: FileHandle, options: ContainerLogOptions) -> FileHandle {
+    static func applyLogOptions(
+        to handle: FileHandle,
+        options: ContainerLogOptions,
+        temporaryDirectory: URL = FileManager.default.temporaryDirectory
+    ) throws -> FileHandle {
         guard options.tail != nil || options.since != nil || options.until != nil else {
             return handle
         }
@@ -786,27 +799,14 @@ public actor ContainersService {
                 return handle
             }
 
-            do {
-                let data = try Self.tailLogData(from: handle, lineCount: tail)
-                guard let filteredHandle = Self.temporaryFileHandle(containing: data) else {
-                    try? handle.seek(toOffset: 0)
-                    return handle
-                }
-                try? handle.close()
-                return filteredHandle
-            } catch {
-                try? handle.seek(toOffset: 0)
-                return handle
-            }
+            let data = try Self.tailLogData(from: handle, lineCount: tail)
+            let filteredHandle = try Self.temporaryFileHandle(containing: data, in: temporaryDirectory)
+            try? handle.close()
+            return filteredHandle
         }
-        guard let data = try? handle.readToEnd() else {
-            return handle
-        }
+        let data = try handle.readToEnd() ?? Data()
         let filtered = Self.filteredLogData(data, options: options)
-        guard let filteredHandle = Self.temporaryFileHandle(containing: filtered) else {
-            try? handle.seek(toOffset: 0)
-            return handle
-        }
+        let filteredHandle = try Self.temporaryFileHandle(containing: filtered, in: temporaryDirectory)
         try? handle.close()
         return filteredHandle
     }
@@ -881,8 +881,12 @@ public actor ContainersService {
         return joinedLogData(lines)
     }
 
-    private static func temporaryFileHandle(containing data: Data) -> FileHandle? {
-        let url = FileManager.default.temporaryDirectory
+    private static func temporaryFileHandle(
+        containing data: Data,
+        in temporaryDirectory: URL
+    ) throws -> FileHandle {
+        let url =
+            temporaryDirectory
             .appendingPathComponent("container-log-\(UUID().uuidString)")
         do {
             try data.write(to: url)
@@ -891,7 +895,11 @@ public actor ContainersService {
             return handle
         } catch {
             try? FileManager.default.removeItem(at: url)
-            return nil
+            throw ContainerizationError(
+                .internalError,
+                message: "failed to prepare filtered container logs",
+                cause: error
+            )
         }
     }
 

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -1055,7 +1055,6 @@ public actor ContainersService {
 
         init(capacity: Int) {
             self.capacity = max(capacity, 0)
-            self.storage.reserveCapacity(self.capacity)
         }
 
         mutating func append(_ line: LogDataLine) {

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -27,6 +27,7 @@ import ContainerizationError
 import ContainerizationExtras
 import ContainerizationOCI
 import ContainerizationOS
+import Darwin
 import Foundation
 import Logging
 import SystemPackage
@@ -888,12 +889,48 @@ public actor ContainersService {
         let url =
             temporaryDirectory
             .appendingPathComponent("container-log-\(UUID().uuidString)")
+        let fd = Darwin.open(url.path, O_CREAT | O_EXCL | O_RDWR, S_IRUSR | S_IWUSR)
+        guard fd >= 0 else {
+            throw ContainerizationError(
+                .internalError,
+                message: "failed to prepare filtered container logs",
+                cause: POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            )
+        }
+
+        var closeFileDescriptor = true
         do {
-            try data.write(to: url)
-            let handle = try FileHandle(forReadingFrom: url)
+            try data.withUnsafeBytes { buffer in
+                guard var pointer = buffer.baseAddress else {
+                    return
+                }
+                var remaining = buffer.count
+                while remaining > 0 {
+                    let written = Darwin.write(fd, pointer, remaining)
+                    if written < 0 {
+                        if errno == EINTR {
+                            continue
+                        }
+                        throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+                    }
+                    guard written > 0 else {
+                        throw POSIXError(.EIO)
+                    }
+                    remaining -= written
+                    pointer = pointer.advanced(by: written)
+                }
+            }
+            guard Darwin.lseek(fd, 0, SEEK_SET) >= 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+            let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+            closeFileDescriptor = false
             try? FileManager.default.removeItem(at: url)
             return handle
         } catch {
+            if closeFileDescriptor {
+                Darwin.close(fd)
+            }
             try? FileManager.default.removeItem(at: url)
             throw ContainerizationError(
                 .internalError,

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -864,6 +864,10 @@ public actor ContainersService {
     }
 
     static func filteredLogData(_ data: Data, options: ContainerLogOptions) throws -> Data {
+        if options.tail == 0 {
+            return Data()
+        }
+
         guard !data.isEmpty else {
             return Data()
         }
@@ -875,9 +879,6 @@ public actor ContainersService {
         }
 
         if let tail = options.tail, tail >= 0 {
-            if tail == 0 {
-                return Data()
-            }
             lines = Array(lines.suffix(tail))
         }
 

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -923,9 +923,11 @@ public actor ContainersService {
             guard Darwin.lseek(fd, 0, SEEK_SET) >= 0 else {
                 throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
             }
+            guard Darwin.unlink(url.path) == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
             let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
             closeFileDescriptor = false
-            try? FileManager.default.removeItem(at: url)
             return handle
         } catch {
             if closeFileDescriptor {

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -50,6 +50,7 @@ public actor ContainersService {
 
     private static let machServicePrefix = "com.apple.container"
     private static let launchdDomainString = try! ServiceManager.getDomainString()
+    private static let logTailReadChunkSize = UInt64(32 * 1024)
 
     private let log: Logger
     private let debugHelpers: Bool
@@ -780,6 +781,24 @@ public actor ContainersService {
         guard options.tail != nil || options.since != nil || options.until != nil else {
             return handle
         }
+        if let tail = options.tail, options.since == nil, options.until == nil {
+            guard tail >= 0 else {
+                return handle
+            }
+
+            do {
+                let data = try Self.tailLogData(from: handle, lineCount: tail)
+                guard let filteredHandle = Self.temporaryFileHandle(containing: data) else {
+                    try? handle.seek(toOffset: 0)
+                    return handle
+                }
+                try? handle.close()
+                return filteredHandle
+            } catch {
+                try? handle.seek(toOffset: 0)
+                return handle
+            }
+        }
         guard let data = try? handle.readToEnd() else {
             return handle
         }
@@ -790,6 +809,45 @@ public actor ContainersService {
         }
         try? handle.close()
         return filteredHandle
+    }
+
+    static func tailLogData(from handle: FileHandle, lineCount: Int) throws -> Data {
+        guard lineCount != 0 else {
+            return Data()
+        }
+        guard lineCount > 0 else {
+            try handle.seek(toOffset: 0)
+            return handle.readDataToEndOfFile()
+        }
+
+        var buffer = Data()
+        try prependTailData(from: handle, lineCount: lineCount, into: &buffer)
+        return filteredLogData(buffer, options: ContainerLogOptions(tail: lineCount))
+    }
+
+    private static func prependTailData(
+        from handle: FileHandle,
+        lineCount: Int,
+        into buffer: inout Data
+    ) throws {
+        var offset = try handle.seekToEnd()
+        while offset > 0, countedLogLines(in: buffer) <= lineCount {
+            let readSize = min(logTailReadChunkSize, offset)
+            offset -= readSize
+            try handle.seek(toOffset: offset)
+            buffer.insert(contentsOf: handle.readData(ofLength: Int(readSize)), at: 0)
+        }
+    }
+
+    private static func countedLogLines(in data: Data) -> Int {
+        guard !data.isEmpty else {
+            return 0
+        }
+
+        let separatorCount = data.reduce(0) { count, byte in
+            byte == LogByte.lineFeed ? count + 1 : count
+        }
+        return data.last == LogByte.lineFeed ? separatorCount : separatorCount + 1
     }
 
     static func filteredLogData(_ data: Data, options: ContainerLogOptions) -> Data {

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -880,18 +880,16 @@ public actor ContainersService {
 
         let timestampParser = LogTimestampParser()
         var result = Data()
-        var retainedTail: [LogDataLine] = []
+        let tailLimit = options.tail ?? -1
+        var retainedTail = LogTailBuffer(capacity: tailLimit)
         var current = Data()
 
         func appendIncludedLine(_ line: LogDataLine) throws {
             guard try shouldIncludeLogLine(line, options: options, timestampParser: timestampParser) else {
                 return
             }
-            if let tail = options.tail, tail > 0 {
+            if tailLimit > 0 {
                 retainedTail.append(line)
-                if retainedTail.count > tail {
-                    retainedTail.removeFirst(retainedTail.count - tail)
-                }
             } else {
                 appendLogLine(line, to: &result)
             }
@@ -915,8 +913,8 @@ public actor ContainersService {
             try appendIncludedLine(LogDataLine(data: current, terminated: false))
         }
 
-        if let tail = options.tail, tail > 0 {
-            return joinedLogData(retainedTail)
+        if tailLimit > 0 {
+            return joinedLogData(retainedTail.lines)
         }
         return result
     }
@@ -1043,6 +1041,46 @@ public actor ContainersService {
     private struct LogDataLine {
         var data: Data
         var terminated: Bool
+    }
+
+    /// Fixed-size tail retention for filtered replay.
+    ///
+    /// The service can scan large log files when `tail` is combined with time
+    /// filters. A ring buffer avoids repeated `removeFirst` reindexing while
+    /// preserving the caller-visible order of the retained lines.
+    private struct LogTailBuffer {
+        private let capacity: Int
+        private var storage: [LogDataLine] = []
+        private var nextIndex = 0
+
+        init(capacity: Int) {
+            self.capacity = max(capacity, 0)
+            self.storage.reserveCapacity(self.capacity)
+        }
+
+        mutating func append(_ line: LogDataLine) {
+            guard capacity > 0 else {
+                return
+            }
+
+            if storage.count < capacity {
+                storage.append(line)
+                return
+            }
+
+            storage[nextIndex] = line
+            nextIndex = (nextIndex + 1) % capacity
+        }
+
+        var lines: [LogDataLine] {
+            guard storage.count == capacity, nextIndex != 0 else {
+                return storage
+            }
+
+            let oldestSegment = Array(storage[nextIndex..<storage.endIndex])
+            let newestSegment = Array(storage[storage.startIndex..<nextIndex])
+            return oldestSegment + newestSegment
+        }
     }
 
     private enum LogByte {

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -805,8 +805,7 @@ public actor ContainersService {
             try? handle.close()
             return filteredHandle
         }
-        let data = try handle.readToEnd() ?? Data()
-        let filtered = Self.filteredLogData(data, options: options)
+        let filtered = try Self.filteredLogData(from: handle, options: options)
         let filteredHandle = try Self.temporaryFileHandle(containing: filtered, in: temporaryDirectory)
         try? handle.close()
         return filteredHandle
@@ -823,7 +822,7 @@ public actor ContainersService {
 
         var buffer = Data()
         try prependTailData(from: handle, lineCount: lineCount, into: &buffer)
-        return filteredLogData(buffer, options: ContainerLogOptions(tail: lineCount))
+        return try filteredLogData(buffer, options: ContainerLogOptions(tail: lineCount))
     }
 
     private static func prependTailData(
@@ -851,25 +850,15 @@ public actor ContainersService {
         return data.last == LogByte.lineFeed ? separatorCount : separatorCount + 1
     }
 
-    static func filteredLogData(_ data: Data, options: ContainerLogOptions) -> Data {
+    static func filteredLogData(_ data: Data, options: ContainerLogOptions) throws -> Data {
         guard !data.isEmpty else {
             return Data()
         }
 
         var lines = logDataLines(data)
-
         let timestampParser = LogTimestampParser()
-        lines = lines.filter { line in
-            guard let timestamp = timestampParser.timestampPrefix(from: line.data) else {
-                return true
-            }
-            if let since = options.since, timestamp < since {
-                return false
-            }
-            if let until = options.until, timestamp > until {
-                return false
-            }
-            return true
+        lines = try lines.filter { line in
+            try shouldIncludeLogLine(line, options: options, timestampParser: timestampParser)
         }
 
         if let tail = options.tail, tail >= 0 {
@@ -880,6 +869,77 @@ public actor ContainersService {
         }
 
         return joinedLogData(lines)
+    }
+
+    private static func filteredLogData(from handle: FileHandle, options: ContainerLogOptions) throws -> Data {
+        if options.tail == 0 {
+            return Data()
+        }
+
+        let timestampParser = LogTimestampParser()
+        var result = Data()
+        var retainedTail: [LogDataLine] = []
+        var current = Data()
+
+        func appendIncludedLine(_ line: LogDataLine) throws {
+            guard try shouldIncludeLogLine(line, options: options, timestampParser: timestampParser) else {
+                return
+            }
+            if let tail = options.tail, tail > 0 {
+                retainedTail.append(line)
+                if retainedTail.count > tail {
+                    retainedTail.removeFirst(retainedTail.count - tail)
+                }
+            } else {
+                appendLogLine(line, to: &result)
+            }
+        }
+
+        while true {
+            let chunk = handle.readData(ofLength: Int(logTailReadChunkSize))
+            if chunk.isEmpty {
+                break
+            }
+            for byte in chunk {
+                if byte == LogByte.lineFeed {
+                    try appendIncludedLine(LogDataLine(data: current, terminated: true))
+                    current.removeAll(keepingCapacity: true)
+                } else {
+                    current.append(byte)
+                }
+            }
+        }
+        if !current.isEmpty {
+            try appendIncludedLine(LogDataLine(data: current, terminated: false))
+        }
+
+        if let tail = options.tail, tail > 0 {
+            return joinedLogData(retainedTail)
+        }
+        return result
+    }
+
+    private static func shouldIncludeLogLine(
+        _ line: LogDataLine,
+        options: ContainerLogOptions,
+        timestampParser: LogTimestampParser
+    ) throws -> Bool {
+        guard let timestamp = timestampParser.timestampPrefix(from: line.data) else {
+            guard (options.since == nil && options.until == nil) || line.data.isEmpty else {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "cannot apply timestamp filters to container logs without timestamp prefixes"
+                )
+            }
+            return true
+        }
+        if let since = options.since, timestamp < since {
+            return false
+        }
+        if let until = options.until, timestamp > until {
+            return false
+        }
+        return true
     }
 
     private static func temporaryFileHandle(
@@ -969,6 +1029,13 @@ public actor ContainersService {
             }
         }
         return result
+    }
+
+    private static func appendLogLine(_ line: LogDataLine, to data: inout Data) {
+        data.append(line.data)
+        if line.terminated {
+            data.append(LogByte.lineFeed)
+        }
     }
 
     private struct LogDataLine {

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -27,7 +27,6 @@ import ContainerizationError
 import ContainerizationExtras
 import ContainerizationOCI
 import ContainerizationOS
-import Darwin
 import Foundation
 import Logging
 import SystemPackage
@@ -730,10 +729,12 @@ public actor ContainersService {
         try await client.resize(processID, size: size)
     }
 
+    /// Get the logs for the container.
     public func logs(id: String) async throws -> [FileHandle] {
         try await logs(id: id, options: .default)
     }
 
+    /// Get the logs for the container.
     public func logs(id: String, options: ContainerLogOptions) async throws -> [FileHandle] {
         log.debug(
             "ContainersService: enter",
@@ -752,27 +753,156 @@ public actor ContainersService {
             )
         }
 
+        // Logs doesn't care if the container is running or not, just that
+        // the bundle is there, and that the files actually exist. We do
+        // first try and get the container state so we get a nicer error message
+        // (container foo not found) however.
         do {
             _ = try _getContainerState(id: id)
             let path = self.containerRoot.appendingPathComponent(id)
             let bundle = ContainerResource.Bundle(path: path)
-            var handles = [
+            let handles = [
                 try FileHandle(forReadingFrom: bundle.containerLog),
                 try FileHandle(forReadingFrom: bundle.bootlog),
             ]
-
-            if let since = options.since {
-                handles = handles.map { fh in
-                    Self.filterFileHandleSince(fh, since: since)
-                }
+            return handles.map { handle in
+                Self.applyLogOptions(to: handle, options: options)
             }
-
-            return handles
         } catch {
             throw ContainerizationError(
                 .internalError,
                 message: "failed to open container logs: \(error)"
             )
+        }
+    }
+
+    static func applyLogOptions(to handle: FileHandle, options: ContainerLogOptions) -> FileHandle {
+        guard options.tail != nil || options.since != nil || options.until != nil else {
+            return handle
+        }
+        guard let data = try? handle.readToEnd() else {
+            return handle
+        }
+        let filtered = Self.filteredLogData(data, options: options)
+        guard let filteredHandle = Self.temporaryFileHandle(containing: filtered) else {
+            try? handle.seek(toOffset: 0)
+            return handle
+        }
+        try? handle.close()
+        return filteredHandle
+    }
+
+    static func filteredLogData(_ data: Data, options: ContainerLogOptions) -> Data {
+        guard !data.isEmpty else {
+            return Data()
+        }
+
+        var lines = logDataLines(data)
+
+        let timestampParser = LogTimestampParser()
+        lines = lines.filter { line in
+            guard let timestamp = timestampParser.timestampPrefix(from: line.data) else {
+                return true
+            }
+            if let since = options.since, timestamp < since {
+                return false
+            }
+            if let until = options.until, timestamp > until {
+                return false
+            }
+            return true
+        }
+
+        if let tail = options.tail, tail >= 0 {
+            if tail == 0 {
+                return Data()
+            }
+            lines = Array(lines.suffix(tail))
+        }
+
+        return joinedLogData(lines)
+    }
+
+    private static func temporaryFileHandle(containing data: Data) -> FileHandle? {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("container-log-\(UUID().uuidString)")
+        do {
+            try data.write(to: url)
+            let handle = try FileHandle(forReadingFrom: url)
+            try? FileManager.default.removeItem(at: url)
+            return handle
+        } catch {
+            try? FileManager.default.removeItem(at: url)
+            return nil
+        }
+    }
+
+    private static func logDataLines(_ data: Data) -> [LogDataLine] {
+        var lines: [LogDataLine] = []
+        var current = Data()
+
+        for byte in data {
+            if byte == LogByte.lineFeed {
+                lines.append(LogDataLine(data: current, terminated: true))
+                current.removeAll()
+            } else {
+                current.append(byte)
+            }
+        }
+        if !current.isEmpty {
+            lines.append(LogDataLine(data: current, terminated: false))
+        }
+        return lines
+    }
+
+    private static func joinedLogData(_ lines: [LogDataLine]) -> Data {
+        var result = Data()
+        for (index, line) in lines.enumerated() {
+            result.append(line.data)
+            if line.terminated || index < lines.count - 1 {
+                result.append(LogByte.lineFeed)
+            }
+        }
+        return result
+    }
+
+    private struct LogDataLine {
+        var data: Data
+        var terminated: Bool
+    }
+
+    private enum LogByte {
+        static let lineFeed = UInt8(ascii: "\n")
+    }
+
+    private struct LogTimestampParser {
+        private let fractionalFormatter: ISO8601DateFormatter
+        private let formatter: ISO8601DateFormatter
+
+        init() {
+            let fractionalFormatter = ISO8601DateFormatter()
+            fractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            self.fractionalFormatter = fractionalFormatter
+
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime]
+            self.formatter = formatter
+        }
+
+        func timestampPrefix(from line: Data) -> Date? {
+            let token = Data(line.prefix { $0 != UInt8(ascii: " ") })
+            guard let timestamp = String(data: token, encoding: .utf8) else {
+                return nil
+            }
+            return timestampPrefix(fromTimestampToken: timestamp)
+        }
+
+        private func timestampPrefix(fromTimestampToken timestamp: String) -> Date? {
+            if let date = fractionalFormatter.date(from: timestamp) {
+                return date
+            }
+
+            return formatter.date(from: timestamp)
         }
     }
 
@@ -798,92 +928,6 @@ public actor ContainersService {
         }
         let client = try state.getClient()
         try await client.copyOut(source: source, destination: destination, createParents: createParents)
-    }
-
-    static func filterFileHandleSince(_ fh: FileHandle, since: Date) -> FileHandle {
-        guard let data = try? fh.readToEnd() else {
-            return fh
-        }
-        guard let result = Self.filteredLogData(data, since: since) else {
-            try? fh.seek(toOffset: 0)
-            return fh
-        }
-
-        if let filteredHandle = Self.temporaryFileHandle(containing: result) {
-            return filteredHandle
-        }
-        try? fh.seek(toOffset: 0)
-        return fh
-    }
-
-    static func filteredLogData(_ data: Data, since: Date) -> Data? {
-        guard let content = String(data: data, encoding: .utf8) else {
-            return nil
-        }
-
-        let iso8601 = ISO8601DateFormatter()
-        iso8601.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        let fallbackFormatter = ISO8601DateFormatter()
-        fallbackFormatter.formatOptions = [.withInternetDateTime]
-
-        let lines = content.components(separatedBy: "\n")
-        var filtered: [String] = []
-        for line in lines {
-            guard !line.isEmpty else {
-                filtered.append(line)
-                continue
-            }
-            let parts = line.split(separator: " ", maxSplits: 1)
-            guard let timestampStr = parts.first else {
-                filtered.append(line)
-                continue
-            }
-            if let date = iso8601.date(from: String(timestampStr)) ?? fallbackFormatter.date(from: String(timestampStr)) {
-                if date >= since {
-                    filtered.append(line)
-                }
-            } else {
-                filtered.append(line)
-            }
-        }
-
-        let result = filtered.joined(separator: "\n")
-        return result.data(using: .utf8)
-    }
-
-    private static func temporaryFileHandle(containing data: Data) -> FileHandle? {
-        let url = FileManager.default.temporaryDirectory.appendingPathComponent("container-log-filter-")
-            .appendingPathExtension(UUID().uuidString)
-        let fd = open(url.path, O_CREAT | O_EXCL | O_RDWR, S_IRUSR | S_IWUSR)
-        guard fd >= 0 else {
-            return nil
-        }
-
-        let success = data.withUnsafeBytes { buffer in
-            guard let baseAddress = buffer.baseAddress else {
-                return true
-            }
-            var remaining = buffer.count
-            var pointer = baseAddress
-            while remaining > 0 {
-                let written = write(fd, pointer, remaining)
-                guard written > 0 else {
-                    return false
-                }
-                remaining -= written
-                pointer += written
-            }
-            return true
-        }
-
-        guard success, lseek(fd, 0, SEEK_SET) >= 0 else {
-            close(fd)
-            try? FileManager.default.removeItem(at: url)
-            return nil
-        }
-
-        try? FileManager.default.removeItem(at: url)
-        return FileHandle(fileDescriptor: fd, closeOnDealloc: true)
     }
 
     /// Get statistics for the container.

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -779,6 +779,8 @@ public actor ContainersService {
                 }
                 throw error
             }
+        } catch let error as ContainerizationError {
+            throw error
         } catch {
             throw ContainerizationError(
                 .internalError,

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -98,6 +98,18 @@ struct ContainerLogsTests {
         #expect(data.isEmpty)
     }
 
+    @Test func tailZeroDoesNotParseTimestampFilters() throws {
+        let data = try ContainersService.filteredLogData(
+            Data("application log without timestamp\n".utf8),
+            options: ContainerLogOptions(
+                tail: 0,
+                since: date("2026-01-01T00:00:00Z")
+            )
+        )
+
+        #expect(data.isEmpty)
+    }
+
     @Test func negativeTailDoesNotDropLogs() throws {
         let content = """
             2026-01-01T00:00:00Z old

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -168,6 +168,37 @@ struct ContainerLogsTests {
         #expect(String(data: data, encoding: .utf8) == "\(longLine)\ntwo\n")
     }
 
+    @Test func filteredHandleRetainsTailInOrderAfterTimeFilters() throws {
+        let content = """
+            2026-01-01T00:00:00Z one
+            2026-01-02T00:00:00Z two
+            2026-01-03T00:00:00Z three
+            2026-01-04T00:00:00Z four
+            2026-01-05T00:00:00Z five
+
+            """
+        let handle = try fileHandle(containing: Data(content.utf8))
+        let filtered = try ContainersService.applyLogOptions(
+            to: handle,
+            options: ContainerLogOptions(
+                tail: 3,
+                since: date("2026-01-01T00:00:00Z")
+            )
+        )
+        defer { try? filtered.close() }
+
+        let data = try filtered.readToEnd() ?? Data()
+
+        #expect(
+            String(data: data, encoding: .utf8) == """
+                2026-01-03T00:00:00Z three
+                2026-01-04T00:00:00Z four
+                2026-01-05T00:00:00Z five
+
+                """
+        )
+    }
+
     @Test func harnessDecodesLogOptions() {
         let message = XPCMessage(route: .containerLogs)
         let since = Date(timeIntervalSince1970: 0)

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -94,10 +94,39 @@ struct ContainerLogsTests {
         let bytes = Data([0xff, 0xfe, 0x0a, 0x41, 0x0a])
         let handle = try fileHandle(containing: bytes)
 
-        let filtered = ContainersService.applyLogOptions(to: handle, options: ContainerLogOptions(tail: 1))
+        let filtered = try ContainersService.applyLogOptions(to: handle, options: ContainerLogOptions(tail: 1))
         let data = try #require(try filtered.readToEnd())
 
         #expect(data == Data([0x41, 0x0a]))
+    }
+
+    @Test func filteredHandleCreationFailureThrows() throws {
+        let handle = try fileHandle(containing: Data("one\ntwo\n".utf8))
+        defer { try? handle.close() }
+        let blockedDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("container-log-test-\(UUID().uuidString)")
+        try Data("not a directory".utf8).write(to: blockedDirectory)
+        defer { try? FileManager.default.removeItem(at: blockedDirectory) }
+
+        #expect(throws: Error.self) {
+            _ = try ContainersService.applyLogOptions(
+                to: handle,
+                options: ContainerLogOptions(tail: 1),
+                temporaryDirectory: blockedDirectory
+            )
+        }
+    }
+
+    @Test func emptyLogsApplyTimeFiltersWithoutThrowing() throws {
+        let handle = try fileHandle(containing: Data())
+
+        let filtered = try ContainersService.applyLogOptions(
+            to: handle,
+            options: ContainerLogOptions(since: date("2026-01-01T00:00:00Z"))
+        )
+        let data = try filtered.readToEnd() ?? Data()
+
+        #expect(data.isEmpty)
     }
 
     @Test func boundedTailPreservesLongLogicalLine() throws {

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -65,6 +65,19 @@ struct ContainerLogsTests {
         }
     }
 
+    @Test func timeFiltersRejectBlankApplicationLines() throws {
+        let content = "2026-01-01T00:00:00Z old\n\n2026-01-03T00:00:00Z retained\n"
+
+        #expect {
+            _ = try ContainersService.filteredLogData(Data(content.utf8), options: ContainerLogOptions(since: date("2026-01-02T00:00:00Z")))
+        } throws: { error in
+            guard let error = error as? ContainerizationError else {
+                return false
+            }
+            return error.code == .invalidArgument
+        }
+    }
+
     @Test func tailOnlyPreservesUnparseableLinesEmptyLinesAndTrailingNewline() throws {
         let content = "unparseable\n\nretained\n"
 
@@ -199,7 +212,34 @@ struct ContainerLogsTests {
         )
     }
 
-    @Test func harnessDecodesLogOptions() {
+    @Test func filtersOnlySelectedLogStream() throws {
+        let stdioHandle = try fileHandle(containing: Data("2026-01-01T00:00:00Z old\n2026-01-03T00:00:00Z retained\n".utf8))
+        let bootHandle = try fileHandle(containing: Data("boot log without timestamp\n".utf8))
+
+        let handles = try ContainersService.applyLogOptions(
+            to: [
+                ContainersService.LogHandle(stream: .stdio, handle: stdioHandle),
+                ContainersService.LogHandle(stream: .boot, handle: bootHandle),
+            ],
+            options: ContainerLogOptions(
+                since: date("2026-01-02T00:00:00Z"),
+                stream: .stdio
+            )
+        )
+        defer {
+            for handle in handles {
+                try? handle.close()
+            }
+        }
+
+        let stdioData = try #require(try handles[0].readToEnd())
+        let bootData = try #require(try handles[1].readToEnd())
+
+        #expect(String(data: stdioData, encoding: .utf8) == "2026-01-03T00:00:00Z retained\n")
+        #expect(String(data: bootData, encoding: .utf8) == "boot log without timestamp\n")
+    }
+
+    @Test func harnessDecodesLogOptions() throws {
         let message = XPCMessage(route: .containerLogs)
         let since = Date(timeIntervalSince1970: 0)
         let until = Date(timeIntervalSince1970: -1)
@@ -207,24 +247,41 @@ struct ContainerLogsTests {
         message.set(key: .logSince, value: since)
         message.set(key: .logUntil, value: until)
         message.set(key: .logTimestamps, value: true)
+        message.set(key: .logStream, value: ContainerLogStream.boot.rawValue)
 
-        let options = ContainersHarness.logOptions(from: message)
+        let options = try ContainersHarness.logOptions(from: message)
 
         #expect(options.tail == 0)
         #expect(options.since == since)
         #expect(options.until == until)
         #expect(options.timestamps)
+        #expect(options.stream == .boot)
     }
 
-    @Test func harnessLeavesAbsentLogOptionsUnset() {
+    @Test func harnessLeavesAbsentLogOptionsUnset() throws {
         let message = XPCMessage(route: .containerLogs)
 
-        let options = ContainersHarness.logOptions(from: message)
+        let options = try ContainersHarness.logOptions(from: message)
 
         #expect(options.tail == nil)
         #expect(options.since == nil)
         #expect(options.until == nil)
         #expect(!options.timestamps)
+        #expect(options.stream == nil)
+    }
+
+    @Test func harnessRejectsInvalidLogStream() {
+        let message = XPCMessage(route: .containerLogs)
+        message.set(key: .logStream, value: "invalid")
+
+        #expect {
+            _ = try ContainersHarness.logOptions(from: message)
+        } throws: { error in
+            guard let error = error as? ContainerizationError else {
+                return false
+            }
+            return error.code == .invalidArgument
+        }
     }
 
     private func fileHandle(containing data: Data) throws -> FileHandle {

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -100,6 +100,15 @@ struct ContainerLogsTests {
         #expect(data == Data([0x41, 0x0a]))
     }
 
+    @Test func boundedTailPreservesLongLogicalLine() throws {
+        let longLine = String(repeating: "x", count: 40_000)
+        let handle = try fileHandle(containing: Data("old\n\(longLine)\ntwo\n".utf8))
+
+        let data = try ContainersService.tailLogData(from: handle, lineCount: 2)
+
+        #expect(String(data: data, encoding: .utf8) == "\(longLine)\ntwo\n")
+    }
+
     @Test func harnessDecodesLogOptions() {
         let message = XPCMessage(route: .containerLogs)
         let since = Date(timeIntervalSince1970: 0)

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerAPIClient
+@testable import ContainerAPIService
+import ContainerXPC
+import Foundation
+import Testing
+
+struct ContainerLogsTests {
+
+    @Test("Log filtering can return output larger than a pipe buffer")
+    func testFilterLargeOutput() throws {
+        let since = Date(timeIntervalSince1970: 1_700_000_000)
+        let line = "2027-01-01T00:00:00Z retained log line with enough bytes to grow the output\n"
+        let content = String(repeating: line, count: 2_000)
+        let handle = try fileHandle(containing: Data(content.utf8))
+
+        let filtered = ContainersService.filterFileHandleSince(handle, since: since)
+        let data = try #require(try filtered.readToEnd())
+
+        #expect(data == Data(content.utf8))
+    }
+
+    @Test("Log filtering preserves empty lines and trailing newline")
+    func testFilterPreservesEmptyLinesAndTrailingNewline() throws {
+        let since = Date(timeIntervalSince1970: 1_700_000_000)
+        let content = "2020-01-01T00:00:00Z old\n\n2027-01-01T00:00:00Z new\n"
+        let expected = "\n2027-01-01T00:00:00Z new\n"
+
+        let data = try #require(ContainersService.filteredLogData(Data(content.utf8), since: since))
+
+        #expect(String(data: data, encoding: .utf8) == expected)
+    }
+
+    @Test("Non-UTF8 logs fall back to the original bytes")
+    func testNonUTF8LogsReturnOriginalBytes() throws {
+        let bytes = Data([0xff, 0xfe, 0x00, 0x41])
+        let handle = try fileHandle(containing: bytes)
+
+        let filtered = ContainersService.filterFileHandleSince(handle, since: Date())
+        let data = try #require(try filtered.readToEnd())
+
+        #expect(data == bytes)
+    }
+
+    @Test("Harness preserves explicit epoch log since option")
+    func testHarnessPreservesEpochSince() {
+        let message = XPCMessage(route: .containerLogs)
+        let epoch = Date(timeIntervalSince1970: 0)
+        message.set(key: .logSince, value: epoch)
+
+        let options = ContainersHarness.logOptions(from: message)
+
+        #expect(options.since == epoch)
+    }
+
+    @Test("Harness preserves explicit pre-epoch log since option")
+    func testHarnessPreservesPreEpochSince() {
+        let message = XPCMessage(route: .containerLogs)
+        let preEpoch = Date(timeIntervalSince1970: -1)
+        message.set(key: .logSince, value: preEpoch)
+
+        let options = ContainersHarness.logOptions(from: message)
+
+        #expect(options.since == preEpoch)
+    }
+
+    @Test("Harness leaves absent log since option unset")
+    func testHarnessLeavesAbsentSinceUnset() {
+        let message = XPCMessage(route: .containerLogs)
+        message.set(key: .logTimestamps, value: true)
+
+        let options = ContainersHarness.logOptions(from: message)
+
+        #expect(options.since == nil)
+        #expect(options.timestamps)
+    }
+
+    private func fileHandle(containing data: Data) throws -> FileHandle {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("container-log-test-")
+            .appendingPathExtension(UUID().uuidString)
+        try data.write(to: url)
+        let handle = try FileHandle(forReadingFrom: url)
+        try? FileManager.default.removeItem(at: url)
+        return handle
+    }
+}

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -95,6 +95,7 @@ struct ContainerLogsTests {
         let handle = try fileHandle(containing: bytes)
 
         let filtered = try ContainersService.applyLogOptions(to: handle, options: ContainerLogOptions(tail: 1))
+        defer { try? filtered.close() }
         let data = try #require(try filtered.readToEnd())
 
         #expect(data == Data([0x41, 0x0a]))
@@ -124,6 +125,7 @@ struct ContainerLogsTests {
             to: handle,
             options: ContainerLogOptions(since: date("2026-01-01T00:00:00Z"))
         )
+        defer { try? filtered.close() }
         let data = try filtered.readToEnd() ?? Data()
 
         #expect(data.isEmpty)
@@ -132,6 +134,7 @@ struct ContainerLogsTests {
     @Test func boundedTailPreservesLongLogicalLine() throws {
         let longLine = String(repeating: "x", count: 40_000)
         let handle = try fileHandle(containing: Data("old\n\(longLine)\ntwo\n".utf8))
+        defer { try? handle.close() }
 
         let data = try ContainersService.tailLogData(from: handle, lineCount: 2)
 

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -17,6 +17,7 @@
 import ContainerAPIClient
 import ContainerResource
 import ContainerXPC
+import ContainerizationError
 import Foundation
 import Testing
 
@@ -54,8 +55,13 @@ struct ContainerLogsTests {
             since: date("2026-01-02T00:00:00Z")
         )
 
-        #expect(throws: Error.self) {
+        #expect {
             _ = try ContainersService.filteredLogData(Data(content.utf8), options: options)
+        } throws: { error in
+            guard let error = error as? ContainerizationError else {
+                return false
+            }
+            return error.code == .invalidArgument
         }
     }
 
@@ -112,8 +118,13 @@ struct ContainerLogsTests {
     @Test func nonUTF8LogsRejectTimeFilters() throws {
         let bytes = Data([0xff, 0xfe, 0x0a, 0x41, 0x0a])
 
-        #expect(throws: Error.self) {
+        #expect {
             _ = try ContainersService.filteredLogData(bytes, options: ContainerLogOptions(since: date("2026-01-01T00:00:00Z")))
+        } throws: { error in
+            guard let error = error as? ContainerizationError else {
+                return false
+            }
+            return error.code == .invalidArgument
         }
     }
 

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -37,12 +37,12 @@ struct ContainerLogsTests {
             until: date("2026-01-03T00:00:00Z")
         )
 
-        let data = ContainersService.filteredLogData(Data(content.utf8), options: options)
+        let data = try ContainersService.filteredLogData(Data(content.utf8), options: options)
 
         #expect(String(data: data, encoding: .utf8) == "2026-01-03T00:00:00Z second\n")
     }
 
-    @Test func preservesUnparseableLinesEmptyLinesAndTrailingNewline() throws {
+    @Test func timeFiltersRejectUnparseableLines() throws {
         let content = """
             2026-01-01T00:00:00Z old
             unparseable
@@ -54,9 +54,17 @@ struct ContainerLogsTests {
             since: date("2026-01-02T00:00:00Z")
         )
 
-        let data = ContainersService.filteredLogData(Data(content.utf8), options: options)
+        #expect(throws: Error.self) {
+            _ = try ContainersService.filteredLogData(Data(content.utf8), options: options)
+        }
+    }
 
-        #expect(String(data: data, encoding: .utf8) == "unparseable\n\n2026-01-03T00:00:00Z retained\n")
+    @Test func tailOnlyPreservesUnparseableLinesEmptyLinesAndTrailingNewline() throws {
+        let content = "unparseable\n\nretained\n"
+
+        let data = try ContainersService.filteredLogData(Data(content.utf8), options: ContainerLogOptions(tail: -1))
+
+        #expect(String(data: data, encoding: .utf8) == content)
     }
 
     @Test func tailZeroReturnsEmptyLogData() throws {
@@ -66,7 +74,7 @@ struct ContainerLogsTests {
 
             """
 
-        let data = ContainersService.filteredLogData(Data(content.utf8), options: ContainerLogOptions(tail: 0))
+        let data = try ContainersService.filteredLogData(Data(content.utf8), options: ContainerLogOptions(tail: 0))
 
         #expect(data.isEmpty)
     }
@@ -78,14 +86,14 @@ struct ContainerLogsTests {
 
             """
 
-        let data = ContainersService.filteredLogData(Data(content.utf8), options: ContainerLogOptions(tail: -1))
+        let data = try ContainersService.filteredLogData(Data(content.utf8), options: ContainerLogOptions(tail: -1))
 
         #expect(String(data: data, encoding: .utf8) == content)
     }
 
     @Test func nonUTF8LogsCanBeTailedWithoutDecoding() throws {
         let bytes = Data([0xff, 0xfe, 0x0a, 0x41, 0x0a])
-        let data = ContainersService.filteredLogData(bytes, options: ContainerLogOptions(tail: 1))
+        let data = try ContainersService.filteredLogData(bytes, options: ContainerLogOptions(tail: 1))
 
         #expect(data == Data([0x41, 0x0a]))
     }
@@ -99,6 +107,14 @@ struct ContainerLogsTests {
         let data = try #require(try filtered.readToEnd())
 
         #expect(data == Data([0x41, 0x0a]))
+    }
+
+    @Test func nonUTF8LogsRejectTimeFilters() throws {
+        let bytes = Data([0xff, 0xfe, 0x0a, 0x41, 0x0a])
+
+        #expect(throws: Error.self) {
+            _ = try ContainersService.filteredLogData(bytes, options: ContainerLogOptions(since: date("2026-01-01T00:00:00Z")))
+        }
     }
 
     @Test func filteredHandleCreationFailureThrows() throws {

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -15,87 +15,131 @@
 //===----------------------------------------------------------------------===//
 
 import ContainerAPIClient
-@testable import ContainerAPIService
+import ContainerResource
 import ContainerXPC
 import Foundation
 import Testing
 
+@testable import ContainerAPIService
+
 struct ContainerLogsTests {
+    @Test func filtersLogsBySinceUntilAndTail() throws {
+        let content = """
+            2026-01-01T00:00:00Z old
+            2026-01-02T00:00:00Z first
+            2026-01-03T00:00:00Z second
+            2026-01-04T00:00:00Z new
 
-    @Test("Log filtering can return output larger than a pipe buffer")
-    func testFilterLargeOutput() throws {
-        let since = Date(timeIntervalSince1970: 1_700_000_000)
-        let line = "2027-01-01T00:00:00Z retained log line with enough bytes to grow the output\n"
-        let content = String(repeating: line, count: 2_000)
-        let handle = try fileHandle(containing: Data(content.utf8))
+            """
+        let options = ContainerLogOptions(
+            tail: 1,
+            since: date("2026-01-02T00:00:00Z"),
+            until: date("2026-01-03T00:00:00Z")
+        )
 
-        let filtered = ContainersService.filterFileHandleSince(handle, since: since)
-        let data = try #require(try filtered.readToEnd())
+        let data = ContainersService.filteredLogData(Data(content.utf8), options: options)
 
-        #expect(data == Data(content.utf8))
+        #expect(String(data: data, encoding: .utf8) == "2026-01-03T00:00:00Z second\n")
     }
 
-    @Test("Log filtering preserves empty lines and trailing newline")
-    func testFilterPreservesEmptyLinesAndTrailingNewline() throws {
-        let since = Date(timeIntervalSince1970: 1_700_000_000)
-        let content = "2020-01-01T00:00:00Z old\n\n2027-01-01T00:00:00Z new\n"
-        let expected = "\n2027-01-01T00:00:00Z new\n"
+    @Test func preservesUnparseableLinesEmptyLinesAndTrailingNewline() throws {
+        let content = """
+            2026-01-01T00:00:00Z old
+            unparseable
 
-        let data = try #require(ContainersService.filteredLogData(Data(content.utf8), since: since))
+            2026-01-03T00:00:00Z retained
 
-        #expect(String(data: data, encoding: .utf8) == expected)
+            """
+        let options = ContainerLogOptions(
+            since: date("2026-01-02T00:00:00Z")
+        )
+
+        let data = ContainersService.filteredLogData(Data(content.utf8), options: options)
+
+        #expect(String(data: data, encoding: .utf8) == "unparseable\n\n2026-01-03T00:00:00Z retained\n")
     }
 
-    @Test("Non-UTF8 logs fall back to the original bytes")
-    func testNonUTF8LogsReturnOriginalBytes() throws {
-        let bytes = Data([0xff, 0xfe, 0x00, 0x41])
+    @Test func tailZeroReturnsEmptyLogData() throws {
+        let content = """
+            2026-01-01T00:00:00Z old
+            2026-01-02T00:00:00Z new
+
+            """
+
+        let data = ContainersService.filteredLogData(Data(content.utf8), options: ContainerLogOptions(tail: 0))
+
+        #expect(data.isEmpty)
+    }
+
+    @Test func negativeTailDoesNotDropLogs() throws {
+        let content = """
+            2026-01-01T00:00:00Z old
+            2026-01-02T00:00:00Z new
+
+            """
+
+        let data = ContainersService.filteredLogData(Data(content.utf8), options: ContainerLogOptions(tail: -1))
+
+        #expect(String(data: data, encoding: .utf8) == content)
+    }
+
+    @Test func nonUTF8LogsCanBeTailedWithoutDecoding() throws {
+        let bytes = Data([0xff, 0xfe, 0x0a, 0x41, 0x0a])
+        let data = ContainersService.filteredLogData(bytes, options: ContainerLogOptions(tail: 1))
+
+        #expect(data == Data([0x41, 0x0a]))
+    }
+
+    @Test func nonUTF8LogsApplyTailWhenOpeningFilteredHandle() throws {
+        let bytes = Data([0xff, 0xfe, 0x0a, 0x41, 0x0a])
         let handle = try fileHandle(containing: bytes)
 
-        let filtered = ContainersService.filterFileHandleSince(handle, since: Date())
+        let filtered = ContainersService.applyLogOptions(to: handle, options: ContainerLogOptions(tail: 1))
         let data = try #require(try filtered.readToEnd())
 
-        #expect(data == bytes)
+        #expect(data == Data([0x41, 0x0a]))
     }
 
-    @Test("Harness preserves explicit epoch log since option")
-    func testHarnessPreservesEpochSince() {
+    @Test func harnessDecodesLogOptions() {
         let message = XPCMessage(route: .containerLogs)
-        let epoch = Date(timeIntervalSince1970: 0)
-        message.set(key: .logSince, value: epoch)
-
-        let options = ContainersHarness.logOptions(from: message)
-
-        #expect(options.since == epoch)
-    }
-
-    @Test("Harness preserves explicit pre-epoch log since option")
-    func testHarnessPreservesPreEpochSince() {
-        let message = XPCMessage(route: .containerLogs)
-        let preEpoch = Date(timeIntervalSince1970: -1)
-        message.set(key: .logSince, value: preEpoch)
-
-        let options = ContainersHarness.logOptions(from: message)
-
-        #expect(options.since == preEpoch)
-    }
-
-    @Test("Harness leaves absent log since option unset")
-    func testHarnessLeavesAbsentSinceUnset() {
-        let message = XPCMessage(route: .containerLogs)
+        let since = Date(timeIntervalSince1970: 0)
+        let until = Date(timeIntervalSince1970: -1)
+        message.set(key: .logTail, value: Int64(0))
+        message.set(key: .logSince, value: since)
+        message.set(key: .logUntil, value: until)
         message.set(key: .logTimestamps, value: true)
 
         let options = ContainersHarness.logOptions(from: message)
 
-        #expect(options.since == nil)
+        #expect(options.tail == 0)
+        #expect(options.since == since)
+        #expect(options.until == until)
         #expect(options.timestamps)
     }
 
+    @Test func harnessLeavesAbsentLogOptionsUnset() {
+        let message = XPCMessage(route: .containerLogs)
+
+        let options = ContainersHarness.logOptions(from: message)
+
+        #expect(options.tail == nil)
+        #expect(options.since == nil)
+        #expect(options.until == nil)
+        #expect(!options.timestamps)
+    }
+
     private func fileHandle(containing data: Data) throws -> FileHandle {
-        let url = FileManager.default.temporaryDirectory.appendingPathComponent("container-log-test-")
-            .appendingPathExtension(UUID().uuidString)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("container-log-test-\(UUID().uuidString)")
         try data.write(to: url)
         let handle = try FileHandle(forReadingFrom: url)
         try? FileManager.default.removeItem(at: url)
         return handle
+    }
+
+    private func date(_ value: String) -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: value)!
     }
 }

--- a/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
+++ b/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
@@ -99,7 +99,9 @@ struct ContainerLogsCommandTests {
         _ = FileManager.default.createFile(atPath: outputURL.path, contents: nil)
 
         let inputHandle = try fileHandle(containing: Data("one\ntwo\n".utf8))
+        defer { try? inputHandle.close() }
         let outputHandle = try FileHandle(forWritingTo: outputURL)
+        defer { try? outputHandle.close() }
         try await LogFileOutput.write(fh: inputHandle, n: -1, follow: false, output: outputHandle)
         try outputHandle.close()
 
@@ -114,7 +116,9 @@ struct ContainerLogsCommandTests {
         let bytes = Data([0xff, 0xfe, 0x0a, 0x41, 0x0a])
 
         let inputHandle = try fileHandle(containing: bytes)
+        defer { try? inputHandle.close() }
         let outputHandle = try FileHandle(forWritingTo: outputURL)
+        defer { try? outputHandle.close() }
         try await LogFileOutput.write(fh: inputHandle, n: nil, follow: false, output: outputHandle)
         try outputHandle.close()
 

--- a/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
+++ b/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
@@ -47,6 +47,7 @@ struct ContainerLogsCommandTests {
         let options = Application.ContainerLogs.retrievalOptions(
             numLines: 25,
             follow: false,
+            boot: false,
             since: since,
             until: until
         )
@@ -54,6 +55,7 @@ struct ContainerLogsCommandTests {
         #expect(options.tail == 25)
         #expect(options.since == since.date)
         #expect(options.until == until.date)
+        #expect(options.stream == .stdio)
     }
 
     @Test
@@ -61,6 +63,7 @@ struct ContainerLogsCommandTests {
         let options = Application.ContainerLogs.retrievalOptions(
             numLines: 25,
             follow: true,
+            boot: false,
             since: nil,
             until: nil
         )
@@ -68,6 +71,20 @@ struct ContainerLogsCommandTests {
         #expect(options.tail == nil)
         #expect(options.since == nil)
         #expect(options.until == nil)
+        #expect(options.stream == .stdio)
+    }
+
+    @Test
+    func logOptionsSelectBootStream() {
+        let options = Application.ContainerLogs.retrievalOptions(
+            numLines: nil,
+            follow: false,
+            boot: true,
+            since: nil,
+            until: nil
+        )
+
+        #expect(options.stream == .boot)
     }
 
     @Test

--- a/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
+++ b/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
@@ -57,33 +57,35 @@ struct ContainerLogsCommandTests {
     }
 
     @Test
-    func logOptionsLeaveTailForLocalFollowHandling() throws {
-        let since = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00Z"))
-        let until = try #require(ContainerLogTimestamp(argument: "2026-06-18T11:00:00Z"))
+    func logOptionsLeaveTailForLocalFollowHandling() {
         let options = Application.ContainerLogs.retrievalOptions(
             numLines: 25,
             follow: true,
-            since: since,
-            until: until
+            since: nil,
+            until: nil
         )
 
         #expect(options.tail == nil)
-        #expect(options.since == since.date)
-        #expect(options.until == until.date)
+        #expect(options.since == nil)
+        #expect(options.until == nil)
     }
 
     @Test
-    func validateAcceptsFollowWithSince() throws {
+    func validateRejectsFollowWithSince() throws {
         let since = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00Z"))
 
-        try Application.ContainerLogs.validateLogOptions(follow: true, since: since, until: nil)
+        #expect(throws: Error.self) {
+            try Application.ContainerLogs.validateLogOptions(follow: true, since: since, until: nil)
+        }
     }
 
     @Test
-    func validateAcceptsFollowWithUntil() throws {
+    func validateRejectsFollowWithUntil() throws {
         let until = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00Z"))
 
-        try Application.ContainerLogs.validateLogOptions(follow: true, since: nil, until: until)
+        #expect(throws: Error.self) {
+            try Application.ContainerLogs.validateLogOptions(follow: true, since: nil, until: until)
+        }
     }
 
     @Test

--- a/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
+++ b/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
@@ -1,0 +1,103 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import ContainerCommands
+
+struct ContainerLogsCommandTests {
+    @Test
+    func parsesRFC3339Timestamp() throws {
+        let timestamp = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00Z"))
+
+        #expect(timestamp.date == date("2026-06-18T10:00:00Z"))
+    }
+
+    @Test
+    func parsesFractionalRFC3339Timestamp() throws {
+        let timestamp = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00.123Z"))
+
+        #expect(timestamp.date == date("2026-06-18T10:00:00.123Z"))
+    }
+
+    @Test
+    func rejectsInvalidTimestamp() {
+        #expect(ContainerLogTimestamp(argument: "not-a-date") == nil)
+    }
+
+    @Test
+    func logOptionsUseAPITailWhenNotFollowing() throws {
+        let since = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00Z"))
+        let until = try #require(ContainerLogTimestamp(argument: "2026-06-18T11:00:00Z"))
+
+        let options = Application.ContainerLogs.retrievalOptions(
+            numLines: 25,
+            follow: false,
+            since: since,
+            until: until
+        )
+
+        #expect(options.tail == 25)
+        #expect(options.since == since.date)
+        #expect(options.until == until.date)
+    }
+
+    @Test
+    func logOptionsLeaveTailForLocalFollowHandling() {
+        let options = Application.ContainerLogs.retrievalOptions(
+            numLines: 25,
+            follow: true,
+            since: nil,
+            until: nil
+        )
+
+        #expect(options.tail == nil)
+        #expect(options.since == nil)
+    }
+
+    @Test
+    func validateRejectsFollowWithSince() throws {
+        let since = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00Z"))
+
+        #expect(throws: Error.self) {
+            try Application.ContainerLogs.validateLogOptions(follow: true, since: since, until: nil)
+        }
+    }
+
+    @Test
+    func validateRejectsFollowWithUntil() throws {
+        let until = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00Z"))
+
+        #expect(throws: Error.self) {
+            try Application.ContainerLogs.validateLogOptions(follow: true, since: nil, until: until)
+        }
+    }
+
+    @Test
+    func validateAcceptsFollowWithTailOnly() throws {
+        try Application.ContainerLogs.validateLogOptions(follow: true, since: nil, until: nil)
+    }
+
+    private func date(_ value: String) -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions =
+            value.contains(".")
+            ? [.withInternetDateTime, .withFractionalSeconds]
+            : [.withInternetDateTime]
+        return formatter.date(from: value)!
+    }
+}

--- a/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
+++ b/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
@@ -107,6 +107,21 @@ struct ContainerLogsCommandTests {
     }
 
     @Test
+    func logFileOutputWritesAllBytesWithoutUTF8Decoding() async throws {
+        let outputURL = temporaryFileURL()
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+        _ = FileManager.default.createFile(atPath: outputURL.path, contents: nil)
+        let bytes = Data([0xff, 0xfe, 0x0a, 0x41, 0x0a])
+
+        let inputHandle = try fileHandle(containing: bytes)
+        let outputHandle = try FileHandle(forWritingTo: outputURL)
+        try await LogFileOutput.write(fh: inputHandle, n: nil, follow: false, output: outputHandle)
+        try outputHandle.close()
+
+        #expect(try Data(contentsOf: outputURL) == bytes)
+    }
+
+    @Test
     func logFileOutputTailDataPreservesBlankLinesAndTrailingNewline() {
         let data = Data("one\n\ntwo\n".utf8)
 

--- a/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
+++ b/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
@@ -57,34 +57,33 @@ struct ContainerLogsCommandTests {
     }
 
     @Test
-    func logOptionsLeaveTailForLocalFollowHandling() {
+    func logOptionsLeaveTailForLocalFollowHandling() throws {
+        let since = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00Z"))
+        let until = try #require(ContainerLogTimestamp(argument: "2026-06-18T11:00:00Z"))
         let options = Application.ContainerLogs.retrievalOptions(
             numLines: 25,
             follow: true,
-            since: nil,
-            until: nil
+            since: since,
+            until: until
         )
 
         #expect(options.tail == nil)
-        #expect(options.since == nil)
+        #expect(options.since == since.date)
+        #expect(options.until == until.date)
     }
 
     @Test
-    func validateRejectsFollowWithSince() throws {
+    func validateAcceptsFollowWithSince() throws {
         let since = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00Z"))
 
-        #expect(throws: Error.self) {
-            try Application.ContainerLogs.validateLogOptions(follow: true, since: since, until: nil)
-        }
+        try Application.ContainerLogs.validateLogOptions(follow: true, since: since, until: nil)
     }
 
     @Test
-    func validateRejectsFollowWithUntil() throws {
+    func validateAcceptsFollowWithUntil() throws {
         let until = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00Z"))
 
-        #expect(throws: Error.self) {
-            try Application.ContainerLogs.validateLogOptions(follow: true, since: nil, until: until)
-        }
+        try Application.ContainerLogs.validateLogOptions(follow: true, since: nil, until: until)
     }
 
     @Test

--- a/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
+++ b/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
@@ -92,6 +92,51 @@ struct ContainerLogsCommandTests {
         try Application.ContainerLogs.validateLogOptions(follow: true, since: nil, until: nil)
     }
 
+    @Test
+    func logFileOutputNegativeTailWritesAllBytes() async throws {
+        let outputURL = temporaryFileURL()
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+        _ = FileManager.default.createFile(atPath: outputURL.path, contents: nil)
+
+        let inputHandle = try fileHandle(containing: Data("one\ntwo\n".utf8))
+        let outputHandle = try FileHandle(forWritingTo: outputURL)
+        try await LogFileOutput.write(fh: inputHandle, n: -1, follow: false, output: outputHandle)
+        try outputHandle.close()
+
+        #expect(String(data: try Data(contentsOf: outputURL), encoding: .utf8) == "one\ntwo\n")
+    }
+
+    @Test
+    func logFileOutputTailDataPreservesBlankLinesAndTrailingNewline() {
+        let data = Data("one\n\ntwo\n".utf8)
+
+        let tail = LogFileOutput.tailData(data, lineCount: 2)
+
+        #expect(String(data: tail, encoding: .utf8) == "\ntwo\n")
+    }
+
+    @Test
+    func logFileOutputZeroTailReturnsEmptyData() {
+        let data = Data("one\ntwo\n".utf8)
+
+        let tail = LogFileOutput.tailData(data, lineCount: 0)
+
+        #expect(tail.isEmpty)
+    }
+
+    private func fileHandle(containing data: Data) throws -> FileHandle {
+        let url = temporaryFileURL()
+        try data.write(to: url)
+        let handle = try FileHandle(forReadingFrom: url)
+        try? FileManager.default.removeItem(at: url)
+        return handle
+    }
+
+    private func temporaryFileURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("container-log-command-test-\(UUID().uuidString)")
+    }
+
     private func date(_ value: String) -> Date {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions =

--- a/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
+++ b/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
@@ -20,24 +20,28 @@ import Testing
 @testable import ContainerResource
 
 struct ContainerLogOptionsTests {
-
-    @Test("Default log options preserve existing logs behavior")
-    func testDefaultOptions() {
+    @Test func defaultOptionsPreserveExistingBehavior() {
         let options = ContainerLogOptions.default
 
+        #expect(options.tail == nil)
         #expect(options.since == nil)
+        #expect(options.until == nil)
         #expect(!options.timestamps)
     }
 
-    @Test("Custom log options round-trip through JSON")
-    func testCustomOptionsRoundTrip() throws {
+    @Test func customOptionsRoundTripThroughJSON() throws {
         let since = Date(timeIntervalSince1970: 1_800_000_000)
-        let options = ContainerLogOptions(since: since, timestamps: true)
+        let until = Date(timeIntervalSince1970: 1_900_000_000)
+        let options = ContainerLogOptions(
+            tail: 100,
+            since: since,
+            until: until,
+            timestamps: true
+        )
 
         let data = try JSONEncoder().encode(options)
         let decoded = try JSONDecoder().decode(ContainerLogOptions.self, from: data)
 
-        #expect(decoded.since == since)
-        #expect(decoded.timestamps)
+        #expect(decoded == options)
     }
 }

--- a/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
+++ b/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
@@ -27,6 +27,7 @@ struct ContainerLogOptionsTests {
         #expect(options.since == nil)
         #expect(options.until == nil)
         #expect(!options.timestamps)
+        #expect(options.stream == nil)
     }
 
     @Test func customOptionsRoundTripThroughJSON() throws {
@@ -36,7 +37,8 @@ struct ContainerLogOptionsTests {
             tail: 100,
             since: since,
             until: until,
-            timestamps: true
+            timestamps: true,
+            stream: .boot
         )
 
         let data = try JSONEncoder().encode(options)

--- a/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
+++ b/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import ContainerResource
+
+struct ContainerLogOptionsTests {
+
+    @Test("Default log options preserve existing logs behavior")
+    func testDefaultOptions() {
+        let options = ContainerLogOptions.default
+
+        #expect(options.since == nil)
+        #expect(!options.timestamps)
+    }
+
+    @Test("Custom log options round-trip through JSON")
+    func testCustomOptionsRoundTrip() throws {
+        let since = Date(timeIntervalSince1970: 1_800_000_000)
+        let options = ContainerLogOptions(since: since, timestamps: true)
+
+        let data = try JSONEncoder().encode(options)
+        let decoded = try JSONDecoder().decode(ContainerLogOptions.self, from: data)
+
+        #expect(decoded.since == since)
+        #expect(decoded.timestamps)
+    }
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -414,6 +414,8 @@ container logs [--boot] [--follow] [-n <n>] [--tail <n>] [--since <timestamp>] [
 *   `--since <timestamp>`: Show logs after the specified RFC 3339 timestamp
 *   `--until <timestamp>`: Show logs before the specified RFC 3339 timestamp
 
+`--since` and `--until` apply to static stdio and boot log replay. Followed stdio time filters are not supported by this change.
+
 ### `container inspect`
 
 Displays detailed container information in JSON. Pass one or more container IDs to inspect multiple containers.
@@ -1276,4 +1278,3 @@ container system property list
 # output as JSON for scripting
 container system property list --format json
 ```
-

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -414,7 +414,7 @@ container logs [--boot] [--follow] [-n <n>] [--tail <n>] [--since <timestamp>] [
 *   `--since <timestamp>`: Show logs after the specified RFC 3339 timestamp
 *   `--until <timestamp>`: Show logs before the specified RFC 3339 timestamp
 
-`--since` and `--until` apply to static stdio and boot log replay. Followed stdio time filters are not supported by this change.
+`--since` and `--until` apply to static stdio and boot log replay. Followed time filters are not supported by this change.
 
 ### `container inspect`
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -394,12 +394,12 @@ container export mycontainer > mycontainer.tar
 
 ### `container logs`
 
-Fetches logs from a container. You can follow the logs (`-f`/`--follow`), restrict the number of lines shown, or view boot logs.
+Fetches logs from a container. You can follow the logs (`-f`/`--follow`), restrict the number of lines shown, filter by RFC 3339 timestamp, or view boot logs.
 
 **Usage**
 
 ```bash
-container logs [--boot] [--follow] [-n <n>] [--debug] <container-id>
+container logs [--boot] [--follow] [-n <n>] [--tail <n>] [--since <timestamp>] [--until <timestamp>] [--debug] <container-id>
 ```
 
 **Arguments**
@@ -410,7 +410,9 @@ container logs [--boot] [--follow] [-n <n>] [--debug] <container-id>
 
 *   `--boot`: Display the boot log for the container instead of stdio
 *   `-f, --follow`: Follow log output
-*   `-n <n>`: Number of lines to show from the end of the logs. If not provided this will print all of the logs
+*   `-n, --tail <n>`: Number of lines to show from the end of the logs. If not provided this will print all of the logs
+*   `--since <timestamp>`: Show logs after the specified RFC 3339 timestamp
+*   `--until <timestamp>`: Show logs before the specified RFC 3339 timestamp
 
 ### `container inspect`
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -414,7 +414,7 @@ container logs [--boot] [--follow] [-n <n>] [--tail <n>] [--since <timestamp>] [
 *   `--since <timestamp>`: Show logs after the specified RFC 3339 timestamp
 *   `--until <timestamp>`: Show logs before the specified RFC 3339 timestamp
 
-`--since` and `--until` apply to static stdio and boot log replay. `--follow --until` stops following once the requested deadline is reached.
+`--since` and `--until` apply to static stdio and boot log replay. Followed time filters are not supported by this change.
 
 ### `container inspect`
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -414,7 +414,7 @@ container logs [--boot] [--follow] [-n <n>] [--tail <n>] [--since <timestamp>] [
 *   `--since <timestamp>`: Show logs after the specified RFC 3339 timestamp
 *   `--until <timestamp>`: Show logs before the specified RFC 3339 timestamp
 
-`--since` and `--until` apply to static stdio and boot log replay. Followed time filters are not supported by this change.
+`--since` and `--until` apply to static stdio and boot log replay. `--follow --until` stops following once the requested deadline is reached.
 
 ### `container inspect`
 

--- a/docs/upstream/PR-1764.md
+++ b/docs/upstream/PR-1764.md
@@ -17,27 +17,29 @@ Linked work:
 - apple/container#1592
 - apple/container#1752
 
-Local code commit:
+Local code commits:
 
 - `3b5aa9b822639be5cd41df3bcbdb5e2936860e26` (`fix(logs): tighten filtered replay semantics`)
+- `be319dd43757d24571d6f5b68ea91d7369cd0b32` (`fix(logs): scope followed time filters`)
 
 Design notes:
 
 - `container logs --follow --tail -1` now treats a negative tail as "all" instead of passing a negative value to local suffix handling.
-- `--follow --since` and `--follow --until` are accepted. The initial replay path applies the time filters, and `--follow --until` stops follow output when the deadline is reached.
+- `--follow --since` and `--follow --until` remain rejected by validation because this PR does not add a live structured-follow stream that can honor time filters safely.
 - Service-side time filtering no longer starts by reading the entire log into memory via `readToEnd()`. It scans the file in bounded chunks, rebuilds logical lines, and keeps only the requested retained tail when `tail > 0`.
 - Raw stdio logs without parseable timestamp prefixes now fail closed for time filters, matching the explicit API contract from the #1592 follow-up.
 - Tail-only paths still preserve raw, non-UTF8 bytes and unparseable lines because no timestamp decision is needed.
+- `ContainerizationError` failures raised by the filter path are preserved so callers see `invalidArgument` instead of a generic log-open failure.
 
 Compatibility impact:
 
-- This brings the CLI closer to Docker log option behavior for negative tail, followed logs, and bounded replay.
+- This brings the CLI closer to Docker log option behavior for negative tail and bounded static replay.
 - It deliberately avoids claiming complete Docker timestamp parity for raw stdio logs. Durable timestamp parity needs the structured log-record work tracked under #1752 and related follow-ups.
-- Compose can use this as an interim direct API contract, while full Docker Compose v2 log parity should depend on structured records and line-oriented replay.
+- Compose can use this as an interim static direct API contract, while full Docker Compose v2 followed timestamp parity should depend on structured records and line-oriented replay.
 
 Remaining risks:
 
-- `--follow --since` only constrains the initial replay for raw stdio follow. Newly appended raw bytes are streamed as they arrive because raw append data has no durable timestamp metadata. Structured log records should close this gap.
+- Followed time filters remain outside this PR. Structured log records and a live record-follow API should close that gap without following a filtered temporary snapshot.
 - The bounded scan avoids full-log `readToEnd()`, but the filtered output is still materialized before being exposed as a handle. A future streaming API would be stronger for very large filtered result sets.
 
 ## Testing
@@ -54,8 +56,9 @@ Local validation:
 
 Test coverage added or updated:
 
-- Follow validation accepts `--since` and `--until`.
-- Follow validation preserves `since` / `until` while leaving `tail` for local follow handling.
+- Follow validation rejects `--since` and `--until` so the CLI cannot follow a filtered temporary snapshot.
+- Follow validation still accepts tail-only follow and leaves `tail` for local follow handling.
 - Tail-only paths preserve non-UTF8 and unparseable lines.
 - Time-filter paths reject unparseable or non-UTF8 log data.
+- Time-filter failures assert the `invalidArgument` error code.
 - Negative tail writes all bytes on the local raw follow path.

--- a/docs/upstream/PR-1764.md
+++ b/docs/upstream/PR-1764.md
@@ -23,6 +23,7 @@ Local code commits:
 - `be319dd43757d24571d6f5b68ea91d7369cd0b32` (`fix(logs): scope followed time filters`)
 - `d44a12225f9ed7afbdc0c13f45f33ada1909d254` (`fix(logs): align filtered tail replay`)
 - `e03b5c92f7be86eb6a457e820311696b175d9b55` (`fix(logs): avoid eager tail allocation`)
+- `dbbb0f2727a1d48f4e24a615be17ce33f000ce46` (`fix(logs): filter selected log stream`)
 
 Design notes:
 
@@ -35,12 +36,15 @@ Design notes:
 - Tail-only paths still preserve raw, non-UTF8 bytes and unparseable lines because no timestamp decision is needed.
 - `ContainerizationError` failures raised by the filter path are preserved so callers see `invalidArgument` instead of a generic log-open failure.
 - The ring buffer grows as retained lines are found instead of preallocating the full caller-provided `tail` value, which avoids turning a large option value into an eager allocation.
+- `ContainerLogOptions.stream` lets callers identify the stream that should receive filters. The CLI sets it from `--boot`, so a normal stdio request is not rejected because the unselected boot log cannot satisfy stdio timestamp-filter rules.
+- Raw blank log records now fail closed under timestamp filters, matching the documented rule that timestamp filtering requires parseable timestamp prefixes. Empty log files still filter to empty output without error.
 
 Compatibility impact:
 
 - This brings the CLI closer to Docker log option behavior for negative tail and bounded static replay.
 - It deliberately avoids claiming complete Docker timestamp parity for raw stdio logs. Durable timestamp parity needs the structured log-record work tracked under #1752 and related follow-ups.
 - Compose can use this as an interim static direct API contract, while full Docker Compose v2 followed timestamp parity should depend on structured records and line-oriented replay.
+- The stream selector keeps the existing two-handle return shape intact while giving CLI and direct API callers a way to avoid filtering streams they will not consume.
 
 Remaining risks:
 
@@ -55,9 +59,9 @@ Remaining risks:
 
 Local validation:
 
-- `swift format lint --strict --configuration .swift-format-nolint Sources/ContainerCommands/LogFileOutput.swift Sources/ContainerCommands/Container/ContainerLogs.swift Sources/ContainerResource/Container/ContainerLogOptions.swift Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift Tests/ContainerAPIServiceTests/ContainerLogsTests.swift Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift`
+- `swift format lint --strict --configuration .swift-format-nolint Sources/ContainerCommands/LogFileOutput.swift Sources/ContainerCommands/Container/ContainerLogs.swift Sources/ContainerResource/Container/ContainerLogOptions.swift Sources/Services/ContainerAPIService/Client/ContainerClient.swift Sources/Services/ContainerAPIService/Client/XPC+.swift Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift Tests/ContainerAPIServiceTests/ContainerLogsTests.swift Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift Tests/ContainerResourceTests/ContainerLogOptionsTests.swift`
 - `git diff --check`
-- `swift test --filter ContainerLogsTests --filter ContainerLogsCommandTests`
+- `swift test --filter ContainerLogsTests --filter ContainerLogsCommandTests --filter ContainerLogOptionsTests`
 
 Test coverage added or updated:
 
@@ -65,6 +69,8 @@ Test coverage added or updated:
 - Follow validation still accepts tail-only follow and leaves `tail` for local follow handling.
 - Tail-only paths preserve non-UTF8 and unparseable lines.
 - Time-filter paths reject unparseable or non-UTF8 log data.
+- Time-filter paths reject blank raw application log records.
 - Time-filter failures assert the `invalidArgument` error code.
 - Negative tail writes all bytes on the local raw follow path.
 - Filtered replay retains the requested tail count in chronological order after applying time filters.
+- Stream selection is covered across the CLI option builder, XPC harness decoding, Codable option round trip, and API-service filtering helper.

--- a/docs/upstream/PR-1764.md
+++ b/docs/upstream/PR-1764.md
@@ -22,6 +22,7 @@ Local code commits:
 - `3b5aa9b822639be5cd41df3bcbdb5e2936860e26` (`fix(logs): tighten filtered replay semantics`)
 - `be319dd43757d24571d6f5b68ea91d7369cd0b32` (`fix(logs): scope followed time filters`)
 - `d44a12225f9ed7afbdc0c13f45f33ada1909d254` (`fix(logs): align filtered tail replay`)
+- `e03b5c92f7be86eb6a457e820311696b175d9b55` (`fix(logs): avoid eager tail allocation`)
 
 Design notes:
 
@@ -33,6 +34,7 @@ Design notes:
 - Raw stdio logs without parseable timestamp prefixes now fail closed for time filters, matching the explicit API contract from the #1592 follow-up.
 - Tail-only paths still preserve raw, non-UTF8 bytes and unparseable lines because no timestamp decision is needed.
 - `ContainerizationError` failures raised by the filter path are preserved so callers see `invalidArgument` instead of a generic log-open failure.
+- The ring buffer grows as retained lines are found instead of preallocating the full caller-provided `tail` value, which avoids turning a large option value into an eager allocation.
 
 Compatibility impact:
 

--- a/docs/upstream/PR-1764.md
+++ b/docs/upstream/PR-1764.md
@@ -24,6 +24,7 @@ Local code commits:
 - `d44a12225f9ed7afbdc0c13f45f33ada1909d254` (`fix(logs): align filtered tail replay`)
 - `e03b5c92f7be86eb6a457e820311696b175d9b55` (`fix(logs): avoid eager tail allocation`)
 - `dbbb0f2727a1d48f4e24a615be17ce33f000ce46` (`fix(logs): filter selected log stream`)
+- `4501c0d2212efac5e5475a2526857a9df4febdea` (`fix(logs): align zero-tail filtering`)
 
 Design notes:
 
@@ -38,6 +39,7 @@ Design notes:
 - The ring buffer grows as retained lines are found instead of preallocating the full caller-provided `tail` value, which avoids turning a large option value into an eager allocation.
 - `ContainerLogOptions.stream` lets callers identify the stream that should receive filters. The CLI sets it from `--boot`, so a normal stdio request is not rejected because the unselected boot log cannot satisfy stdio timestamp-filter rules.
 - Raw blank log records now fail closed under timestamp filters, matching the documented rule that timestamp filtering requires parseable timestamp prefixes. Empty log files still filter to empty output without error.
+- Zero-tail replay returns an empty result before timestamp parsing in both the in-memory helper and file-handle path, so `tail: 0` never rejects existing unparseable log bytes.
 
 Compatibility impact:
 
@@ -74,3 +76,4 @@ Test coverage added or updated:
 - Negative tail writes all bytes on the local raw follow path.
 - Filtered replay retains the requested tail count in chronological order after applying time filters.
 - Stream selection is covered across the CLI option builder, XPC harness decoding, Codable option round trip, and API-service filtering helper.
+- Zero-tail replay is covered for timestamped logs and unparseable logs combined with timestamp filters.

--- a/docs/upstream/PR-1764.md
+++ b/docs/upstream/PR-1764.md
@@ -21,12 +21,15 @@ Local code commits:
 
 - `3b5aa9b822639be5cd41df3bcbdb5e2936860e26` (`fix(logs): tighten filtered replay semantics`)
 - `be319dd43757d24571d6f5b68ea91d7369cd0b32` (`fix(logs): scope followed time filters`)
+- `d44a12225f9ed7afbdc0c13f45f33ada1909d254` (`fix(logs): align filtered tail replay`)
 
 Design notes:
 
 - `container logs --follow --tail -1` now treats a negative tail as "all" instead of passing a negative value to local suffix handling.
 - `--follow --since` and `--follow --until` remain rejected by validation because this PR does not add a live structured-follow stream that can honor time filters safely.
 - Service-side time filtering no longer starts by reading the entire log into memory via `readToEnd()`. It scans the file in bounded chunks, rebuilds logical lines, and keeps only the requested retained tail when `tail > 0`.
+- The public `ContainerLogOptions.tail` contract now states the Docker-shaped semantics explicitly: positive means last N lines, zero means no lines, and negative means all lines.
+- Filtered replay now retains requested tail lines in a fixed-size ring buffer instead of repeatedly trimming from the front of an array while scanning large logs.
 - Raw stdio logs without parseable timestamp prefixes now fail closed for time filters, matching the explicit API contract from the #1592 follow-up.
 - Tail-only paths still preserve raw, non-UTF8 bytes and unparseable lines because no timestamp decision is needed.
 - `ContainerizationError` failures raised by the filter path are preserved so callers see `invalidArgument` instead of a generic log-open failure.
@@ -62,3 +65,4 @@ Test coverage added or updated:
 - Time-filter paths reject unparseable or non-UTF8 log data.
 - Time-filter failures assert the `invalidArgument` error code.
 - Negative tail writes all bytes on the local raw follow path.
+- Filtered replay retains the requested tail count in chronological order after applying time filters.

--- a/docs/upstream/PR-1764.md
+++ b/docs/upstream/PR-1764.md
@@ -1,0 +1,61 @@
+<!-- markdownlint-disable MD013 MD041 -->
+
+## Type of Change
+
+- [x] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [x] Documentation update
+
+## Motivation and Context
+
+This follow-up fixes the strict review findings on #1764 by making followed and static log filtering safer, more Docker-shaped, and less memory-heavy. The branch remains scoped to CLI/API log filtering behavior and does not introduce Compose-specific functionality into apple/container.
+
+Linked work:
+
+- apple/container#1764
+- apple/container#1592
+- apple/container#1752
+
+Local code commit:
+
+- `3b5aa9b822639be5cd41df3bcbdb5e2936860e26` (`fix(logs): tighten filtered replay semantics`)
+
+Design notes:
+
+- `container logs --follow --tail -1` now treats a negative tail as "all" instead of passing a negative value to local suffix handling.
+- `--follow --since` and `--follow --until` are accepted. The initial replay path applies the time filters, and `--follow --until` stops follow output when the deadline is reached.
+- Service-side time filtering no longer starts by reading the entire log into memory via `readToEnd()`. It scans the file in bounded chunks, rebuilds logical lines, and keeps only the requested retained tail when `tail > 0`.
+- Raw stdio logs without parseable timestamp prefixes now fail closed for time filters, matching the explicit API contract from the #1592 follow-up.
+- Tail-only paths still preserve raw, non-UTF8 bytes and unparseable lines because no timestamp decision is needed.
+
+Compatibility impact:
+
+- This brings the CLI closer to Docker log option behavior for negative tail, followed logs, and bounded replay.
+- It deliberately avoids claiming complete Docker timestamp parity for raw stdio logs. Durable timestamp parity needs the structured log-record work tracked under #1752 and related follow-ups.
+- Compose can use this as an interim direct API contract, while full Docker Compose v2 log parity should depend on structured records and line-oriented replay.
+
+Remaining risks:
+
+- `--follow --since` only constrains the initial replay for raw stdio follow. Newly appended raw bytes are streamed as they arrive because raw append data has no durable timestamp metadata. Structured log records should close this gap.
+- The bounded scan avoids full-log `readToEnd()`, but the filtered output is still materialized before being exposed as a handle. A future streaming API would be stronger for very large filtered result sets.
+
+## Testing
+
+- [x] Tested locally
+- [x] Added/updated tests
+- [x] Added/updated docs
+
+Local validation:
+
+- `swift format lint --strict --configuration .swift-format-nolint Sources/ContainerCommands/LogFileOutput.swift Sources/ContainerCommands/Container/ContainerLogs.swift Sources/ContainerResource/Container/ContainerLogOptions.swift Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift Tests/ContainerAPIServiceTests/ContainerLogsTests.swift Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift`
+- `git diff --check`
+- `swift test --filter ContainerLogsTests --filter ContainerLogsCommandTests`
+
+Test coverage added or updated:
+
+- Follow validation accepts `--since` and `--until`.
+- Follow validation preserves `since` / `until` while leaving `tail` for local follow handling.
+- Tail-only paths preserve non-UTF8 and unparseable lines.
+- Time-filter paths reject unparseable or non-UTF8 log data.
+- Negative tail writes all bytes on the local raw follow path.


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context

This is a draft stacked follow-up to #1592. Chris's #1592 introduces the initial `ContainerLogOptions` API shape for `since` and `timestamps`; this draft extends that direction with the remaining line-retrieval filters needed by `container logs` and external API clients: `tail` and `until`.

The motivation is to keep Docker-style log retrieval semantics close to the service that owns the log files, rather than requiring every caller to replay and filter the complete stream locally. This is useful for the `container logs` CLI and for external orchestrators, while keeping Compose-specific formatting and policy out of `apple/container`.

Draft/stacking note: this branch is based on `full-chaos/container:feat/chaos-1322-log-options` from #1592. Because GitHub PRs to `apple/container` target `main`, this diff includes #1592 plus the follow-up commits below. The intended review delta for this draft is:

- `ece5d5d feat(logs): add tail and until retrieval filters`
- `bd178e8 fix(logs): harden tail replay filters`
- `acab75a test(logs): cover byte-preserving log replay`
- `881f9e9 fix(logs): fail closed when filtering logs`
- `b8d7675 test(logs): close filtered log handles`
- `f4e2723 test(logs): close command log handles`
- `03c2594 docs(logs): clarify followed time filter limitation`
- `4884d25 fix(logs): create filtered logs with private permissions`
- `897665a fix(logs): require unlinking filtered log files`

## What Changed

- Extends `ContainerLogOptions` with `tail` and `until` while preserving the existing zero-option behavior.
- Plumbs `tail`, `since`, and `until` through `ContainerClient`, XPC, the harness, and `ContainersService`.
- Applies `tail` after service-side line filtering, with Docker-compatible negative-tail behavior treated as "all".
- Adds a bounded service-side tail scan for static tail-only requests instead of reading the whole log into memory.
- Adds byte-preserving local output for followed raw logs so negative tail and non-UTF-8 log bytes do not crash or decode incorrectly.
- Adds `container logs --tail` long-form support and `--since` / `--until` CLI arguments.
- Preserves unparseable and non-UTF-8 raw log bytes while filtering what can be safely filtered.
- Fails closed when filtered log replay cannot create the temporary filtered handle, so callers do not silently receive unfiltered logs.
- Creates filtered replay files with exclusive owner-only permissions and requires successful unlink before returning the replay handle.
- Closes filtered and command log handles explicitly in focused tests.
- Clarifies that followed time filters are not supported for this static-replay draft.
- Updates the command reference for the new CLI options and the current followed time-filter limitation.

## Relationship to Existing Work

- Builds on #1592 rather than replacing it.
- Related to #1591 and #1752.
- If maintainers prefer, the retrieval-only shape from this draft can be folded into #1592 before that PR lands.

## Non-Goals

- This does not add structured log records.
- This does not add timestamp rendering for raw logs.
- This does not add Compose-specific behavior.
- This does not support followed `--since` / `--until` yet; those filters are static replay only in this draft.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [x] Added/updated docs

Local verification:

```bash
swift format lint --strict --configuration .swift-format-nolint Sources/ContainerCommands/LogFileOutput.swift Sources/ContainerCommands/Container/ContainerLogs.swift Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift Tests/ContainerAPIServiceTests/ContainerLogsTests.swift Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
git diff --check
swift build
swift test --filter ContainerLogsCommandTests
swift test --filter ContainerLogsTests
swift test --filter ContainerLogOptionsTests
```

Result: focused validation passed locally. The focused tests ran 25 tests across `ContainerLogsCommandTests`, `ContainerLogsTests`, and `ContainerLogOptionsTests`.