### PR TITLE
feat(logs): accept Docker-compatible timestamp filters

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -203,9 +203,12 @@ let package = Package(
             name: "ContainerAPIServiceTests",
             dependencies: [
                 .product(name: "Containerization", package: "containerization"),
+                "ContainerAPIClient",
+                "ContainerAPIService",
                 "ContainerResource",
                 "ContainerRuntimeLinuxClient",
                 "ContainerRuntimeClient",
+                "ContainerXPC",
             ]
         ),
         .target(

--- a/Sources/ContainerCommands/Container/ContainerLogs.swift
+++ b/Sources/ContainerCommands/Container/ContainerLogs.swift
@@ -16,6 +16,7 @@
 
 import ArgumentParser
 import ContainerAPIClient
+import ContainerResource
 import ContainerizationError
 import Darwin
 import Dispatch
@@ -36,8 +37,14 @@ extension Application {
         @Flag(name: .shortAndLong, help: "Follow log output")
         var follow: Bool = false
 
-        @Option(name: .short, help: "Number of lines to show from the end of the logs. If not provided this will print all of the logs")
+        @Option(name: [.short, .customLong("tail")], help: "Number of lines to show from the end of the logs. If not provided this will print all of the logs")
         var numLines: Int?
+
+        @Option(name: .long, help: "Show logs after the specified RFC 3339 timestamp")
+        var since: ContainerLogTimestamp?
+
+        @Option(name: .long, help: "Show logs before the specified RFC 3339 timestamp")
+        var until: ContainerLogTimestamp?
 
         @OptionGroup
         public var logOptions: Flags.Logging
@@ -45,15 +52,48 @@ extension Application {
         @Argument(help: "Container ID")
         var containerId: String
 
+        public func validate() throws {
+            try Self.validateLogOptions(follow: follow, since: since, until: until)
+        }
+
         public func run() async throws {
             let client = ContainerClient()
-            let fhs = try await client.logs(id: containerId)
+            let options = Self.retrievalOptions(
+                numLines: numLines,
+                follow: follow,
+                since: since,
+                until: until
+            )
+            let fhs = try await client.logs(id: containerId, options: options)
             let fileHandle = boot ? fhs[1] : fhs[0]
 
             try await Self.tail(
                 fh: fileHandle,
-                n: numLines,
+                n: follow ? numLines : nil,
                 follow: follow
+            )
+        }
+
+        static func validateLogOptions(
+            follow: Bool,
+            since: ContainerLogTimestamp?,
+            until: ContainerLogTimestamp?
+        ) throws {
+            if follow && (since != nil || until != nil) {
+                throw ValidationError("--follow cannot be combined with --since or --until")
+            }
+        }
+
+        static func retrievalOptions(
+            numLines: Int?,
+            follow: Bool,
+            since: ContainerLogTimestamp?,
+            until: ContainerLogTimestamp?
+        ) -> ContainerLogOptions {
+            ContainerLogOptions(
+                tail: follow ? nil : numLines,
+                since: since?.date,
+                until: until?.date
             )
         }
 
@@ -138,5 +178,22 @@ extension Application {
                 print(line)
             }
         }
+    }
+}
+
+struct ContainerLogTimestamp: ExpressibleByArgument, Equatable {
+    let date: Date
+
+    init?(argument: String) {
+        let fractionalFormatter = ISO8601DateFormatter()
+        fractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+
+        if let date = fractionalFormatter.date(from: argument) ?? formatter.date(from: argument) {
+            self.date = date
+            return
+        }
+        return nil
     }
 }

--- a/Sources/ContainerCommands/Container/ContainerLogs.swift
+++ b/Sources/ContainerCommands/Container/ContainerLogs.swift
@@ -72,16 +72,18 @@ extension Application {
             try await LogFileOutput.write(
                 fh: fileHandle,
                 n: follow ? numLines : nil,
-                follow: follow,
-                until: until?.date
+                follow: follow
             )
         }
 
         static func validateLogOptions(
-            follow _: Bool,
-            since _: ContainerLogTimestamp?,
-            until _: ContainerLogTimestamp?
+            follow: Bool,
+            since: ContainerLogTimestamp?,
+            until: ContainerLogTimestamp?
         ) throws {
+            if follow && (since != nil || until != nil) {
+                throw ValidationError("--follow cannot be combined with --since or --until")
+            }
         }
 
         static func retrievalOptions(

--- a/Sources/ContainerCommands/Container/ContainerLogs.swift
+++ b/Sources/ContainerCommands/Container/ContainerLogs.swift
@@ -58,6 +58,7 @@ extension Application {
             let options = Self.retrievalOptions(
                 numLines: numLines,
                 follow: follow,
+                boot: boot,
                 since: since,
                 until: until
             )
@@ -89,13 +90,15 @@ extension Application {
         static func retrievalOptions(
             numLines: Int?,
             follow: Bool,
+            boot: Bool,
             since: ContainerLogTimestamp?,
             until: ContainerLogTimestamp?
         ) -> ContainerLogOptions {
             ContainerLogOptions(
                 tail: follow ? nil : numLines,
                 since: since?.date,
-                until: until?.date
+                until: until?.date,
+                stream: boot ? .boot : .stdio
             )
         }
     }

--- a/Sources/ContainerCommands/Container/ContainerLogs.swift
+++ b/Sources/ContainerCommands/Container/ContainerLogs.swift
@@ -37,10 +37,10 @@ extension Application {
         @Option(name: [.short, .customLong("tail")], help: "Number of lines to show from the end of the logs. If not provided this will print all of the logs")
         var numLines: Int?
 
-        @Option(name: .long, help: "Show logs after the specified RFC 3339 timestamp")
+        @Option(name: .long, help: "Show logs after the specified RFC 3339 timestamp, Unix timestamp, or relative duration")
         var since: ContainerLogTimestamp?
 
-        @Option(name: .long, help: "Show logs before the specified RFC 3339 timestamp")
+        @Option(name: .long, help: "Show logs before the specified RFC 3339 timestamp, Unix timestamp, or relative duration")
         var until: ContainerLogTimestamp?
 
         @OptionGroup
@@ -108,12 +108,7 @@ struct ContainerLogTimestamp: ExpressibleByArgument, Equatable {
     let date: Date
 
     init?(argument: String) {
-        let fractionalFormatter = ISO8601DateFormatter()
-        fractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime]
-
-        if let date = fractionalFormatter.date(from: argument) ?? formatter.date(from: argument) {
+        if let date = ContainerLogTimestampParser.parse(argument) {
             self.date = date
             return
         }

--- a/Sources/ContainerCommands/Container/ContainerLogs.swift
+++ b/Sources/ContainerCommands/Container/ContainerLogs.swift
@@ -17,9 +17,6 @@
 import ArgumentParser
 import ContainerAPIClient
 import ContainerResource
-import ContainerizationError
-import Darwin
-import Dispatch
 import Foundation
 
 extension Application {
@@ -66,11 +63,16 @@ extension Application {
             )
             let fhs = try await client.logs(id: containerId, options: options)
             let fileHandle = boot ? fhs[1] : fhs[0]
+            defer {
+                for handle in fhs {
+                    try? handle.close()
+                }
+            }
 
-            try await Self.tail(
+            try await LogFileOutput.write(
                 fh: fileHandle,
                 n: follow ? numLines : nil,
-                follow: follow
+                follow: follow,
             )
         }
 
@@ -95,88 +97,6 @@ extension Application {
                 since: since?.date,
                 until: until?.date
             )
-        }
-
-        private static func tail(
-            fh: FileHandle,
-            n: Int?,
-            follow: Bool
-        ) async throws {
-            if let n {
-                var buffer = Data()
-                let size = try fh.seekToEnd()
-                var offset = size
-                var lines: [String] = []
-
-                while offset > 0, lines.count < n {
-                    let readSize = min(1024, offset)
-                    offset -= readSize
-                    try fh.seek(toOffset: offset)
-
-                    let data = fh.readData(ofLength: Int(readSize))
-                    buffer.insert(contentsOf: data, at: 0)
-
-                    if let chunk = String(data: buffer, encoding: .utf8) {
-                        lines = chunk.components(separatedBy: .newlines)
-                        lines = lines.filter { !$0.isEmpty }
-                    }
-                }
-
-                lines = Array(lines.suffix(n))
-                for line in lines {
-                    print(line)
-                }
-            } else {
-                // Fast path if all they want is the full file.
-                guard let data = try fh.readToEnd() else {
-                    // Seems you get nil if it's a zero byte read, or you
-                    // try and read from dev/null.
-                    return
-                }
-                guard let str = String(data: data, encoding: .utf8) else {
-                    throw ContainerizationError(
-                        .internalError,
-                        message: "failed to convert container logs to utf8"
-                    )
-                }
-                print(str.trimmingCharacters(in: .newlines))
-            }
-
-            fflush(stdout)
-            if follow {
-                setbuf(stdout, nil)
-                try await Self.followFile(fh: fh)
-            }
-        }
-
-        private static func followFile(fh: FileHandle) async throws {
-            _ = try fh.seekToEnd()
-            let stream = AsyncStream<String> { cont in
-                fh.readabilityHandler = { handle in
-                    let data = handle.availableData
-                    if data.isEmpty {
-                        // Triggers on container restart - can exit here as well
-                        do {
-                            _ = try fh.seekToEnd()  // To continue streaming existing truncated log files
-                        } catch {
-                            fh.readabilityHandler = nil
-                            cont.finish()
-                            return
-                        }
-                    }
-                    if let str = String(data: data, encoding: .utf8), !str.isEmpty {
-                        var lines = str.components(separatedBy: .newlines)
-                        lines = lines.filter { !$0.isEmpty }
-                        for line in lines {
-                            cont.yield(line)
-                        }
-                    }
-                }
-            }
-
-            for await line in stream {
-                print(line)
-            }
         }
     }
 }

--- a/Sources/ContainerCommands/Container/ContainerLogs.swift
+++ b/Sources/ContainerCommands/Container/ContainerLogs.swift
@@ -73,17 +73,15 @@ extension Application {
                 fh: fileHandle,
                 n: follow ? numLines : nil,
                 follow: follow,
+                until: until?.date
             )
         }
 
         static func validateLogOptions(
-            follow: Bool,
-            since: ContainerLogTimestamp?,
-            until: ContainerLogTimestamp?
+            follow _: Bool,
+            since _: ContainerLogTimestamp?,
+            until _: ContainerLogTimestamp?
         ) throws {
-            if follow && (since != nil || until != nil) {
-                throw ValidationError("--follow cannot be combined with --since or --until")
-            }
         }
 
         static func retrievalOptions(

--- a/Sources/ContainerCommands/LogFileOutput.swift
+++ b/Sources/ContainerCommands/LogFileOutput.swift
@@ -23,6 +23,7 @@ struct LogFileOutput {
         fh: FileHandle,
         n: Int?,
         follow: Bool,
+        until: Date? = nil,
         output: FileHandle = .standardOutput
     ) async throws {
         if let n {
@@ -32,7 +33,7 @@ struct LogFileOutput {
         }
 
         if follow {
-            try await followFile(fh: fh, output: output)
+            try await followFile(fh: fh, output: output, until: until)
         }
     }
 
@@ -108,8 +109,12 @@ struct LogFileOutput {
 
     private static func followFile(
         fh: FileHandle,
-        output: FileHandle
+        output: FileHandle,
+        until: Date?
     ) async throws {
+        guard until.map({ $0 > Date() }) ?? true else {
+            return
+        }
         _ = try? fh.seekToEnd()
         let stream = AsyncStream<Data> { continuation in
             fh.readabilityHandler = { handle in
@@ -125,7 +130,20 @@ struct LogFileOutput {
                 }
                 continuation.yield(data)
             }
+
+            let stopTask = until.map { deadline in
+                Task {
+                    let seconds = deadline.timeIntervalSinceNow
+                    guard seconds > 0 else {
+                        continuation.finish()
+                        return
+                    }
+                    try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                    continuation.finish()
+                }
+            }
             continuation.onTermination = { _ in
+                stopTask?.cancel()
                 fh.readabilityHandler = nil
             }
         }

--- a/Sources/ContainerCommands/LogFileOutput.swift
+++ b/Sources/ContainerCommands/LogFileOutput.swift
@@ -36,14 +36,6 @@ struct LogFileOutput {
         }
     }
 
-    /// Writes existing raw log data without binding output to a specific file handle.
-    static func write(data: Data, n: Int?, output: FileHandle = .standardOutput) {
-        let selected = n.map { tailData(data, lineCount: $0) } ?? data
-        if !selected.isEmpty {
-            output.write(selected)
-        }
-    }
-
     /// Returns the final `lineCount` log records from `data`.
     static func tailData(_ data: Data, lineCount: Int) -> Data {
         guard lineCount != 0 else {

--- a/Sources/ContainerCommands/LogFileOutput.swift
+++ b/Sources/ContainerCommands/LogFileOutput.swift
@@ -1,0 +1,162 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Writes log file data while preserving the stored byte stream.
+struct LogFileOutput {
+    /// Writes all requested log data and optionally continues streaming appended bytes.
+    static func write(
+        fh: FileHandle,
+        n: Int?,
+        follow: Bool,
+        output: FileHandle = .standardOutput
+    ) async throws {
+        if let n {
+            try writeTail(fh: fh, lineCount: n, output: output)
+        } else {
+            try writeAll(fh: fh, output: output)
+        }
+
+        if follow {
+            try await followFile(fh: fh, output: output)
+        }
+    }
+
+    /// Writes existing raw log data without binding output to a specific file handle.
+    static func write(data: Data, n: Int?, output: FileHandle = .standardOutput) {
+        let selected = n.map { tailData(data, lineCount: $0) } ?? data
+        if !selected.isEmpty {
+            output.write(selected)
+        }
+    }
+
+    /// Returns the final `lineCount` log records from `data`.
+    static func tailData(_ data: Data, lineCount: Int) -> Data {
+        guard lineCount != 0 else {
+            return Data()
+        }
+        guard lineCount > 0 else {
+            return data
+        }
+
+        var index = data.endIndex
+        if index > data.startIndex, data[data.index(before: index)] == LogByte.lineFeed {
+            index = data.index(before: index)
+        }
+
+        var foundLines = 0
+        while index > data.startIndex {
+            let previous = data.index(before: index)
+            if data[previous] == LogByte.lineFeed {
+                foundLines += 1
+                if foundLines == lineCount {
+                    return Data(data[data.index(after: previous)..<data.endIndex])
+                }
+            }
+            index = previous
+        }
+
+        return data
+    }
+
+    private static func writeTail(
+        fh: FileHandle,
+        lineCount: Int,
+        output: FileHandle
+    ) throws {
+        guard lineCount != 0 else {
+            return
+        }
+        guard lineCount > 0 else {
+            try writeAll(fh: fh, output: output)
+            return
+        }
+
+        let size = try fh.seekToEnd()
+        var offset = size
+        var buffer = Data()
+
+        while offset > 0, countedLines(in: buffer) <= lineCount {
+            let readSize = min(1024, offset)
+            offset -= readSize
+            try fh.seek(toOffset: offset)
+            let data = fh.readData(ofLength: Int(readSize))
+            buffer.insert(contentsOf: data, at: 0)
+        }
+
+        let data = tailData(buffer, lineCount: lineCount)
+        if !data.isEmpty {
+            output.write(data)
+        }
+    }
+
+    private static func writeAll(
+        fh: FileHandle,
+        output: FileHandle
+    ) throws {
+        guard let data = try fh.readToEnd(), !data.isEmpty else {
+            return
+        }
+        output.write(data)
+    }
+
+    private static func followFile(
+        fh: FileHandle,
+        output: FileHandle
+    ) async throws {
+        _ = try? fh.seekToEnd()
+        let stream = AsyncStream<Data> { continuation in
+            fh.readabilityHandler = { handle in
+                let data = handle.availableData
+                if data.isEmpty {
+                    do {
+                        _ = try handle.seekToEnd()
+                    } catch {
+                        handle.readabilityHandler = nil
+                        continuation.finish()
+                    }
+                    return
+                }
+                continuation.yield(data)
+            }
+            continuation.onTermination = { _ in
+                fh.readabilityHandler = nil
+            }
+        }
+
+        for await data in stream {
+            output.write(data)
+        }
+    }
+
+    private static func countedLines(in data: Data) -> Int {
+        guard !data.isEmpty else {
+            return 0
+        }
+        let separatorCount = data.reduce(0) { count, byte in
+            byte == LogByte.lineFeed ? count + 1 : count
+        }
+        if data.last == LogByte.lineFeed {
+            return separatorCount
+        }
+        return separatorCount + 1
+    }
+}
+
+private enum LogByte {
+    static let lineFeed = UInt8(ascii: "\n")
+}

--- a/Sources/ContainerCommands/LogFileOutput.swift
+++ b/Sources/ContainerCommands/LogFileOutput.swift
@@ -23,7 +23,6 @@ struct LogFileOutput {
         fh: FileHandle,
         n: Int?,
         follow: Bool,
-        until: Date? = nil,
         output: FileHandle = .standardOutput
     ) async throws {
         if let n {
@@ -33,7 +32,7 @@ struct LogFileOutput {
         }
 
         if follow {
-            try await followFile(fh: fh, output: output, until: until)
+            try await followFile(fh: fh, output: output)
         }
     }
 
@@ -109,12 +108,8 @@ struct LogFileOutput {
 
     private static func followFile(
         fh: FileHandle,
-        output: FileHandle,
-        until: Date?
+        output: FileHandle
     ) async throws {
-        guard until.map({ $0 > Date() }) ?? true else {
-            return
-        }
         _ = try? fh.seekToEnd()
         let stream = AsyncStream<Data> { continuation in
             fh.readabilityHandler = { handle in
@@ -130,20 +125,7 @@ struct LogFileOutput {
                 }
                 continuation.yield(data)
             }
-
-            let stopTask = until.map { deadline in
-                Task {
-                    let seconds = deadline.timeIntervalSinceNow
-                    guard seconds > 0 else {
-                        continuation.finish()
-                        return
-                    }
-                    try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-                    continuation.finish()
-                }
-            }
             continuation.onTermination = { _ in
-                stopTask?.cancel()
                 fh.readabilityHandler = nil
             }
         }

--- a/Sources/ContainerResource/Container/ContainerLogOptions.swift
+++ b/Sources/ContainerResource/Container/ContainerLogOptions.swift
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Options that refine how `ContainerClient.logs(id:options:)` returns
+/// container log file handles.
+///
+/// Both fields are optional / additive; ``default`` is the zero-value
+/// equivalent to the original `logs(id:)` behavior.
+public struct ContainerLogOptions: Sendable, Codable {
+    /// If non-nil, log lines whose ISO-8601 timestamp prefix is older than
+    /// this date are filtered out before the file handle is returned to the
+    /// client. Lines without a parseable timestamp are passed through
+    /// unchanged.
+    public let since: Date?
+
+    /// If true, the client wants timestamps preserved on the returned lines.
+    /// At present this is a hint only — the daemon does not decorate raw log
+    /// lines that lack a timestamp prefix; line decoration is a follow-up.
+    public let timestamps: Bool
+
+    public static let `default` = ContainerLogOptions(since: nil, timestamps: false)
+
+    public init(since: Date? = nil, timestamps: Bool = false) {
+        self.since = since
+        self.timestamps = timestamps
+    }
+}

--- a/Sources/ContainerResource/Container/ContainerLogOptions.swift
+++ b/Sources/ContainerResource/Container/ContainerLogOptions.swift
@@ -21,7 +21,10 @@ import Foundation
 /// ``default`` is the zero-option equivalent to the original `logs(id:)`
 /// behavior.
 public struct ContainerLogOptions: Codable, Equatable, Sendable {
-    /// If non-nil and non-negative, return only the last `tail` log lines.
+    /// If non-nil, refine how many log lines are returned.
+    ///
+    /// Positive values return the last `tail` lines, zero returns no lines,
+    /// and negative values follow Docker's behavior of returning all lines.
     public let tail: Int?
 
     /// If non-nil, return log lines whose timestamp prefix is not older than

--- a/Sources/ContainerResource/Container/ContainerLogOptions.swift
+++ b/Sources/ContainerResource/Container/ContainerLogOptions.swift
@@ -16,6 +16,14 @@
 
 import Foundation
 
+/// Identifies which stored log stream should receive filtering options.
+public enum ContainerLogStream: String, Codable, Equatable, Sendable {
+    /// Workload stdio logs.
+    case stdio
+    /// VM boot logs.
+    case boot
+}
+
 /// Options that refine how container logs are returned.
 ///
 /// ``default`` is the zero-option equivalent to the original `logs(id:)`
@@ -44,17 +52,24 @@ public struct ContainerLogOptions: Codable, Equatable, Sendable {
     /// behavior as the log implementation evolves.
     public let timestamps: Bool
 
+    /// The log stream that should receive filtering options.
+    ///
+    /// When nil, filtering applies to every returned stream.
+    public let stream: ContainerLogStream?
+
     public static let `default` = ContainerLogOptions()
 
     public init(
         tail: Int? = nil,
         since: Date? = nil,
         until: Date? = nil,
-        timestamps: Bool = false
+        timestamps: Bool = false,
+        stream: ContainerLogStream? = nil
     ) {
         self.tail = tail
         self.since = since
         self.until = until
         self.timestamps = timestamps
+        self.stream = stream
     }
 }

--- a/Sources/ContainerResource/Container/ContainerLogOptions.swift
+++ b/Sources/ContainerResource/Container/ContainerLogOptions.swift
@@ -16,27 +16,40 @@
 
 import Foundation
 
-/// Options that refine how `ContainerClient.logs(id:options:)` returns
-/// container log file handles.
+/// Options that refine how container logs are returned.
 ///
-/// Both fields are optional / additive; ``default`` is the zero-value
-/// equivalent to the original `logs(id:)` behavior.
-public struct ContainerLogOptions: Sendable, Codable {
-    /// If non-nil, log lines whose ISO-8601 timestamp prefix is older than
-    /// this date are filtered out before the file handle is returned to the
-    /// client. Lines without a parseable timestamp are passed through
-    /// unchanged.
+/// ``default`` is the zero-option equivalent to the original `logs(id:)`
+/// behavior.
+public struct ContainerLogOptions: Codable, Equatable, Sendable {
+    /// If non-nil and non-negative, return only the last `tail` log lines.
+    public let tail: Int?
+
+    /// If non-nil, return log lines whose timestamp prefix is not older than
+    /// this date. Lines without a parseable timestamp prefix are preserved.
     public let since: Date?
 
-    /// If true, the client wants timestamps preserved on the returned lines.
-    /// At present this is a hint only — the daemon does not decorate raw log
-    /// lines that lack a timestamp prefix; line decoration is a follow-up.
+    /// If non-nil, return log lines whose timestamp prefix is not newer than
+    /// this date. Lines without a parseable timestamp prefix are preserved.
+    public let until: Date?
+
+    /// If true, callers want timestamps preserved on returned log lines.
+    ///
+    /// The current log files are already returned as stored; this value is
+    /// carried through the API boundary for callers that need stable timestamp
+    /// behavior as the log implementation evolves.
     public let timestamps: Bool
 
-    public static let `default` = ContainerLogOptions(since: nil, timestamps: false)
+    public static let `default` = ContainerLogOptions()
 
-    public init(since: Date? = nil, timestamps: Bool = false) {
+    public init(
+        tail: Int? = nil,
+        since: Date? = nil,
+        until: Date? = nil,
+        timestamps: Bool = false
+    ) {
+        self.tail = tail
         self.since = since
+        self.until = until
         self.timestamps = timestamps
     }
 }

--- a/Sources/ContainerResource/Container/ContainerLogOptions.swift
+++ b/Sources/ContainerResource/Container/ContainerLogOptions.swift
@@ -25,11 +25,13 @@ public struct ContainerLogOptions: Codable, Equatable, Sendable {
     public let tail: Int?
 
     /// If non-nil, return log lines whose timestamp prefix is not older than
-    /// this date. Lines without a parseable timestamp prefix are preserved.
+    /// this date. Logs without parseable timestamp prefixes cannot be filtered
+    /// safely and cause the request to fail.
     public let since: Date?
 
     /// If non-nil, return log lines whose timestamp prefix is not newer than
-    /// this date. Lines without a parseable timestamp prefix are preserved.
+    /// this date. Logs without parseable timestamp prefixes cannot be filtered
+    /// safely and cause the request to fail.
     public let until: Date?
 
     /// If true, callers want timestamps preserved on returned log lines.

--- a/Sources/ContainerResource/Container/ContainerLogTimestampParser.swift
+++ b/Sources/ContainerResource/Container/ContainerLogTimestampParser.swift
@@ -70,12 +70,23 @@ public struct ContainerLogTimestampParser: Sendable {
 
     /// Parses Go-style durations such as `1m30s`, `250ms`, and `1.5h`.
     public static func parseDuration(_ value: String) -> TimeInterval? {
-        guard !value.isEmpty, !value.hasPrefix("-") else {
+        guard !value.isEmpty else {
+            return nil
+        }
+
+        var sign: TimeInterval = 1
+        var index = value.startIndex
+        if value[index] == "-" {
+            sign = -1
+            index = value.index(after: index)
+        } else if value[index] == "+" {
+            index = value.index(after: index)
+        }
+        guard index < value.endIndex else {
             return nil
         }
 
         var total: TimeInterval = 0
-        var index = value.startIndex
         var parsedComponent = false
 
         while index < value.endIndex {
@@ -119,7 +130,7 @@ public struct ContainerLogTimestampParser: Sendable {
             parsedComponent = true
         }
 
-        return parsedComponent ? total : nil
+        return parsedComponent ? total * sign : nil
     }
 
     private static func parseLayoutTimestamp(_ value: String) -> Date? {

--- a/Sources/ContainerResource/Container/ContainerLogTimestampParser.swift
+++ b/Sources/ContainerResource/Container/ContainerLogTimestampParser.swift
@@ -30,6 +30,16 @@ public struct ContainerLogTimestampParser: Sendable {
         absoluteTimestampParser.parse(value)
     }
 
+    /// Parses a timestamp token that was read from a stored log record prefix.
+    ///
+    /// CLI filter arguments intentionally accept Docker-compatible local dates,
+    /// Unix timestamps, and relative durations. Runtime-authored log prefixes
+    /// need a stricter boundary: only RFC 3339-style timestamps with explicit
+    /// timezone information are treated as record timestamps.
+    public static func parseRecordTimestampPrefix(_ value: String) -> Date? {
+        recordTimestampPrefixParser.parse(value)
+    }
+
     /// Parses a Unix timestamp with optional fractional seconds.
     public static func parseUnixTimestamp(_ value: String) -> Date? {
         let parts = value.split(separator: ".", omittingEmptySubsequences: false)
@@ -126,6 +136,7 @@ public struct ContainerLogTimestampParser: Sendable {
     }
 
     private static let absoluteTimestampParser = AbsoluteTimestampParser()
+    private static let recordTimestampPrefixParser = RecordTimestampPrefixParser()
 
     private static let timestampLayouts = [
         "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXXXXX",
@@ -153,6 +164,65 @@ public struct ContainerLogTimestampParser: Sendable {
             return 60 * 60
         default:
             return nil
+        }
+    }
+
+    private final class RecordTimestampPrefixParser: @unchecked Sendable {
+        private let lock = NSLock()
+        private let fractionalFormatter: ISO8601DateFormatter
+        private let internetFormatter: ISO8601DateFormatter
+
+        init() {
+            let fractionalFormatter = ISO8601DateFormatter()
+            fractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            self.fractionalFormatter = fractionalFormatter
+
+            let internetFormatter = ISO8601DateFormatter()
+            internetFormatter.formatOptions = [.withInternetDateTime]
+            self.internetFormatter = internetFormatter
+        }
+
+        func parse(_ value: String) -> Date? {
+            guard Self.hasExplicitTimeZone(in: value) else {
+                return nil
+            }
+
+            lock.lock()
+            defer {
+                lock.unlock()
+            }
+
+            return fractionalFormatter.date(from: value)
+                ?? internetFormatter.date(from: value)
+        }
+
+        private static func hasExplicitTimeZone(in value: String) -> Bool {
+            guard let timeSeparator = value.firstIndex(of: "T") else {
+                return false
+            }
+
+            let timeStart = value.index(after: timeSeparator)
+            let timePart = value[timeStart..<value.endIndex]
+            if timePart.hasSuffix("Z") {
+                return true
+            }
+
+            guard let offsetStart = timePart.lastIndex(where: { $0 == "+" || $0 == "-" }) else {
+                return false
+            }
+
+            let offset = timePart[offsetStart..<timePart.endIndex]
+            guard offset.count == 6 else {
+                return false
+            }
+
+            let hourStart = offset.index(after: offsetStart)
+            let colonIndex = offset.index(hourStart, offsetBy: 2)
+            let minuteStart = offset.index(after: colonIndex)
+
+            return offset[colonIndex] == ":"
+                && offset[hourStart..<colonIndex].allSatisfy(\.isNumber)
+                && offset[minuteStart..<offset.endIndex].allSatisfy(\.isNumber)
         }
     }
 

--- a/Sources/ContainerResource/Container/ContainerLogTimestampParser.swift
+++ b/Sources/ContainerResource/Container/ContainerLogTimestampParser.swift
@@ -112,7 +112,14 @@ public struct ContainerLogTimestampParser: Sendable {
             guard let multiplier = durationMultiplier(unit) else {
                 return nil
             }
-            total += amount * multiplier
+            let component = amount * multiplier
+            guard component.isFinite else {
+                return nil
+            }
+            total += component
+            guard total.isFinite else {
+                return nil
+            }
             parsedComponent = true
         }
 
@@ -133,17 +140,15 @@ public struct ContainerLogTimestampParser: Sendable {
         return nil
     }
 
-    private static var timestampLayouts: [String] {
-        [
-            "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXXXXX",
-            "yyyy-MM-dd'T'HH:mm:ssXXXXX",
-            "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS",
-            "yyyy-MM-dd'T'HH:mm:ss",
-            "yyyy-MM-dd'T'HH:mmXXXXX",
-            "yyyy-MM-dd'T'HH:mm",
-            "yyyy-MM-dd",
-        ]
-    }
+    private static let timestampLayouts = [
+        "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXXXXX",
+        "yyyy-MM-dd'T'HH:mm:ssXXXXX",
+        "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS",
+        "yyyy-MM-dd'T'HH:mm:ss",
+        "yyyy-MM-dd'T'HH:mmXXXXX",
+        "yyyy-MM-dd'T'HH:mm",
+        "yyyy-MM-dd",
+    ]
 
     private static func durationMultiplier(_ unit: String) -> TimeInterval? {
         switch unit {

--- a/Sources/ContainerResource/Container/ContainerLogTimestampParser.swift
+++ b/Sources/ContainerResource/Container/ContainerLogTimestampParser.swift
@@ -1,0 +1,166 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Parses log timestamp filters accepted by Docker-compatible log commands.
+public struct ContainerLogTimestampParser: Sendable {
+    /// Parses absolute timestamps, Unix timestamps, or relative durations.
+    public static func parse(_ value: String, relativeTo now: Date = Date()) -> Date? {
+        parseAbsoluteTimestamp(value)
+            ?? parseUnixTimestamp(value)
+            ?? parseDuration(value).map { now.addingTimeInterval(-$0) }
+    }
+
+    /// Parses an absolute timestamp without interpreting relative durations.
+    public static func parseAbsoluteTimestamp(_ value: String) -> Date? {
+        let fractionalFormatter = ISO8601DateFormatter()
+        fractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        let internetFormatter = ISO8601DateFormatter()
+        internetFormatter.formatOptions = [.withInternetDateTime]
+
+        let dateOnlyFormatter = ISO8601DateFormatter()
+        dateOnlyFormatter.formatOptions = [.withFullDate]
+
+        return fractionalFormatter.date(from: value)
+            ?? internetFormatter.date(from: value)
+            ?? dateOnlyFormatter.date(from: value)
+            ?? parseLayoutTimestamp(value)
+    }
+
+    /// Parses a Unix timestamp with optional fractional seconds.
+    public static func parseUnixTimestamp(_ value: String) -> Date? {
+        let parts = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count <= 2,
+            let secondsPart = parts.first,
+            !secondsPart.isEmpty,
+            secondsPart.allSatisfy(\.isNumber),
+            let seconds = TimeInterval(String(secondsPart)),
+            seconds.isFinite,
+            seconds >= 0
+        else {
+            return nil
+        }
+
+        var fractionalSeconds: TimeInterval = 0
+        if parts.count == 2 {
+            let fractionPart = parts[1]
+            guard !fractionPart.isEmpty,
+                fractionPart.count <= 9,
+                fractionPart.allSatisfy(\.isNumber),
+                let fraction = TimeInterval("0.\(fractionPart)")
+            else {
+                return nil
+            }
+            fractionalSeconds = fraction
+        }
+
+        return Date(timeIntervalSince1970: seconds + fractionalSeconds)
+    }
+
+    /// Parses Go-style durations such as `1m30s`, `250ms`, and `1.5h`.
+    public static func parseDuration(_ value: String) -> TimeInterval? {
+        guard !value.isEmpty, !value.hasPrefix("-") else {
+            return nil
+        }
+
+        var total: TimeInterval = 0
+        var index = value.startIndex
+        var parsedComponent = false
+
+        while index < value.endIndex {
+            let numberStart = index
+            var seenDecimalPoint = false
+            while index < value.endIndex {
+                let character = value[index]
+                if character.isNumber {
+                    index = value.index(after: index)
+                } else if character == ".", !seenDecimalPoint {
+                    seenDecimalPoint = true
+                    index = value.index(after: index)
+                } else {
+                    break
+                }
+            }
+
+            guard numberStart < index,
+                let amount = TimeInterval(value[numberStart..<index]),
+                amount.isFinite
+            else {
+                return nil
+            }
+
+            let unitStart = index
+            while index < value.endIndex, value[index].isLetter || value[index] == "µ" || value[index] == "μ" {
+                index = value.index(after: index)
+            }
+            let unit = String(value[unitStart..<index])
+            guard let multiplier = durationMultiplier(unit) else {
+                return nil
+            }
+            total += amount * multiplier
+            parsedComponent = true
+        }
+
+        return parsedComponent ? total : nil
+    }
+
+    private static func parseLayoutTimestamp(_ value: String) -> Date? {
+        for format in timestampLayouts {
+            let formatter = DateFormatter()
+            formatter.calendar = Calendar(identifier: .gregorian)
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone.current
+            formatter.dateFormat = format
+            if let date = formatter.date(from: value) {
+                return date
+            }
+        }
+        return nil
+    }
+
+    private static var timestampLayouts: [String] {
+        [
+            "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXXXXX",
+            "yyyy-MM-dd'T'HH:mm:ssXXXXX",
+            "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS",
+            "yyyy-MM-dd'T'HH:mm:ss",
+            "yyyy-MM-dd'T'HH:mmXXXXX",
+            "yyyy-MM-dd'T'HH:mm",
+            "yyyy-MM-dd",
+        ]
+    }
+
+    private static func durationMultiplier(_ unit: String) -> TimeInterval? {
+        switch unit {
+        case "ns":
+            return 0.000_000_001
+        case "us", "µs", "μs":
+            return 0.000_001
+        case "ms":
+            return 0.001
+        case "s":
+            return 1
+        case "m":
+            return 60
+        case "h":
+            return 60 * 60
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/ContainerResource/Container/ContainerLogTimestampParser.swift
+++ b/Sources/ContainerResource/Container/ContainerLogTimestampParser.swift
@@ -33,12 +33,8 @@ public struct ContainerLogTimestampParser: Sendable {
         let internetFormatter = ISO8601DateFormatter()
         internetFormatter.formatOptions = [.withInternetDateTime]
 
-        let dateOnlyFormatter = ISO8601DateFormatter()
-        dateOnlyFormatter.formatOptions = [.withFullDate]
-
         return fractionalFormatter.date(from: value)
             ?? internetFormatter.date(from: value)
-            ?? dateOnlyFormatter.date(from: value)
             ?? parseLayoutTimestamp(value)
     }
 

--- a/Sources/ContainerResource/Container/ContainerLogTimestampParser.swift
+++ b/Sources/ContainerResource/Container/ContainerLogTimestampParser.swift
@@ -27,15 +27,7 @@ public struct ContainerLogTimestampParser: Sendable {
 
     /// Parses an absolute timestamp without interpreting relative durations.
     public static func parseAbsoluteTimestamp(_ value: String) -> Date? {
-        let fractionalFormatter = ISO8601DateFormatter()
-        fractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-
-        let internetFormatter = ISO8601DateFormatter()
-        internetFormatter.formatOptions = [.withInternetDateTime]
-
-        return fractionalFormatter.date(from: value)
-            ?? internetFormatter.date(from: value)
-            ?? parseLayoutTimestamp(value)
+        absoluteTimestampParser.parse(value)
     }
 
     /// Parses a Unix timestamp with optional fractional seconds.
@@ -133,19 +125,7 @@ public struct ContainerLogTimestampParser: Sendable {
         return parsedComponent ? total * sign : nil
     }
 
-    private static func parseLayoutTimestamp(_ value: String) -> Date? {
-        for format in timestampLayouts {
-            let formatter = DateFormatter()
-            formatter.calendar = Calendar(identifier: .gregorian)
-            formatter.locale = Locale(identifier: "en_US_POSIX")
-            formatter.timeZone = TimeZone.current
-            formatter.dateFormat = format
-            if let date = formatter.date(from: value) {
-                return date
-            }
-        }
-        return nil
-    }
+    private static let absoluteTimestampParser = AbsoluteTimestampParser()
 
     private static let timestampLayouts = [
         "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXXXXX",
@@ -172,6 +152,52 @@ public struct ContainerLogTimestampParser: Sendable {
         case "h":
             return 60 * 60
         default:
+            return nil
+        }
+    }
+
+    private final class AbsoluteTimestampParser: @unchecked Sendable {
+        private let lock = NSLock()
+        private let fractionalFormatter: ISO8601DateFormatter
+        private let internetFormatter: ISO8601DateFormatter
+        private let layoutFormatters: [DateFormatter]
+
+        init() {
+            let fractionalFormatter = ISO8601DateFormatter()
+            fractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            self.fractionalFormatter = fractionalFormatter
+
+            let internetFormatter = ISO8601DateFormatter()
+            internetFormatter.formatOptions = [.withInternetDateTime]
+            self.internetFormatter = internetFormatter
+
+            self.layoutFormatters = timestampLayouts.map { format in
+                let formatter = DateFormatter()
+                formatter.calendar = Calendar(identifier: .gregorian)
+                formatter.locale = Locale(identifier: "en_US_POSIX")
+                formatter.dateFormat = format
+                return formatter
+            }
+        }
+
+        func parse(_ value: String) -> Date? {
+            lock.lock()
+            defer {
+                lock.unlock()
+            }
+
+            return fractionalFormatter.date(from: value)
+                ?? internetFormatter.date(from: value)
+                ?? parseLayoutTimestamp(value)
+        }
+
+        private func parseLayoutTimestamp(_ value: String) -> Date? {
+            for formatter in layoutFormatters {
+                formatter.timeZone = TimeZone.current
+                if let date = formatter.date(from: value) {
+                    return date
+                }
+            }
             return nil
         }
     }

--- a/Sources/ContainerXPC/XPCMessage.swift
+++ b/Sources/ContainerXPC/XPCMessage.swift
@@ -117,6 +117,7 @@ extension XPCMessage {
         return Data(bytes: bytes, count: length)
     }
 
+    /// Returns true when the message contains a value for the provided key.
     public func contains(key: String) -> Bool {
         lock.withLock {
             xpc_dictionary_get_value(self.object, key) != nil

--- a/Sources/ContainerXPC/XPCMessage.swift
+++ b/Sources/ContainerXPC/XPCMessage.swift
@@ -117,6 +117,12 @@ extension XPCMessage {
         return Data(bytes: bytes, count: length)
     }
 
+    public func contains(key: String) -> Bool {
+        lock.withLock {
+            xpc_dictionary_get_value(self.object, key) != nil
+        }
+    }
+
     /// dataNoCopy is similar to data, except the data is not copied
     /// to a new buffer. What this means in practice is the second the
     /// underlying xpc_object_t gets released by ARC the data will be

--- a/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
+++ b/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
@@ -267,18 +267,19 @@ public struct ContainerClient: Sendable {
         try await logs(id: id, options: .default)
     }
 
-    /// Get the log file handles for a container, refined by ``ContainerLogOptions``.
-    ///
-    /// `options.since` filters out log lines whose ISO-8601 timestamp prefix
-    /// predates the given date; lines without a parseable timestamp are
-    /// passed through. `options.timestamps` is forwarded to the daemon as a
-    /// hint; line-level timestamp decoration is a deferred follow-up.
+    /// Get the log file handles for a container.
     public func logs(id: String, options: ContainerLogOptions) async throws -> [FileHandle] {
         do {
             let request = XPCMessage(route: .containerLogs)
             request.set(key: .id, value: id)
+            if let tail = options.tail {
+                request.set(key: .logTail, value: Int64(tail))
+            }
             if let since = options.since {
                 request.set(key: .logSince, value: since)
+            }
+            if let until = options.until {
+                request.set(key: .logUntil, value: until)
             }
             request.set(key: .logTimestamps, value: options.timestamps)
 

--- a/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
+++ b/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
@@ -282,6 +282,9 @@ public struct ContainerClient: Sendable {
                 request.set(key: .logUntil, value: until)
             }
             request.set(key: .logTimestamps, value: options.timestamps)
+            if let stream = options.stream {
+                request.set(key: .logStream, value: stream.rawValue)
+            }
 
             let response = try await xpcClient.send(request)
             let fds = response.fileHandles(key: .logs)

--- a/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
+++ b/Sources/Services/ContainerAPIService/Client/ContainerClient.swift
@@ -264,9 +264,23 @@ public struct ContainerClient: Sendable {
 
     /// Get the log file handles for a container.
     public func logs(id: String) async throws -> [FileHandle] {
+        try await logs(id: id, options: .default)
+    }
+
+    /// Get the log file handles for a container, refined by ``ContainerLogOptions``.
+    ///
+    /// `options.since` filters out log lines whose ISO-8601 timestamp prefix
+    /// predates the given date; lines without a parseable timestamp are
+    /// passed through. `options.timestamps` is forwarded to the daemon as a
+    /// hint; line-level timestamp decoration is a deferred follow-up.
+    public func logs(id: String, options: ContainerLogOptions) async throws -> [FileHandle] {
         do {
             let request = XPCMessage(route: .containerLogs)
             request.set(key: .id, value: id)
+            if let since = options.since {
+                request.set(key: .logSince, value: since)
+            }
+            request.set(key: .logTimestamps, value: options.timestamps)
 
             let response = try await xpcClient.send(request)
             let fds = response.fileHandles(key: .logs)

--- a/Sources/Services/ContainerAPIService/Client/XPC+.swift
+++ b/Sources/Services/ContainerAPIService/Client/XPC+.swift
@@ -156,6 +156,8 @@ public enum XPCKeys: String {
     case logUntil
     /// Timestamp preference for container logs.
     case logTimestamps
+    /// Stream selected for container log filtering.
+    case logStream
 }
 
 public enum XPCRoute: String {

--- a/Sources/Services/ContainerAPIService/Client/XPC+.swift
+++ b/Sources/Services/ContainerAPIService/Client/XPC+.swift
@@ -148,9 +148,13 @@ public enum XPCKeys: String {
     case fileMode
     case createParents
 
-    /// Optional `since: Date` filter on `logs`.
+    /// Optional tail line limit for container logs.
+    case logTail
+    /// Optional lower timestamp bound for container logs.
     case logSince
-    /// Optional `timestamps: Bool` flag on `logs`.
+    /// Optional upper timestamp bound for container logs.
+    case logUntil
+    /// Timestamp preference for container logs.
     case logTimestamps
 }
 

--- a/Sources/Services/ContainerAPIService/Client/XPC+.swift
+++ b/Sources/Services/ContainerAPIService/Client/XPC+.swift
@@ -147,6 +147,11 @@ public enum XPCKeys: String {
     case destinationPath
     case fileMode
     case createParents
+
+    /// Optional `since: Date` filter on `logs`.
+    case logSince
+    /// Optional `timestamps: Bool` flag on `logs`.
+    case logTimestamps
 }
 
 public enum XPCRoute: String {
@@ -205,6 +210,10 @@ extension XPCMessage {
 
     public func dataNoCopy(key: XPCKeys) -> Data? {
         dataNoCopy(key: key.rawValue)
+    }
+
+    public func contains(key: XPCKeys) -> Bool {
+        contains(key: key.rawValue)
     }
 
     public func set(key: XPCKeys, value: Data) {

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift
@@ -289,10 +289,19 @@ public struct ContainersHarness: Sendable {
                 message: "id cannot be empty"
             )
         }
-        let fds = try await service.logs(id: id)
+
+        let options = Self.logOptions(from: message)
+
+        let fds = try await service.logs(id: id, options: options)
         let reply = message.reply()
         try reply.set(key: .logs, value: fds)
         return reply
+    }
+
+    static func logOptions(from message: XPCMessage) -> ContainerLogOptions {
+        let since = message.contains(key: .logSince) ? message.date(key: .logSince) : nil
+        let timestamps = message.bool(key: .logTimestamps)
+        return ContainerLogOptions(since: since, timestamps: timestamps)
     }
 
     @Sendable

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift
@@ -289,22 +289,37 @@ public struct ContainersHarness: Sendable {
                 message: "id cannot be empty"
             )
         }
-        let options = Self.logOptions(from: message)
+        let options = try Self.logOptions(from: message)
         let fds = try await service.logs(id: id, options: options)
         let reply = message.reply()
         try reply.set(key: .logs, value: fds)
         return reply
     }
 
-    static func logOptions(from message: XPCMessage) -> ContainerLogOptions {
+    static func logOptions(from message: XPCMessage) throws -> ContainerLogOptions {
         let tail = message.contains(key: .logTail) ? Int(message.int64(key: .logTail)) : nil
         let since = message.contains(key: .logSince) ? message.date(key: .logSince) : nil
         let until = message.contains(key: .logUntil) ? message.date(key: .logUntil) : nil
+        let stream: ContainerLogStream?
+        if message.contains(key: .logStream) {
+            guard let value = message.string(key: .logStream),
+                let decoded = ContainerLogStream(rawValue: value)
+            else {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "invalid container log stream"
+                )
+            }
+            stream = decoded
+        } else {
+            stream = nil
+        }
         return ContainerLogOptions(
             tail: tail,
             since: since,
             until: until,
-            timestamps: message.bool(key: .logTimestamps)
+            timestamps: message.bool(key: .logTimestamps),
+            stream: stream
         )
     }
 

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift
@@ -289,9 +289,7 @@ public struct ContainersHarness: Sendable {
                 message: "id cannot be empty"
             )
         }
-
         let options = Self.logOptions(from: message)
-
         let fds = try await service.logs(id: id, options: options)
         let reply = message.reply()
         try reply.set(key: .logs, value: fds)
@@ -299,9 +297,15 @@ public struct ContainersHarness: Sendable {
     }
 
     static func logOptions(from message: XPCMessage) -> ContainerLogOptions {
+        let tail = message.contains(key: .logTail) ? Int(message.int64(key: .logTail)) : nil
         let since = message.contains(key: .logSince) ? message.date(key: .logSince) : nil
-        let timestamps = message.bool(key: .logTimestamps)
-        return ContainerLogOptions(since: since, timestamps: timestamps)
+        let until = message.contains(key: .logUntil) ? message.date(key: .logUntil) : nil
+        return ContainerLogOptions(
+            tail: tail,
+            since: since,
+            until: until,
+            timestamps: message.bool(key: .logTimestamps)
+        )
     }
 
     @Sendable

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -1113,7 +1113,7 @@ public actor ContainersService {
         }
 
         private func timestampPrefix(fromTimestampToken timestamp: String) -> Date? {
-            ContainerLogTimestampParser.parseAbsoluteTimestamp(timestamp)
+            ContainerLogTimestampParser.parseRecordTimestampPrefix(timestamp)
         }
     }
 

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -764,21 +764,10 @@ public actor ContainersService {
             let path = self.containerRoot.appendingPathComponent(id)
             let bundle = ContainerResource.Bundle(path: path)
             let handles = [
-                try FileHandle(forReadingFrom: bundle.containerLog),
-                try FileHandle(forReadingFrom: bundle.bootlog),
+                LogHandle(stream: .stdio, handle: try FileHandle(forReadingFrom: bundle.containerLog)),
+                LogHandle(stream: .boot, handle: try FileHandle(forReadingFrom: bundle.bootlog)),
             ]
-            var filteredHandles: [FileHandle] = []
-            do {
-                for handle in handles {
-                    filteredHandles.append(try Self.applyLogOptions(to: handle, options: options))
-                }
-                return filteredHandles
-            } catch {
-                for handle in handles + filteredHandles {
-                    try? handle.close()
-                }
-                throw error
-            }
+            return try Self.applyLogOptions(to: handles, options: options)
         } catch let error as ContainerizationError {
             throw error
         } catch {
@@ -786,6 +775,28 @@ public actor ContainersService {
                 .internalError,
                 message: "failed to open container logs: \(error)"
             )
+        }
+    }
+
+    static func applyLogOptions(
+        to handles: [LogHandle],
+        options: ContainerLogOptions
+    ) throws -> [FileHandle] {
+        var filteredHandles: [FileHandle] = []
+        do {
+            for logHandle in handles {
+                guard options.stream == nil || options.stream == logHandle.stream else {
+                    filteredHandles.append(logHandle.handle)
+                    continue
+                }
+                filteredHandles.append(try Self.applyLogOptions(to: logHandle.handle, options: options))
+            }
+            return filteredHandles
+        } catch {
+            for handle in handles.map(\.handle) + filteredHandles {
+                try? handle.close()
+            }
+            throw error
         }
     }
 
@@ -925,7 +936,7 @@ public actor ContainersService {
         timestampParser: LogTimestampParser
     ) throws -> Bool {
         guard let timestamp = timestampParser.timestampPrefix(from: line.data) else {
-            guard (options.since == nil && options.until == nil) || line.data.isEmpty else {
+            guard options.since == nil && options.until == nil else {
                 throw ContainerizationError(
                     .invalidArgument,
                     message: "cannot apply timestamp filters to container logs without timestamp prefixes"
@@ -1041,6 +1052,11 @@ public actor ContainersService {
     private struct LogDataLine {
         var data: Data
         var terminated: Bool
+    }
+
+    struct LogHandle {
+        var stream: ContainerLogStream
+        var handle: FileHandle
     }
 
     /// Fixed-size tail retention for filtered replay.

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -27,6 +27,7 @@ import ContainerizationError
 import ContainerizationExtras
 import ContainerizationOCI
 import ContainerizationOS
+import Darwin
 import Foundation
 import Logging
 import SystemPackage
@@ -729,8 +730,11 @@ public actor ContainersService {
         try await client.resize(processID, size: size)
     }
 
-    // Get the logs for the container.
     public func logs(id: String) async throws -> [FileHandle] {
+        try await logs(id: id, options: .default)
+    }
+
+    public func logs(id: String, options: ContainerLogOptions) async throws -> [FileHandle] {
         log.debug(
             "ContainersService: enter",
             metadata: [
@@ -748,18 +752,22 @@ public actor ContainersService {
             )
         }
 
-        // Logs doesn't care if the container is running or not, just that
-        // the bundle is there, and that the files actually exist. We do
-        // first try and get the container state so we get a nicer error message
-        // (container foo not found) however.
         do {
             _ = try _getContainerState(id: id)
             let path = self.containerRoot.appendingPathComponent(id)
             let bundle = ContainerResource.Bundle(path: path)
-            return [
+            var handles = [
                 try FileHandle(forReadingFrom: bundle.containerLog),
                 try FileHandle(forReadingFrom: bundle.bootlog),
             ]
+
+            if let since = options.since {
+                handles = handles.map { fh in
+                    Self.filterFileHandleSince(fh, since: since)
+                }
+            }
+
+            return handles
         } catch {
             throw ContainerizationError(
                 .internalError,
@@ -790,6 +798,92 @@ public actor ContainersService {
         }
         let client = try state.getClient()
         try await client.copyOut(source: source, destination: destination, createParents: createParents)
+    }
+
+    static func filterFileHandleSince(_ fh: FileHandle, since: Date) -> FileHandle {
+        guard let data = try? fh.readToEnd() else {
+            return fh
+        }
+        guard let result = Self.filteredLogData(data, since: since) else {
+            try? fh.seek(toOffset: 0)
+            return fh
+        }
+
+        if let filteredHandle = Self.temporaryFileHandle(containing: result) {
+            return filteredHandle
+        }
+        try? fh.seek(toOffset: 0)
+        return fh
+    }
+
+    static func filteredLogData(_ data: Data, since: Date) -> Data? {
+        guard let content = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        let iso8601 = ISO8601DateFormatter()
+        iso8601.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let fallbackFormatter = ISO8601DateFormatter()
+        fallbackFormatter.formatOptions = [.withInternetDateTime]
+
+        let lines = content.components(separatedBy: "\n")
+        var filtered: [String] = []
+        for line in lines {
+            guard !line.isEmpty else {
+                filtered.append(line)
+                continue
+            }
+            let parts = line.split(separator: " ", maxSplits: 1)
+            guard let timestampStr = parts.first else {
+                filtered.append(line)
+                continue
+            }
+            if let date = iso8601.date(from: String(timestampStr)) ?? fallbackFormatter.date(from: String(timestampStr)) {
+                if date >= since {
+                    filtered.append(line)
+                }
+            } else {
+                filtered.append(line)
+            }
+        }
+
+        let result = filtered.joined(separator: "\n")
+        return result.data(using: .utf8)
+    }
+
+    private static func temporaryFileHandle(containing data: Data) -> FileHandle? {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("container-log-filter-")
+            .appendingPathExtension(UUID().uuidString)
+        let fd = open(url.path, O_CREAT | O_EXCL | O_RDWR, S_IRUSR | S_IWUSR)
+        guard fd >= 0 else {
+            return nil
+        }
+
+        let success = data.withUnsafeBytes { buffer in
+            guard let baseAddress = buffer.baseAddress else {
+                return true
+            }
+            var remaining = buffer.count
+            var pointer = baseAddress
+            while remaining > 0 {
+                let written = write(fd, pointer, remaining)
+                guard written > 0 else {
+                    return false
+                }
+                remaining -= written
+                pointer += written
+            }
+            return true
+        }
+
+        guard success, lseek(fd, 0, SEEK_SET) >= 0 else {
+            close(fd)
+            try? FileManager.default.removeItem(at: url)
+            return nil
+        }
+
+        try? FileManager.default.removeItem(at: url)
+        return FileHandle(fileDescriptor: fd, closeOnDealloc: true)
     }
 
     /// Get statistics for the container.

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -766,8 +766,17 @@ public actor ContainersService {
                 try FileHandle(forReadingFrom: bundle.containerLog),
                 try FileHandle(forReadingFrom: bundle.bootlog),
             ]
-            return handles.map { handle in
-                Self.applyLogOptions(to: handle, options: options)
+            var filteredHandles: [FileHandle] = []
+            do {
+                for handle in handles {
+                    filteredHandles.append(try Self.applyLogOptions(to: handle, options: options))
+                }
+                return filteredHandles
+            } catch {
+                for handle in handles + filteredHandles {
+                    try? handle.close()
+                }
+                throw error
             }
         } catch {
             throw ContainerizationError(
@@ -777,7 +786,11 @@ public actor ContainersService {
         }
     }
 
-    static func applyLogOptions(to handle: FileHandle, options: ContainerLogOptions) -> FileHandle {
+    static func applyLogOptions(
+        to handle: FileHandle,
+        options: ContainerLogOptions,
+        temporaryDirectory: URL = FileManager.default.temporaryDirectory
+    ) throws -> FileHandle {
         guard options.tail != nil || options.since != nil || options.until != nil else {
             return handle
         }
@@ -786,27 +799,14 @@ public actor ContainersService {
                 return handle
             }
 
-            do {
-                let data = try Self.tailLogData(from: handle, lineCount: tail)
-                guard let filteredHandle = Self.temporaryFileHandle(containing: data) else {
-                    try? handle.seek(toOffset: 0)
-                    return handle
-                }
-                try? handle.close()
-                return filteredHandle
-            } catch {
-                try? handle.seek(toOffset: 0)
-                return handle
-            }
+            let data = try Self.tailLogData(from: handle, lineCount: tail)
+            let filteredHandle = try Self.temporaryFileHandle(containing: data, in: temporaryDirectory)
+            try? handle.close()
+            return filteredHandle
         }
-        guard let data = try? handle.readToEnd() else {
-            return handle
-        }
+        let data = try handle.readToEnd() ?? Data()
         let filtered = Self.filteredLogData(data, options: options)
-        guard let filteredHandle = Self.temporaryFileHandle(containing: filtered) else {
-            try? handle.seek(toOffset: 0)
-            return handle
-        }
+        let filteredHandle = try Self.temporaryFileHandle(containing: filtered, in: temporaryDirectory)
         try? handle.close()
         return filteredHandle
     }
@@ -881,8 +881,12 @@ public actor ContainersService {
         return joinedLogData(lines)
     }
 
-    private static func temporaryFileHandle(containing data: Data) -> FileHandle? {
-        let url = FileManager.default.temporaryDirectory
+    private static func temporaryFileHandle(
+        containing data: Data,
+        in temporaryDirectory: URL
+    ) throws -> FileHandle {
+        let url =
+            temporaryDirectory
             .appendingPathComponent("container-log-\(UUID().uuidString)")
         do {
             try data.write(to: url)
@@ -891,7 +895,11 @@ public actor ContainersService {
             return handle
         } catch {
             try? FileManager.default.removeItem(at: url)
-            return nil
+            throw ContainerizationError(
+                .internalError,
+                message: "failed to prepare filtered container logs",
+                cause: error
+            )
         }
     }
 

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -1104,19 +1104,6 @@ public actor ContainersService {
     }
 
     private struct LogTimestampParser {
-        private let fractionalFormatter: ISO8601DateFormatter
-        private let formatter: ISO8601DateFormatter
-
-        init() {
-            let fractionalFormatter = ISO8601DateFormatter()
-            fractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-            self.fractionalFormatter = fractionalFormatter
-
-            let formatter = ISO8601DateFormatter()
-            formatter.formatOptions = [.withInternetDateTime]
-            self.formatter = formatter
-        }
-
         func timestampPrefix(from line: Data) -> Date? {
             let token = Data(line.prefix { $0 != UInt8(ascii: " ") })
             guard let timestamp = String(data: token, encoding: .utf8) else {
@@ -1126,11 +1113,7 @@ public actor ContainersService {
         }
 
         private func timestampPrefix(fromTimestampToken timestamp: String) -> Date? {
-            if let date = fractionalFormatter.date(from: timestamp) {
-                return date
-            }
-
-            return formatter.date(from: timestamp)
+            ContainerLogTimestampParser.parseAbsoluteTimestamp(timestamp)
         }
     }
 

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -1055,7 +1055,6 @@ public actor ContainersService {
 
         init(capacity: Int) {
             self.capacity = max(capacity, 0)
-            self.storage.reserveCapacity(self.capacity)
         }
 
         mutating func append(_ line: LogDataLine) {

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -27,6 +27,7 @@ import ContainerizationError
 import ContainerizationExtras
 import ContainerizationOCI
 import ContainerizationOS
+import Darwin
 import Foundation
 import Logging
 import SystemPackage
@@ -888,12 +889,48 @@ public actor ContainersService {
         let url =
             temporaryDirectory
             .appendingPathComponent("container-log-\(UUID().uuidString)")
+        let fd = Darwin.open(url.path, O_CREAT | O_EXCL | O_RDWR, S_IRUSR | S_IWUSR)
+        guard fd >= 0 else {
+            throw ContainerizationError(
+                .internalError,
+                message: "failed to prepare filtered container logs",
+                cause: POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            )
+        }
+
+        var closeFileDescriptor = true
         do {
-            try data.write(to: url)
-            let handle = try FileHandle(forReadingFrom: url)
+            try data.withUnsafeBytes { buffer in
+                guard var pointer = buffer.baseAddress else {
+                    return
+                }
+                var remaining = buffer.count
+                while remaining > 0 {
+                    let written = Darwin.write(fd, pointer, remaining)
+                    if written < 0 {
+                        if errno == EINTR {
+                            continue
+                        }
+                        throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+                    }
+                    guard written > 0 else {
+                        throw POSIXError(.EIO)
+                    }
+                    remaining -= written
+                    pointer = pointer.advanced(by: written)
+                }
+            }
+            guard Darwin.lseek(fd, 0, SEEK_SET) >= 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+            let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+            closeFileDescriptor = false
             try? FileManager.default.removeItem(at: url)
             return handle
         } catch {
+            if closeFileDescriptor {
+                Darwin.close(fd)
+            }
             try? FileManager.default.removeItem(at: url)
             throw ContainerizationError(
                 .internalError,

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -864,6 +864,10 @@ public actor ContainersService {
     }
 
     static func filteredLogData(_ data: Data, options: ContainerLogOptions) throws -> Data {
+        if options.tail == 0 {
+            return Data()
+        }
+
         guard !data.isEmpty else {
             return Data()
         }
@@ -875,9 +879,6 @@ public actor ContainersService {
         }
 
         if let tail = options.tail, tail >= 0 {
-            if tail == 0 {
-                return Data()
-            }
             lines = Array(lines.suffix(tail))
         }
 

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -923,9 +923,11 @@ public actor ContainersService {
             guard Darwin.lseek(fd, 0, SEEK_SET) >= 0 else {
                 throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
             }
+            guard Darwin.unlink(url.path) == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
             let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
             closeFileDescriptor = false
-            try? FileManager.default.removeItem(at: url)
             return handle
         } catch {
             if closeFileDescriptor {

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -50,6 +50,7 @@ public actor ContainersService {
 
     private static let machServicePrefix = "com.apple.container"
     private static let launchdDomainString = try! ServiceManager.getDomainString()
+    private static let logTailReadChunkSize = UInt64(32 * 1024)
 
     private let log: Logger
     private let debugHelpers: Bool
@@ -780,6 +781,24 @@ public actor ContainersService {
         guard options.tail != nil || options.since != nil || options.until != nil else {
             return handle
         }
+        if let tail = options.tail, options.since == nil, options.until == nil {
+            guard tail >= 0 else {
+                return handle
+            }
+
+            do {
+                let data = try Self.tailLogData(from: handle, lineCount: tail)
+                guard let filteredHandle = Self.temporaryFileHandle(containing: data) else {
+                    try? handle.seek(toOffset: 0)
+                    return handle
+                }
+                try? handle.close()
+                return filteredHandle
+            } catch {
+                try? handle.seek(toOffset: 0)
+                return handle
+            }
+        }
         guard let data = try? handle.readToEnd() else {
             return handle
         }
@@ -790,6 +809,45 @@ public actor ContainersService {
         }
         try? handle.close()
         return filteredHandle
+    }
+
+    static func tailLogData(from handle: FileHandle, lineCount: Int) throws -> Data {
+        guard lineCount != 0 else {
+            return Data()
+        }
+        guard lineCount > 0 else {
+            try handle.seek(toOffset: 0)
+            return handle.readDataToEndOfFile()
+        }
+
+        var buffer = Data()
+        try prependTailData(from: handle, lineCount: lineCount, into: &buffer)
+        return filteredLogData(buffer, options: ContainerLogOptions(tail: lineCount))
+    }
+
+    private static func prependTailData(
+        from handle: FileHandle,
+        lineCount: Int,
+        into buffer: inout Data
+    ) throws {
+        var offset = try handle.seekToEnd()
+        while offset > 0, countedLogLines(in: buffer) <= lineCount {
+            let readSize = min(logTailReadChunkSize, offset)
+            offset -= readSize
+            try handle.seek(toOffset: offset)
+            buffer.insert(contentsOf: handle.readData(ofLength: Int(readSize)), at: 0)
+        }
+    }
+
+    private static func countedLogLines(in data: Data) -> Int {
+        guard !data.isEmpty else {
+            return 0
+        }
+
+        let separatorCount = data.reduce(0) { count, byte in
+            byte == LogByte.lineFeed ? count + 1 : count
+        }
+        return data.last == LogByte.lineFeed ? separatorCount : separatorCount + 1
     }
 
     static func filteredLogData(_ data: Data, options: ContainerLogOptions) -> Data {

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -880,18 +880,16 @@ public actor ContainersService {
 
         let timestampParser = LogTimestampParser()
         var result = Data()
-        var retainedTail: [LogDataLine] = []
+        let tailLimit = options.tail ?? -1
+        var retainedTail = LogTailBuffer(capacity: tailLimit)
         var current = Data()
 
         func appendIncludedLine(_ line: LogDataLine) throws {
             guard try shouldIncludeLogLine(line, options: options, timestampParser: timestampParser) else {
                 return
             }
-            if let tail = options.tail, tail > 0 {
+            if tailLimit > 0 {
                 retainedTail.append(line)
-                if retainedTail.count > tail {
-                    retainedTail.removeFirst(retainedTail.count - tail)
-                }
             } else {
                 appendLogLine(line, to: &result)
             }
@@ -915,8 +913,8 @@ public actor ContainersService {
             try appendIncludedLine(LogDataLine(data: current, terminated: false))
         }
 
-        if let tail = options.tail, tail > 0 {
-            return joinedLogData(retainedTail)
+        if tailLimit > 0 {
+            return joinedLogData(retainedTail.lines)
         }
         return result
     }
@@ -1043,6 +1041,46 @@ public actor ContainersService {
     private struct LogDataLine {
         var data: Data
         var terminated: Bool
+    }
+
+    /// Fixed-size tail retention for filtered replay.
+    ///
+    /// The service can scan large log files when `tail` is combined with time
+    /// filters. A ring buffer avoids repeated `removeFirst` reindexing while
+    /// preserving the caller-visible order of the retained lines.
+    private struct LogTailBuffer {
+        private let capacity: Int
+        private var storage: [LogDataLine] = []
+        private var nextIndex = 0
+
+        init(capacity: Int) {
+            self.capacity = max(capacity, 0)
+            self.storage.reserveCapacity(self.capacity)
+        }
+
+        mutating func append(_ line: LogDataLine) {
+            guard capacity > 0 else {
+                return
+            }
+
+            if storage.count < capacity {
+                storage.append(line)
+                return
+            }
+
+            storage[nextIndex] = line
+            nextIndex = (nextIndex + 1) % capacity
+        }
+
+        var lines: [LogDataLine] {
+            guard storage.count == capacity, nextIndex != 0 else {
+                return storage
+            }
+
+            let oldestSegment = Array(storage[nextIndex..<storage.endIndex])
+            let newestSegment = Array(storage[storage.startIndex..<nextIndex])
+            return oldestSegment + newestSegment
+        }
     }
 
     private enum LogByte {

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -805,8 +805,7 @@ public actor ContainersService {
             try? handle.close()
             return filteredHandle
         }
-        let data = try handle.readToEnd() ?? Data()
-        let filtered = Self.filteredLogData(data, options: options)
+        let filtered = try Self.filteredLogData(from: handle, options: options)
         let filteredHandle = try Self.temporaryFileHandle(containing: filtered, in: temporaryDirectory)
         try? handle.close()
         return filteredHandle
@@ -823,7 +822,7 @@ public actor ContainersService {
 
         var buffer = Data()
         try prependTailData(from: handle, lineCount: lineCount, into: &buffer)
-        return filteredLogData(buffer, options: ContainerLogOptions(tail: lineCount))
+        return try filteredLogData(buffer, options: ContainerLogOptions(tail: lineCount))
     }
 
     private static func prependTailData(
@@ -851,25 +850,15 @@ public actor ContainersService {
         return data.last == LogByte.lineFeed ? separatorCount : separatorCount + 1
     }
 
-    static func filteredLogData(_ data: Data, options: ContainerLogOptions) -> Data {
+    static func filteredLogData(_ data: Data, options: ContainerLogOptions) throws -> Data {
         guard !data.isEmpty else {
             return Data()
         }
 
         var lines = logDataLines(data)
-
         let timestampParser = LogTimestampParser()
-        lines = lines.filter { line in
-            guard let timestamp = timestampParser.timestampPrefix(from: line.data) else {
-                return true
-            }
-            if let since = options.since, timestamp < since {
-                return false
-            }
-            if let until = options.until, timestamp > until {
-                return false
-            }
-            return true
+        lines = try lines.filter { line in
+            try shouldIncludeLogLine(line, options: options, timestampParser: timestampParser)
         }
 
         if let tail = options.tail, tail >= 0 {
@@ -880,6 +869,77 @@ public actor ContainersService {
         }
 
         return joinedLogData(lines)
+    }
+
+    private static func filteredLogData(from handle: FileHandle, options: ContainerLogOptions) throws -> Data {
+        if options.tail == 0 {
+            return Data()
+        }
+
+        let timestampParser = LogTimestampParser()
+        var result = Data()
+        var retainedTail: [LogDataLine] = []
+        var current = Data()
+
+        func appendIncludedLine(_ line: LogDataLine) throws {
+            guard try shouldIncludeLogLine(line, options: options, timestampParser: timestampParser) else {
+                return
+            }
+            if let tail = options.tail, tail > 0 {
+                retainedTail.append(line)
+                if retainedTail.count > tail {
+                    retainedTail.removeFirst(retainedTail.count - tail)
+                }
+            } else {
+                appendLogLine(line, to: &result)
+            }
+        }
+
+        while true {
+            let chunk = handle.readData(ofLength: Int(logTailReadChunkSize))
+            if chunk.isEmpty {
+                break
+            }
+            for byte in chunk {
+                if byte == LogByte.lineFeed {
+                    try appendIncludedLine(LogDataLine(data: current, terminated: true))
+                    current.removeAll(keepingCapacity: true)
+                } else {
+                    current.append(byte)
+                }
+            }
+        }
+        if !current.isEmpty {
+            try appendIncludedLine(LogDataLine(data: current, terminated: false))
+        }
+
+        if let tail = options.tail, tail > 0 {
+            return joinedLogData(retainedTail)
+        }
+        return result
+    }
+
+    private static func shouldIncludeLogLine(
+        _ line: LogDataLine,
+        options: ContainerLogOptions,
+        timestampParser: LogTimestampParser
+    ) throws -> Bool {
+        guard let timestamp = timestampParser.timestampPrefix(from: line.data) else {
+            guard (options.since == nil && options.until == nil) || line.data.isEmpty else {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message: "cannot apply timestamp filters to container logs without timestamp prefixes"
+                )
+            }
+            return true
+        }
+        if let since = options.since, timestamp < since {
+            return false
+        }
+        if let until = options.until, timestamp > until {
+            return false
+        }
+        return true
     }
 
     private static func temporaryFileHandle(
@@ -969,6 +1029,13 @@ public actor ContainersService {
             }
         }
         return result
+    }
+
+    private static func appendLogLine(_ line: LogDataLine, to data: inout Data) {
+        data.append(line.data)
+        if line.terminated {
+            data.append(LogByte.lineFeed)
+        }
     }
 
     private struct LogDataLine {

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -27,7 +27,6 @@ import ContainerizationError
 import ContainerizationExtras
 import ContainerizationOCI
 import ContainerizationOS
-import Darwin
 import Foundation
 import Logging
 import SystemPackage
@@ -730,10 +729,12 @@ public actor ContainersService {
         try await client.resize(processID, size: size)
     }
 
+    /// Get the logs for the container.
     public func logs(id: String) async throws -> [FileHandle] {
         try await logs(id: id, options: .default)
     }
 
+    /// Get the logs for the container.
     public func logs(id: String, options: ContainerLogOptions) async throws -> [FileHandle] {
         log.debug(
             "ContainersService: enter",
@@ -752,27 +753,156 @@ public actor ContainersService {
             )
         }
 
+        // Logs doesn't care if the container is running or not, just that
+        // the bundle is there, and that the files actually exist. We do
+        // first try and get the container state so we get a nicer error message
+        // (container foo not found) however.
         do {
             _ = try _getContainerState(id: id)
             let path = self.containerRoot.appendingPathComponent(id)
             let bundle = ContainerResource.Bundle(path: path)
-            var handles = [
+            let handles = [
                 try FileHandle(forReadingFrom: bundle.containerLog),
                 try FileHandle(forReadingFrom: bundle.bootlog),
             ]
-
-            if let since = options.since {
-                handles = handles.map { fh in
-                    Self.filterFileHandleSince(fh, since: since)
-                }
+            return handles.map { handle in
+                Self.applyLogOptions(to: handle, options: options)
             }
-
-            return handles
         } catch {
             throw ContainerizationError(
                 .internalError,
                 message: "failed to open container logs: \(error)"
             )
+        }
+    }
+
+    static func applyLogOptions(to handle: FileHandle, options: ContainerLogOptions) -> FileHandle {
+        guard options.tail != nil || options.since != nil || options.until != nil else {
+            return handle
+        }
+        guard let data = try? handle.readToEnd() else {
+            return handle
+        }
+        let filtered = Self.filteredLogData(data, options: options)
+        guard let filteredHandle = Self.temporaryFileHandle(containing: filtered) else {
+            try? handle.seek(toOffset: 0)
+            return handle
+        }
+        try? handle.close()
+        return filteredHandle
+    }
+
+    static func filteredLogData(_ data: Data, options: ContainerLogOptions) -> Data {
+        guard !data.isEmpty else {
+            return Data()
+        }
+
+        var lines = logDataLines(data)
+
+        let timestampParser = LogTimestampParser()
+        lines = lines.filter { line in
+            guard let timestamp = timestampParser.timestampPrefix(from: line.data) else {
+                return true
+            }
+            if let since = options.since, timestamp < since {
+                return false
+            }
+            if let until = options.until, timestamp > until {
+                return false
+            }
+            return true
+        }
+
+        if let tail = options.tail, tail >= 0 {
+            if tail == 0 {
+                return Data()
+            }
+            lines = Array(lines.suffix(tail))
+        }
+
+        return joinedLogData(lines)
+    }
+
+    private static func temporaryFileHandle(containing data: Data) -> FileHandle? {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("container-log-\(UUID().uuidString)")
+        do {
+            try data.write(to: url)
+            let handle = try FileHandle(forReadingFrom: url)
+            try? FileManager.default.removeItem(at: url)
+            return handle
+        } catch {
+            try? FileManager.default.removeItem(at: url)
+            return nil
+        }
+    }
+
+    private static func logDataLines(_ data: Data) -> [LogDataLine] {
+        var lines: [LogDataLine] = []
+        var current = Data()
+
+        for byte in data {
+            if byte == LogByte.lineFeed {
+                lines.append(LogDataLine(data: current, terminated: true))
+                current.removeAll()
+            } else {
+                current.append(byte)
+            }
+        }
+        if !current.isEmpty {
+            lines.append(LogDataLine(data: current, terminated: false))
+        }
+        return lines
+    }
+
+    private static func joinedLogData(_ lines: [LogDataLine]) -> Data {
+        var result = Data()
+        for (index, line) in lines.enumerated() {
+            result.append(line.data)
+            if line.terminated || index < lines.count - 1 {
+                result.append(LogByte.lineFeed)
+            }
+        }
+        return result
+    }
+
+    private struct LogDataLine {
+        var data: Data
+        var terminated: Bool
+    }
+
+    private enum LogByte {
+        static let lineFeed = UInt8(ascii: "\n")
+    }
+
+    private struct LogTimestampParser {
+        private let fractionalFormatter: ISO8601DateFormatter
+        private let formatter: ISO8601DateFormatter
+
+        init() {
+            let fractionalFormatter = ISO8601DateFormatter()
+            fractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            self.fractionalFormatter = fractionalFormatter
+
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime]
+            self.formatter = formatter
+        }
+
+        func timestampPrefix(from line: Data) -> Date? {
+            let token = Data(line.prefix { $0 != UInt8(ascii: " ") })
+            guard let timestamp = String(data: token, encoding: .utf8) else {
+                return nil
+            }
+            return timestampPrefix(fromTimestampToken: timestamp)
+        }
+
+        private func timestampPrefix(fromTimestampToken timestamp: String) -> Date? {
+            if let date = fractionalFormatter.date(from: timestamp) {
+                return date
+            }
+
+            return formatter.date(from: timestamp)
         }
     }
 
@@ -798,92 +928,6 @@ public actor ContainersService {
         }
         let client = try state.getClient()
         try await client.copyOut(source: source, destination: destination, createParents: createParents)
-    }
-
-    static func filterFileHandleSince(_ fh: FileHandle, since: Date) -> FileHandle {
-        guard let data = try? fh.readToEnd() else {
-            return fh
-        }
-        guard let result = Self.filteredLogData(data, since: since) else {
-            try? fh.seek(toOffset: 0)
-            return fh
-        }
-
-        if let filteredHandle = Self.temporaryFileHandle(containing: result) {
-            return filteredHandle
-        }
-        try? fh.seek(toOffset: 0)
-        return fh
-    }
-
-    static func filteredLogData(_ data: Data, since: Date) -> Data? {
-        guard let content = String(data: data, encoding: .utf8) else {
-            return nil
-        }
-
-        let iso8601 = ISO8601DateFormatter()
-        iso8601.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        let fallbackFormatter = ISO8601DateFormatter()
-        fallbackFormatter.formatOptions = [.withInternetDateTime]
-
-        let lines = content.components(separatedBy: "\n")
-        var filtered: [String] = []
-        for line in lines {
-            guard !line.isEmpty else {
-                filtered.append(line)
-                continue
-            }
-            let parts = line.split(separator: " ", maxSplits: 1)
-            guard let timestampStr = parts.first else {
-                filtered.append(line)
-                continue
-            }
-            if let date = iso8601.date(from: String(timestampStr)) ?? fallbackFormatter.date(from: String(timestampStr)) {
-                if date >= since {
-                    filtered.append(line)
-                }
-            } else {
-                filtered.append(line)
-            }
-        }
-
-        let result = filtered.joined(separator: "\n")
-        return result.data(using: .utf8)
-    }
-
-    private static func temporaryFileHandle(containing data: Data) -> FileHandle? {
-        let url = FileManager.default.temporaryDirectory.appendingPathComponent("container-log-filter-")
-            .appendingPathExtension(UUID().uuidString)
-        let fd = open(url.path, O_CREAT | O_EXCL | O_RDWR, S_IRUSR | S_IWUSR)
-        guard fd >= 0 else {
-            return nil
-        }
-
-        let success = data.withUnsafeBytes { buffer in
-            guard let baseAddress = buffer.baseAddress else {
-                return true
-            }
-            var remaining = buffer.count
-            var pointer = baseAddress
-            while remaining > 0 {
-                let written = write(fd, pointer, remaining)
-                guard written > 0 else {
-                    return false
-                }
-                remaining -= written
-                pointer += written
-            }
-            return true
-        }
-
-        guard success, lseek(fd, 0, SEEK_SET) >= 0 else {
-            close(fd)
-            try? FileManager.default.removeItem(at: url)
-            return nil
-        }
-
-        try? FileManager.default.removeItem(at: url)
-        return FileHandle(fileDescriptor: fd, closeOnDealloc: true)
     }
 
     /// Get statistics for the container.

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -779,6 +779,8 @@ public actor ContainersService {
                 }
                 throw error
             }
+        } catch let error as ContainerizationError {
+            throw error
         } catch {
             throw ContainerizationError(
                 .internalError,

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -98,6 +98,18 @@ struct ContainerLogsTests {
         #expect(data.isEmpty)
     }
 
+    @Test func tailZeroDoesNotParseTimestampFilters() throws {
+        let data = try ContainersService.filteredLogData(
+            Data("application log without timestamp\n".utf8),
+            options: ContainerLogOptions(
+                tail: 0,
+                since: date("2026-01-01T00:00:00Z")
+            )
+        )
+
+        #expect(data.isEmpty)
+    }
+
     @Test func negativeTailDoesNotDropLogs() throws {
         let content = """
             2026-01-01T00:00:00Z old

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -168,6 +168,37 @@ struct ContainerLogsTests {
         #expect(String(data: data, encoding: .utf8) == "\(longLine)\ntwo\n")
     }
 
+    @Test func filteredHandleRetainsTailInOrderAfterTimeFilters() throws {
+        let content = """
+            2026-01-01T00:00:00Z one
+            2026-01-02T00:00:00Z two
+            2026-01-03T00:00:00Z three
+            2026-01-04T00:00:00Z four
+            2026-01-05T00:00:00Z five
+
+            """
+        let handle = try fileHandle(containing: Data(content.utf8))
+        let filtered = try ContainersService.applyLogOptions(
+            to: handle,
+            options: ContainerLogOptions(
+                tail: 3,
+                since: date("2026-01-01T00:00:00Z")
+            )
+        )
+        defer { try? filtered.close() }
+
+        let data = try filtered.readToEnd() ?? Data()
+
+        #expect(
+            String(data: data, encoding: .utf8) == """
+                2026-01-03T00:00:00Z three
+                2026-01-04T00:00:00Z four
+                2026-01-05T00:00:00Z five
+
+                """
+        )
+    }
+
     @Test func harnessDecodesLogOptions() {
         let message = XPCMessage(route: .containerLogs)
         let since = Date(timeIntervalSince1970: 0)

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -94,10 +94,39 @@ struct ContainerLogsTests {
         let bytes = Data([0xff, 0xfe, 0x0a, 0x41, 0x0a])
         let handle = try fileHandle(containing: bytes)
 
-        let filtered = ContainersService.applyLogOptions(to: handle, options: ContainerLogOptions(tail: 1))
+        let filtered = try ContainersService.applyLogOptions(to: handle, options: ContainerLogOptions(tail: 1))
         let data = try #require(try filtered.readToEnd())
 
         #expect(data == Data([0x41, 0x0a]))
+    }
+
+    @Test func filteredHandleCreationFailureThrows() throws {
+        let handle = try fileHandle(containing: Data("one\ntwo\n".utf8))
+        defer { try? handle.close() }
+        let blockedDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("container-log-test-\(UUID().uuidString)")
+        try Data("not a directory".utf8).write(to: blockedDirectory)
+        defer { try? FileManager.default.removeItem(at: blockedDirectory) }
+
+        #expect(throws: Error.self) {
+            _ = try ContainersService.applyLogOptions(
+                to: handle,
+                options: ContainerLogOptions(tail: 1),
+                temporaryDirectory: blockedDirectory
+            )
+        }
+    }
+
+    @Test func emptyLogsApplyTimeFiltersWithoutThrowing() throws {
+        let handle = try fileHandle(containing: Data())
+
+        let filtered = try ContainersService.applyLogOptions(
+            to: handle,
+            options: ContainerLogOptions(since: date("2026-01-01T00:00:00Z"))
+        )
+        let data = try filtered.readToEnd() ?? Data()
+
+        #expect(data.isEmpty)
     }
 
     @Test func boundedTailPreservesLongLogicalLine() throws {

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -65,6 +65,19 @@ struct ContainerLogsTests {
         }
     }
 
+    @Test func timeFiltersRejectBlankApplicationLines() throws {
+        let content = "2026-01-01T00:00:00Z old\n\n2026-01-03T00:00:00Z retained\n"
+
+        #expect {
+            _ = try ContainersService.filteredLogData(Data(content.utf8), options: ContainerLogOptions(since: date("2026-01-02T00:00:00Z")))
+        } throws: { error in
+            guard let error = error as? ContainerizationError else {
+                return false
+            }
+            return error.code == .invalidArgument
+        }
+    }
+
     @Test func tailOnlyPreservesUnparseableLinesEmptyLinesAndTrailingNewline() throws {
         let content = "unparseable\n\nretained\n"
 
@@ -199,7 +212,34 @@ struct ContainerLogsTests {
         )
     }
 
-    @Test func harnessDecodesLogOptions() {
+    @Test func filtersOnlySelectedLogStream() throws {
+        let stdioHandle = try fileHandle(containing: Data("2026-01-01T00:00:00Z old\n2026-01-03T00:00:00Z retained\n".utf8))
+        let bootHandle = try fileHandle(containing: Data("boot log without timestamp\n".utf8))
+
+        let handles = try ContainersService.applyLogOptions(
+            to: [
+                ContainersService.LogHandle(stream: .stdio, handle: stdioHandle),
+                ContainersService.LogHandle(stream: .boot, handle: bootHandle),
+            ],
+            options: ContainerLogOptions(
+                since: date("2026-01-02T00:00:00Z"),
+                stream: .stdio
+            )
+        )
+        defer {
+            for handle in handles {
+                try? handle.close()
+            }
+        }
+
+        let stdioData = try #require(try handles[0].readToEnd())
+        let bootData = try #require(try handles[1].readToEnd())
+
+        #expect(String(data: stdioData, encoding: .utf8) == "2026-01-03T00:00:00Z retained\n")
+        #expect(String(data: bootData, encoding: .utf8) == "boot log without timestamp\n")
+    }
+
+    @Test func harnessDecodesLogOptions() throws {
         let message = XPCMessage(route: .containerLogs)
         let since = Date(timeIntervalSince1970: 0)
         let until = Date(timeIntervalSince1970: -1)
@@ -207,24 +247,41 @@ struct ContainerLogsTests {
         message.set(key: .logSince, value: since)
         message.set(key: .logUntil, value: until)
         message.set(key: .logTimestamps, value: true)
+        message.set(key: .logStream, value: ContainerLogStream.boot.rawValue)
 
-        let options = ContainersHarness.logOptions(from: message)
+        let options = try ContainersHarness.logOptions(from: message)
 
         #expect(options.tail == 0)
         #expect(options.since == since)
         #expect(options.until == until)
         #expect(options.timestamps)
+        #expect(options.stream == .boot)
     }
 
-    @Test func harnessLeavesAbsentLogOptionsUnset() {
+    @Test func harnessLeavesAbsentLogOptionsUnset() throws {
         let message = XPCMessage(route: .containerLogs)
 
-        let options = ContainersHarness.logOptions(from: message)
+        let options = try ContainersHarness.logOptions(from: message)
 
         #expect(options.tail == nil)
         #expect(options.since == nil)
         #expect(options.until == nil)
         #expect(!options.timestamps)
+        #expect(options.stream == nil)
+    }
+
+    @Test func harnessRejectsInvalidLogStream() {
+        let message = XPCMessage(route: .containerLogs)
+        message.set(key: .logStream, value: "invalid")
+
+        #expect {
+            _ = try ContainersHarness.logOptions(from: message)
+        } throws: { error in
+            guard let error = error as? ContainerizationError else {
+                return false
+            }
+            return error.code == .invalidArgument
+        }
     }
 
     private func fileHandle(containing data: Data) throws -> FileHandle {

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -100,6 +100,15 @@ struct ContainerLogsTests {
         #expect(data == Data([0x41, 0x0a]))
     }
 
+    @Test func boundedTailPreservesLongLogicalLine() throws {
+        let longLine = String(repeating: "x", count: 40_000)
+        let handle = try fileHandle(containing: Data("old\n\(longLine)\ntwo\n".utf8))
+
+        let data = try ContainersService.tailLogData(from: handle, lineCount: 2)
+
+        #expect(String(data: data, encoding: .utf8) == "\(longLine)\ntwo\n")
+    }
+
     @Test func harnessDecodesLogOptions() {
         let message = XPCMessage(route: .containerLogs)
         let since = Date(timeIntervalSince1970: 0)

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerAPIClient
+@testable import ContainerAPIService
+import ContainerXPC
+import Foundation
+import Testing
+
+struct ContainerLogsTests {
+
+    @Test("Log filtering can return output larger than a pipe buffer")
+    func testFilterLargeOutput() throws {
+        let since = Date(timeIntervalSince1970: 1_700_000_000)
+        let line = "2027-01-01T00:00:00Z retained log line with enough bytes to grow the output\n"
+        let content = String(repeating: line, count: 2_000)
+        let handle = try fileHandle(containing: Data(content.utf8))
+
+        let filtered = ContainersService.filterFileHandleSince(handle, since: since)
+        let data = try #require(try filtered.readToEnd())
+
+        #expect(data == Data(content.utf8))
+    }
+
+    @Test("Log filtering preserves empty lines and trailing newline")
+    func testFilterPreservesEmptyLinesAndTrailingNewline() throws {
+        let since = Date(timeIntervalSince1970: 1_700_000_000)
+        let content = "2020-01-01T00:00:00Z old\n\n2027-01-01T00:00:00Z new\n"
+        let expected = "\n2027-01-01T00:00:00Z new\n"
+
+        let data = try #require(ContainersService.filteredLogData(Data(content.utf8), since: since))
+
+        #expect(String(data: data, encoding: .utf8) == expected)
+    }
+
+    @Test("Non-UTF8 logs fall back to the original bytes")
+    func testNonUTF8LogsReturnOriginalBytes() throws {
+        let bytes = Data([0xff, 0xfe, 0x00, 0x41])
+        let handle = try fileHandle(containing: bytes)
+
+        let filtered = ContainersService.filterFileHandleSince(handle, since: Date())
+        let data = try #require(try filtered.readToEnd())
+
+        #expect(data == bytes)
+    }
+
+    @Test("Harness preserves explicit epoch log since option")
+    func testHarnessPreservesEpochSince() {
+        let message = XPCMessage(route: .containerLogs)
+        let epoch = Date(timeIntervalSince1970: 0)
+        message.set(key: .logSince, value: epoch)
+
+        let options = ContainersHarness.logOptions(from: message)
+
+        #expect(options.since == epoch)
+    }
+
+    @Test("Harness preserves explicit pre-epoch log since option")
+    func testHarnessPreservesPreEpochSince() {
+        let message = XPCMessage(route: .containerLogs)
+        let preEpoch = Date(timeIntervalSince1970: -1)
+        message.set(key: .logSince, value: preEpoch)
+
+        let options = ContainersHarness.logOptions(from: message)
+
+        #expect(options.since == preEpoch)
+    }
+
+    @Test("Harness leaves absent log since option unset")
+    func testHarnessLeavesAbsentSinceUnset() {
+        let message = XPCMessage(route: .containerLogs)
+        message.set(key: .logTimestamps, value: true)
+
+        let options = ContainersHarness.logOptions(from: message)
+
+        #expect(options.since == nil)
+        #expect(options.timestamps)
+    }
+
+    private func fileHandle(containing data: Data) throws -> FileHandle {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("container-log-test-")
+            .appendingPathExtension(UUID().uuidString)
+        try data.write(to: url)
+        let handle = try FileHandle(forReadingFrom: url)
+        try? FileManager.default.removeItem(at: url)
+        return handle
+    }
+}

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -95,6 +95,7 @@ struct ContainerLogsTests {
         let handle = try fileHandle(containing: bytes)
 
         let filtered = try ContainersService.applyLogOptions(to: handle, options: ContainerLogOptions(tail: 1))
+        defer { try? filtered.close() }
         let data = try #require(try filtered.readToEnd())
 
         #expect(data == Data([0x41, 0x0a]))
@@ -124,6 +125,7 @@ struct ContainerLogsTests {
             to: handle,
             options: ContainerLogOptions(since: date("2026-01-01T00:00:00Z"))
         )
+        defer { try? filtered.close() }
         let data = try filtered.readToEnd() ?? Data()
 
         #expect(data.isEmpty)
@@ -132,6 +134,7 @@ struct ContainerLogsTests {
     @Test func boundedTailPreservesLongLogicalLine() throws {
         let longLine = String(repeating: "x", count: 40_000)
         let handle = try fileHandle(containing: Data("old\n\(longLine)\ntwo\n".utf8))
+        defer { try? handle.close() }
 
         let data = try ContainersService.tailLogData(from: handle, lineCount: 2)
 

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -17,6 +17,7 @@
 import ContainerAPIClient
 import ContainerResource
 import ContainerXPC
+import ContainerizationError
 import Foundation
 import Testing
 
@@ -54,8 +55,13 @@ struct ContainerLogsTests {
             since: date("2026-01-02T00:00:00Z")
         )
 
-        #expect(throws: Error.self) {
+        #expect {
             _ = try ContainersService.filteredLogData(Data(content.utf8), options: options)
+        } throws: { error in
+            guard let error = error as? ContainerizationError else {
+                return false
+            }
+            return error.code == .invalidArgument
         }
     }
 
@@ -112,8 +118,13 @@ struct ContainerLogsTests {
     @Test func nonUTF8LogsRejectTimeFilters() throws {
         let bytes = Data([0xff, 0xfe, 0x0a, 0x41, 0x0a])
 
-        #expect(throws: Error.self) {
+        #expect {
             _ = try ContainersService.filteredLogData(bytes, options: ContainerLogOptions(since: date("2026-01-01T00:00:00Z")))
+        } throws: { error in
+            guard let error = error as? ContainerizationError else {
+                return false
+            }
+            return error.code == .invalidArgument
         }
     }
 

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -78,6 +78,22 @@ struct ContainerLogsTests {
         }
     }
 
+    @Test func timeFiltersRejectDateLikeApplicationLines() throws {
+        let content = "2026-06-18 application log without runtime timestamp\n"
+
+        #expect {
+            _ = try ContainersService.filteredLogData(
+                Data(content.utf8),
+                options: ContainerLogOptions(since: date("2026-01-01T00:00:00Z"))
+            )
+        } throws: { error in
+            guard let error = error as? ContainerizationError else {
+                return false
+            }
+            return error.code == .invalidArgument
+        }
+    }
+
     @Test func tailOnlyPreservesUnparseableLinesEmptyLinesAndTrailingNewline() throws {
         let content = "unparseable\n\nretained\n"
 

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -37,12 +37,12 @@ struct ContainerLogsTests {
             until: date("2026-01-03T00:00:00Z")
         )
 
-        let data = ContainersService.filteredLogData(Data(content.utf8), options: options)
+        let data = try ContainersService.filteredLogData(Data(content.utf8), options: options)
 
         #expect(String(data: data, encoding: .utf8) == "2026-01-03T00:00:00Z second\n")
     }
 
-    @Test func preservesUnparseableLinesEmptyLinesAndTrailingNewline() throws {
+    @Test func timeFiltersRejectUnparseableLines() throws {
         let content = """
             2026-01-01T00:00:00Z old
             unparseable
@@ -54,9 +54,17 @@ struct ContainerLogsTests {
             since: date("2026-01-02T00:00:00Z")
         )
 
-        let data = ContainersService.filteredLogData(Data(content.utf8), options: options)
+        #expect(throws: Error.self) {
+            _ = try ContainersService.filteredLogData(Data(content.utf8), options: options)
+        }
+    }
 
-        #expect(String(data: data, encoding: .utf8) == "unparseable\n\n2026-01-03T00:00:00Z retained\n")
+    @Test func tailOnlyPreservesUnparseableLinesEmptyLinesAndTrailingNewline() throws {
+        let content = "unparseable\n\nretained\n"
+
+        let data = try ContainersService.filteredLogData(Data(content.utf8), options: ContainerLogOptions(tail: -1))
+
+        #expect(String(data: data, encoding: .utf8) == content)
     }
 
     @Test func tailZeroReturnsEmptyLogData() throws {
@@ -66,7 +74,7 @@ struct ContainerLogsTests {
 
             """
 
-        let data = ContainersService.filteredLogData(Data(content.utf8), options: ContainerLogOptions(tail: 0))
+        let data = try ContainersService.filteredLogData(Data(content.utf8), options: ContainerLogOptions(tail: 0))
 
         #expect(data.isEmpty)
     }
@@ -78,14 +86,14 @@ struct ContainerLogsTests {
 
             """
 
-        let data = ContainersService.filteredLogData(Data(content.utf8), options: ContainerLogOptions(tail: -1))
+        let data = try ContainersService.filteredLogData(Data(content.utf8), options: ContainerLogOptions(tail: -1))
 
         #expect(String(data: data, encoding: .utf8) == content)
     }
 
     @Test func nonUTF8LogsCanBeTailedWithoutDecoding() throws {
         let bytes = Data([0xff, 0xfe, 0x0a, 0x41, 0x0a])
-        let data = ContainersService.filteredLogData(bytes, options: ContainerLogOptions(tail: 1))
+        let data = try ContainersService.filteredLogData(bytes, options: ContainerLogOptions(tail: 1))
 
         #expect(data == Data([0x41, 0x0a]))
     }
@@ -99,6 +107,14 @@ struct ContainerLogsTests {
         let data = try #require(try filtered.readToEnd())
 
         #expect(data == Data([0x41, 0x0a]))
+    }
+
+    @Test func nonUTF8LogsRejectTimeFilters() throws {
+        let bytes = Data([0xff, 0xfe, 0x0a, 0x41, 0x0a])
+
+        #expect(throws: Error.self) {
+            _ = try ContainersService.filteredLogData(bytes, options: ContainerLogOptions(since: date("2026-01-01T00:00:00Z")))
+        }
     }
 
     @Test func filteredHandleCreationFailureThrows() throws {

--- a/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
@@ -15,87 +15,131 @@
 //===----------------------------------------------------------------------===//
 
 import ContainerAPIClient
-@testable import ContainerAPIService
+import ContainerResource
 import ContainerXPC
 import Foundation
 import Testing
 
+@testable import ContainerAPIService
+
 struct ContainerLogsTests {
+    @Test func filtersLogsBySinceUntilAndTail() throws {
+        let content = """
+            2026-01-01T00:00:00Z old
+            2026-01-02T00:00:00Z first
+            2026-01-03T00:00:00Z second
+            2026-01-04T00:00:00Z new
 
-    @Test("Log filtering can return output larger than a pipe buffer")
-    func testFilterLargeOutput() throws {
-        let since = Date(timeIntervalSince1970: 1_700_000_000)
-        let line = "2027-01-01T00:00:00Z retained log line with enough bytes to grow the output\n"
-        let content = String(repeating: line, count: 2_000)
-        let handle = try fileHandle(containing: Data(content.utf8))
+            """
+        let options = ContainerLogOptions(
+            tail: 1,
+            since: date("2026-01-02T00:00:00Z"),
+            until: date("2026-01-03T00:00:00Z")
+        )
 
-        let filtered = ContainersService.filterFileHandleSince(handle, since: since)
-        let data = try #require(try filtered.readToEnd())
+        let data = ContainersService.filteredLogData(Data(content.utf8), options: options)
 
-        #expect(data == Data(content.utf8))
+        #expect(String(data: data, encoding: .utf8) == "2026-01-03T00:00:00Z second\n")
     }
 
-    @Test("Log filtering preserves empty lines and trailing newline")
-    func testFilterPreservesEmptyLinesAndTrailingNewline() throws {
-        let since = Date(timeIntervalSince1970: 1_700_000_000)
-        let content = "2020-01-01T00:00:00Z old\n\n2027-01-01T00:00:00Z new\n"
-        let expected = "\n2027-01-01T00:00:00Z new\n"
+    @Test func preservesUnparseableLinesEmptyLinesAndTrailingNewline() throws {
+        let content = """
+            2026-01-01T00:00:00Z old
+            unparseable
 
-        let data = try #require(ContainersService.filteredLogData(Data(content.utf8), since: since))
+            2026-01-03T00:00:00Z retained
 
-        #expect(String(data: data, encoding: .utf8) == expected)
+            """
+        let options = ContainerLogOptions(
+            since: date("2026-01-02T00:00:00Z")
+        )
+
+        let data = ContainersService.filteredLogData(Data(content.utf8), options: options)
+
+        #expect(String(data: data, encoding: .utf8) == "unparseable\n\n2026-01-03T00:00:00Z retained\n")
     }
 
-    @Test("Non-UTF8 logs fall back to the original bytes")
-    func testNonUTF8LogsReturnOriginalBytes() throws {
-        let bytes = Data([0xff, 0xfe, 0x00, 0x41])
+    @Test func tailZeroReturnsEmptyLogData() throws {
+        let content = """
+            2026-01-01T00:00:00Z old
+            2026-01-02T00:00:00Z new
+
+            """
+
+        let data = ContainersService.filteredLogData(Data(content.utf8), options: ContainerLogOptions(tail: 0))
+
+        #expect(data.isEmpty)
+    }
+
+    @Test func negativeTailDoesNotDropLogs() throws {
+        let content = """
+            2026-01-01T00:00:00Z old
+            2026-01-02T00:00:00Z new
+
+            """
+
+        let data = ContainersService.filteredLogData(Data(content.utf8), options: ContainerLogOptions(tail: -1))
+
+        #expect(String(data: data, encoding: .utf8) == content)
+    }
+
+    @Test func nonUTF8LogsCanBeTailedWithoutDecoding() throws {
+        let bytes = Data([0xff, 0xfe, 0x0a, 0x41, 0x0a])
+        let data = ContainersService.filteredLogData(bytes, options: ContainerLogOptions(tail: 1))
+
+        #expect(data == Data([0x41, 0x0a]))
+    }
+
+    @Test func nonUTF8LogsApplyTailWhenOpeningFilteredHandle() throws {
+        let bytes = Data([0xff, 0xfe, 0x0a, 0x41, 0x0a])
         let handle = try fileHandle(containing: bytes)
 
-        let filtered = ContainersService.filterFileHandleSince(handle, since: Date())
+        let filtered = ContainersService.applyLogOptions(to: handle, options: ContainerLogOptions(tail: 1))
         let data = try #require(try filtered.readToEnd())
 
-        #expect(data == bytes)
+        #expect(data == Data([0x41, 0x0a]))
     }
 
-    @Test("Harness preserves explicit epoch log since option")
-    func testHarnessPreservesEpochSince() {
+    @Test func harnessDecodesLogOptions() {
         let message = XPCMessage(route: .containerLogs)
-        let epoch = Date(timeIntervalSince1970: 0)
-        message.set(key: .logSince, value: epoch)
-
-        let options = ContainersHarness.logOptions(from: message)
-
-        #expect(options.since == epoch)
-    }
-
-    @Test("Harness preserves explicit pre-epoch log since option")
-    func testHarnessPreservesPreEpochSince() {
-        let message = XPCMessage(route: .containerLogs)
-        let preEpoch = Date(timeIntervalSince1970: -1)
-        message.set(key: .logSince, value: preEpoch)
-
-        let options = ContainersHarness.logOptions(from: message)
-
-        #expect(options.since == preEpoch)
-    }
-
-    @Test("Harness leaves absent log since option unset")
-    func testHarnessLeavesAbsentSinceUnset() {
-        let message = XPCMessage(route: .containerLogs)
+        let since = Date(timeIntervalSince1970: 0)
+        let until = Date(timeIntervalSince1970: -1)
+        message.set(key: .logTail, value: Int64(0))
+        message.set(key: .logSince, value: since)
+        message.set(key: .logUntil, value: until)
         message.set(key: .logTimestamps, value: true)
 
         let options = ContainersHarness.logOptions(from: message)
 
-        #expect(options.since == nil)
+        #expect(options.tail == 0)
+        #expect(options.since == since)
+        #expect(options.until == until)
         #expect(options.timestamps)
     }
 
+    @Test func harnessLeavesAbsentLogOptionsUnset() {
+        let message = XPCMessage(route: .containerLogs)
+
+        let options = ContainersHarness.logOptions(from: message)
+
+        #expect(options.tail == nil)
+        #expect(options.since == nil)
+        #expect(options.until == nil)
+        #expect(!options.timestamps)
+    }
+
     private func fileHandle(containing data: Data) throws -> FileHandle {
-        let url = FileManager.default.temporaryDirectory.appendingPathComponent("container-log-test-")
-            .appendingPathExtension(UUID().uuidString)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("container-log-test-\(UUID().uuidString)")
         try data.write(to: url)
         let handle = try FileHandle(forReadingFrom: url)
         try? FileManager.default.removeItem(at: url)
         return handle
+    }
+
+    private func date(_ value: String) -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: value)!
     }
 }

--- a/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
+++ b/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
@@ -99,7 +99,9 @@ struct ContainerLogsCommandTests {
         _ = FileManager.default.createFile(atPath: outputURL.path, contents: nil)
 
         let inputHandle = try fileHandle(containing: Data("one\ntwo\n".utf8))
+        defer { try? inputHandle.close() }
         let outputHandle = try FileHandle(forWritingTo: outputURL)
+        defer { try? outputHandle.close() }
         try await LogFileOutput.write(fh: inputHandle, n: -1, follow: false, output: outputHandle)
         try outputHandle.close()
 
@@ -114,7 +116,9 @@ struct ContainerLogsCommandTests {
         let bytes = Data([0xff, 0xfe, 0x0a, 0x41, 0x0a])
 
         let inputHandle = try fileHandle(containing: bytes)
+        defer { try? inputHandle.close() }
         let outputHandle = try FileHandle(forWritingTo: outputURL)
+        defer { try? outputHandle.close() }
         try await LogFileOutput.write(fh: inputHandle, n: nil, follow: false, output: outputHandle)
         try outputHandle.close()
 

--- a/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
+++ b/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
@@ -49,6 +49,17 @@ struct ContainerLogsCommandTests {
     }
 
     @Test
+    func parsesLocalDateTimeTimestamp() throws {
+        let previousTimeZone = NSTimeZone.default
+        NSTimeZone.default = TimeZone(secondsFromGMT: 3_600)!
+        defer { NSTimeZone.default = previousTimeZone }
+
+        let timestamp = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:30:45"))
+
+        #expect(timestamp.date == localDate("2026-06-18T10:30:45"))
+    }
+
+    @Test
     func parsesRelativeDurationTimestamp() throws {
         let before = Date()
         let timestamp = try #require(ContainerLogTimestamp(argument: "1m30s"))
@@ -204,6 +215,15 @@ struct ContainerLogsCommandTests {
             value.contains(".")
             ? [.withInternetDateTime, .withFractionalSeconds]
             : [.withInternetDateTime]
+        return formatter.date(from: value)!
+    }
+
+    private func localDate(_ value: String) -> Date {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone.current
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
         return formatter.date(from: value)!
     }
 }

--- a/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
+++ b/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
@@ -47,6 +47,7 @@ struct ContainerLogsCommandTests {
         let options = Application.ContainerLogs.retrievalOptions(
             numLines: 25,
             follow: false,
+            boot: false,
             since: since,
             until: until
         )
@@ -54,6 +55,7 @@ struct ContainerLogsCommandTests {
         #expect(options.tail == 25)
         #expect(options.since == since.date)
         #expect(options.until == until.date)
+        #expect(options.stream == .stdio)
     }
 
     @Test
@@ -61,6 +63,7 @@ struct ContainerLogsCommandTests {
         let options = Application.ContainerLogs.retrievalOptions(
             numLines: 25,
             follow: true,
+            boot: false,
             since: nil,
             until: nil
         )
@@ -68,6 +71,20 @@ struct ContainerLogsCommandTests {
         #expect(options.tail == nil)
         #expect(options.since == nil)
         #expect(options.until == nil)
+        #expect(options.stream == .stdio)
+    }
+
+    @Test
+    func logOptionsSelectBootStream() {
+        let options = Application.ContainerLogs.retrievalOptions(
+            numLines: nil,
+            follow: false,
+            boot: true,
+            since: nil,
+            until: nil
+        )
+
+        #expect(options.stream == .boot)
     }
 
     @Test

--- a/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
+++ b/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
@@ -57,33 +57,35 @@ struct ContainerLogsCommandTests {
     }
 
     @Test
-    func logOptionsLeaveTailForLocalFollowHandling() throws {
-        let since = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00Z"))
-        let until = try #require(ContainerLogTimestamp(argument: "2026-06-18T11:00:00Z"))
+    func logOptionsLeaveTailForLocalFollowHandling() {
         let options = Application.ContainerLogs.retrievalOptions(
             numLines: 25,
             follow: true,
-            since: since,
-            until: until
+            since: nil,
+            until: nil
         )
 
         #expect(options.tail == nil)
-        #expect(options.since == since.date)
-        #expect(options.until == until.date)
+        #expect(options.since == nil)
+        #expect(options.until == nil)
     }
 
     @Test
-    func validateAcceptsFollowWithSince() throws {
+    func validateRejectsFollowWithSince() throws {
         let since = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00Z"))
 
-        try Application.ContainerLogs.validateLogOptions(follow: true, since: since, until: nil)
+        #expect(throws: Error.self) {
+            try Application.ContainerLogs.validateLogOptions(follow: true, since: since, until: nil)
+        }
     }
 
     @Test
-    func validateAcceptsFollowWithUntil() throws {
+    func validateRejectsFollowWithUntil() throws {
         let until = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00Z"))
 
-        try Application.ContainerLogs.validateLogOptions(follow: true, since: nil, until: until)
+        #expect(throws: Error.self) {
+            try Application.ContainerLogs.validateLogOptions(follow: true, since: nil, until: until)
+        }
     }
 
     @Test

--- a/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
+++ b/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
@@ -35,6 +35,20 @@ struct ContainerLogsCommandTests {
     }
 
     @Test
+    func parsesUnixTimestamp() throws {
+        let timestamp = try #require(ContainerLogTimestamp(argument: "1781776800"))
+
+        #expect(timestamp.date == Date(timeIntervalSince1970: 1_781_776_800))
+    }
+
+    @Test
+    func parsesFractionalUnixTimestamp() throws {
+        let timestamp = try #require(ContainerLogTimestamp(argument: "1781776800.25"))
+
+        #expect(timestamp.date == Date(timeIntervalSince1970: 1_781_776_800.25))
+    }
+
+    @Test
     func rejectsInvalidTimestamp() {
         #expect(ContainerLogTimestamp(argument: "not-a-date") == nil)
     }

--- a/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
+++ b/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
@@ -1,0 +1,103 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import ContainerCommands
+
+struct ContainerLogsCommandTests {
+    @Test
+    func parsesRFC3339Timestamp() throws {
+        let timestamp = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00Z"))
+
+        #expect(timestamp.date == date("2026-06-18T10:00:00Z"))
+    }
+
+    @Test
+    func parsesFractionalRFC3339Timestamp() throws {
+        let timestamp = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00.123Z"))
+
+        #expect(timestamp.date == date("2026-06-18T10:00:00.123Z"))
+    }
+
+    @Test
+    func rejectsInvalidTimestamp() {
+        #expect(ContainerLogTimestamp(argument: "not-a-date") == nil)
+    }
+
+    @Test
+    func logOptionsUseAPITailWhenNotFollowing() throws {
+        let since = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00Z"))
+        let until = try #require(ContainerLogTimestamp(argument: "2026-06-18T11:00:00Z"))
+
+        let options = Application.ContainerLogs.retrievalOptions(
+            numLines: 25,
+            follow: false,
+            since: since,
+            until: until
+        )
+
+        #expect(options.tail == 25)
+        #expect(options.since == since.date)
+        #expect(options.until == until.date)
+    }
+
+    @Test
+    func logOptionsLeaveTailForLocalFollowHandling() {
+        let options = Application.ContainerLogs.retrievalOptions(
+            numLines: 25,
+            follow: true,
+            since: nil,
+            until: nil
+        )
+
+        #expect(options.tail == nil)
+        #expect(options.since == nil)
+    }
+
+    @Test
+    func validateRejectsFollowWithSince() throws {
+        let since = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00Z"))
+
+        #expect(throws: Error.self) {
+            try Application.ContainerLogs.validateLogOptions(follow: true, since: since, until: nil)
+        }
+    }
+
+    @Test
+    func validateRejectsFollowWithUntil() throws {
+        let until = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00Z"))
+
+        #expect(throws: Error.self) {
+            try Application.ContainerLogs.validateLogOptions(follow: true, since: nil, until: until)
+        }
+    }
+
+    @Test
+    func validateAcceptsFollowWithTailOnly() throws {
+        try Application.ContainerLogs.validateLogOptions(follow: true, since: nil, until: nil)
+    }
+
+    private func date(_ value: String) -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions =
+            value.contains(".")
+            ? [.withInternetDateTime, .withFractionalSeconds]
+            : [.withInternetDateTime]
+        return formatter.date(from: value)!
+    }
+}

--- a/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
+++ b/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
@@ -107,6 +107,21 @@ struct ContainerLogsCommandTests {
     }
 
     @Test
+    func logFileOutputWritesAllBytesWithoutUTF8Decoding() async throws {
+        let outputURL = temporaryFileURL()
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+        _ = FileManager.default.createFile(atPath: outputURL.path, contents: nil)
+        let bytes = Data([0xff, 0xfe, 0x0a, 0x41, 0x0a])
+
+        let inputHandle = try fileHandle(containing: bytes)
+        let outputHandle = try FileHandle(forWritingTo: outputURL)
+        try await LogFileOutput.write(fh: inputHandle, n: nil, follow: false, output: outputHandle)
+        try outputHandle.close()
+
+        #expect(try Data(contentsOf: outputURL) == bytes)
+    }
+
+    @Test
     func logFileOutputTailDataPreservesBlankLinesAndTrailingNewline() {
         let data = Data("one\n\ntwo\n".utf8)
 

--- a/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
+++ b/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
@@ -57,34 +57,33 @@ struct ContainerLogsCommandTests {
     }
 
     @Test
-    func logOptionsLeaveTailForLocalFollowHandling() {
+    func logOptionsLeaveTailForLocalFollowHandling() throws {
+        let since = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00Z"))
+        let until = try #require(ContainerLogTimestamp(argument: "2026-06-18T11:00:00Z"))
         let options = Application.ContainerLogs.retrievalOptions(
             numLines: 25,
             follow: true,
-            since: nil,
-            until: nil
+            since: since,
+            until: until
         )
 
         #expect(options.tail == nil)
-        #expect(options.since == nil)
+        #expect(options.since == since.date)
+        #expect(options.until == until.date)
     }
 
     @Test
-    func validateRejectsFollowWithSince() throws {
+    func validateAcceptsFollowWithSince() throws {
         let since = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00Z"))
 
-        #expect(throws: Error.self) {
-            try Application.ContainerLogs.validateLogOptions(follow: true, since: since, until: nil)
-        }
+        try Application.ContainerLogs.validateLogOptions(follow: true, since: since, until: nil)
     }
 
     @Test
-    func validateRejectsFollowWithUntil() throws {
+    func validateAcceptsFollowWithUntil() throws {
         let until = try #require(ContainerLogTimestamp(argument: "2026-06-18T10:00:00Z"))
 
-        #expect(throws: Error.self) {
-            try Application.ContainerLogs.validateLogOptions(follow: true, since: nil, until: until)
-        }
+        try Application.ContainerLogs.validateLogOptions(follow: true, since: nil, until: until)
     }
 
     @Test

--- a/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
+++ b/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
@@ -92,6 +92,51 @@ struct ContainerLogsCommandTests {
         try Application.ContainerLogs.validateLogOptions(follow: true, since: nil, until: nil)
     }
 
+    @Test
+    func logFileOutputNegativeTailWritesAllBytes() async throws {
+        let outputURL = temporaryFileURL()
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+        _ = FileManager.default.createFile(atPath: outputURL.path, contents: nil)
+
+        let inputHandle = try fileHandle(containing: Data("one\ntwo\n".utf8))
+        let outputHandle = try FileHandle(forWritingTo: outputURL)
+        try await LogFileOutput.write(fh: inputHandle, n: -1, follow: false, output: outputHandle)
+        try outputHandle.close()
+
+        #expect(String(data: try Data(contentsOf: outputURL), encoding: .utf8) == "one\ntwo\n")
+    }
+
+    @Test
+    func logFileOutputTailDataPreservesBlankLinesAndTrailingNewline() {
+        let data = Data("one\n\ntwo\n".utf8)
+
+        let tail = LogFileOutput.tailData(data, lineCount: 2)
+
+        #expect(String(data: tail, encoding: .utf8) == "\ntwo\n")
+    }
+
+    @Test
+    func logFileOutputZeroTailReturnsEmptyData() {
+        let data = Data("one\ntwo\n".utf8)
+
+        let tail = LogFileOutput.tailData(data, lineCount: 0)
+
+        #expect(tail.isEmpty)
+    }
+
+    private func fileHandle(containing data: Data) throws -> FileHandle {
+        let url = temporaryFileURL()
+        try data.write(to: url)
+        let handle = try FileHandle(forReadingFrom: url)
+        try? FileManager.default.removeItem(at: url)
+        return handle
+    }
+
+    private func temporaryFileURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("container-log-command-test-\(UUID().uuidString)")
+    }
+
     private func date(_ value: String) -> Date {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions =

--- a/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
+++ b/Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift
@@ -49,6 +49,16 @@ struct ContainerLogsCommandTests {
     }
 
     @Test
+    func parsesRelativeDurationTimestamp() throws {
+        let before = Date()
+        let timestamp = try #require(ContainerLogTimestamp(argument: "1m30s"))
+        let after = Date()
+
+        #expect(timestamp.date >= before.addingTimeInterval(-90))
+        #expect(timestamp.date <= after.addingTimeInterval(-90))
+    }
+
+    @Test
     func rejectsInvalidTimestamp() {
         #expect(ContainerLogTimestamp(argument: "not-a-date") == nil)
     }

--- a/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
+++ b/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
@@ -57,6 +57,9 @@ struct ContainerLogOptionsTests {
         #expect(ContainerLogTimestampParser.parse("1m30s", relativeTo: reference) == reference.addingTimeInterval(-90))
         #expect(ContainerLogTimestampParser.parse("250ms", relativeTo: reference) == reference.addingTimeInterval(-0.25))
         #expect(ContainerLogTimestampParser.parse("1.5h", relativeTo: reference) == reference.addingTimeInterval(-5_400))
+        #expect(ContainerLogTimestampParser.parse("+1s", relativeTo: reference) == reference.addingTimeInterval(-1))
+        #expect(ContainerLogTimestampParser.parse("-1s", relativeTo: reference) == reference.addingTimeInterval(1))
+        #expect(ContainerLogTimestampParser.parse("-.5h", relativeTo: reference) == reference.addingTimeInterval(1_800))
     }
 
     @Test func parsesDateOnlyLogTimestampInLocalTime() throws {
@@ -71,7 +74,7 @@ struct ContainerLogOptionsTests {
 
     @Test func rejectsInvalidLogTimestamps() {
         #expect(ContainerLogTimestampParser.parse("not-a-date") == nil)
-        #expect(ContainerLogTimestampParser.parse("-1s") == nil)
+        #expect(ContainerLogTimestampParser.parse("-s") == nil)
         #expect(ContainerLogTimestampParser.parse("1781776800.") == nil)
         #expect(ContainerLogTimestampParser.parse("1d") == nil)
     }

--- a/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
+++ b/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
@@ -19,6 +19,7 @@ import Testing
 
 @testable import ContainerResource
 
+@Suite(.serialized)
 struct ContainerLogOptionsTests {
     @Test func defaultOptionsPreserveExistingBehavior() {
         let options = ContainerLogOptions.default
@@ -58,6 +59,16 @@ struct ContainerLogOptionsTests {
         #expect(ContainerLogTimestampParser.parse("1.5h", relativeTo: reference) == reference.addingTimeInterval(-5_400))
     }
 
+    @Test func parsesDateOnlyLogTimestampInLocalTime() throws {
+        let previousTimeZone = NSTimeZone.default
+        NSTimeZone.default = TimeZone(secondsFromGMT: 3_600)!
+        defer { NSTimeZone.default = previousTimeZone }
+
+        let timestamp = try #require(ContainerLogTimestampParser.parse("2026-06-18"))
+
+        #expect(timestamp == localDate("2026-06-18"))
+    }
+
     @Test func rejectsInvalidLogTimestamps() {
         #expect(ContainerLogTimestampParser.parse("not-a-date") == nil)
         #expect(ContainerLogTimestampParser.parse("-1s") == nil)
@@ -71,6 +82,15 @@ struct ContainerLogOptionsTests {
             value.contains(".")
             ? [.withInternetDateTime, .withFractionalSeconds]
             : [.withInternetDateTime]
+        return formatter.date(from: value)!
+    }
+
+    private func localDate(_ value: String) -> Date {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone.current
+        formatter.dateFormat = "yyyy-MM-dd"
         return formatter.date(from: value)!
     }
 }

--- a/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
+++ b/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
@@ -20,24 +20,28 @@ import Testing
 @testable import ContainerResource
 
 struct ContainerLogOptionsTests {
-
-    @Test("Default log options preserve existing logs behavior")
-    func testDefaultOptions() {
+    @Test func defaultOptionsPreserveExistingBehavior() {
         let options = ContainerLogOptions.default
 
+        #expect(options.tail == nil)
         #expect(options.since == nil)
+        #expect(options.until == nil)
         #expect(!options.timestamps)
     }
 
-    @Test("Custom log options round-trip through JSON")
-    func testCustomOptionsRoundTrip() throws {
+    @Test func customOptionsRoundTripThroughJSON() throws {
         let since = Date(timeIntervalSince1970: 1_800_000_000)
-        let options = ContainerLogOptions(since: since, timestamps: true)
+        let until = Date(timeIntervalSince1970: 1_900_000_000)
+        let options = ContainerLogOptions(
+            tail: 100,
+            since: since,
+            until: until,
+            timestamps: true
+        )
 
         let data = try JSONEncoder().encode(options)
         let decoded = try JSONDecoder().decode(ContainerLogOptions.self, from: data)
 
-        #expect(decoded.since == since)
-        #expect(decoded.timestamps)
+        #expect(decoded == options)
     }
 }

--- a/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
+++ b/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
@@ -27,6 +27,7 @@ struct ContainerLogOptionsTests {
         #expect(options.since == nil)
         #expect(options.until == nil)
         #expect(!options.timestamps)
+        #expect(options.stream == nil)
     }
 
     @Test func customOptionsRoundTripThroughJSON() throws {
@@ -36,7 +37,8 @@ struct ContainerLogOptionsTests {
             tail: 100,
             since: since,
             until: until,
-            timestamps: true
+            timestamps: true,
+            stream: .boot
         )
 
         let data = try JSONEncoder().encode(options)

--- a/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
+++ b/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import ContainerResource
+
+struct ContainerLogOptionsTests {
+
+    @Test("Default log options preserve existing logs behavior")
+    func testDefaultOptions() {
+        let options = ContainerLogOptions.default
+
+        #expect(options.since == nil)
+        #expect(!options.timestamps)
+    }
+
+    @Test("Custom log options round-trip through JSON")
+    func testCustomOptionsRoundTrip() throws {
+        let since = Date(timeIntervalSince1970: 1_800_000_000)
+        let options = ContainerLogOptions(since: since, timestamps: true)
+
+        let data = try JSONEncoder().encode(options)
+        let decoded = try JSONDecoder().decode(ContainerLogOptions.self, from: data)
+
+        #expect(decoded.since == since)
+        #expect(decoded.timestamps)
+    }
+}

--- a/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
+++ b/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
@@ -92,6 +92,15 @@ struct ContainerLogOptionsTests {
         #expect(timestamp == localDate("2026-06-18"))
     }
 
+    @Test func parsesLocalDateTimeLogTimestampInLocalTime() throws {
+        let previousTimeZone = NSTimeZone.default
+        NSTimeZone.default = TimeZone(secondsFromGMT: 3_600)!
+        defer { NSTimeZone.default = previousTimeZone }
+
+        #expect(ContainerLogTimestampParser.parse("2026-06-18T10:30") == localDate("2026-06-18T10:30", format: "yyyy-MM-dd'T'HH:mm"))
+        #expect(ContainerLogTimestampParser.parse("2026-06-18T10:30:45") == localDate("2026-06-18T10:30:45", format: "yyyy-MM-dd'T'HH:mm:ss"))
+    }
+
     @Test func rejectsInvalidLogTimestamps() {
         #expect(ContainerLogTimestampParser.parse("not-a-date") == nil)
         #expect(ContainerLogTimestampParser.parse("-s") == nil)
@@ -108,12 +117,12 @@ struct ContainerLogOptionsTests {
         return formatter.date(from: value)!
     }
 
-    private func localDate(_ value: String) -> Date {
+    private func localDate(_ value: String, format: String = "yyyy-MM-dd") -> Date {
         let formatter = DateFormatter()
         formatter.calendar = Calendar(identifier: .gregorian)
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = TimeZone.current
-        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.dateFormat = format
         return formatter.date(from: value)!
     }
 }

--- a/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
+++ b/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
@@ -62,6 +62,13 @@ struct ContainerLogOptionsTests {
         #expect(ContainerLogTimestampParser.parse("-.5h", relativeTo: reference) == reference.addingTimeInterval(1_800))
     }
 
+    @Test func parsesRepeatedAbsoluteLogTimestamps() {
+        for _ in 0..<1_000 {
+            #expect(ContainerLogTimestampParser.parseAbsoluteTimestamp("2026-06-18T10:00:00Z") == date("2026-06-18T10:00:00Z"))
+            #expect(ContainerLogTimestampParser.parseAbsoluteTimestamp("2026-06-18T10:00:00.123456789Z") != nil)
+        }
+    }
+
     @Test func parsesDateOnlyLogTimestampInLocalTime() throws {
         let previousTimeZone = NSTimeZone.default
         NSTimeZone.default = TimeZone(secondsFromGMT: 3_600)!

--- a/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
+++ b/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
@@ -46,4 +46,31 @@ struct ContainerLogOptionsTests {
 
         #expect(decoded == options)
     }
+
+    @Test func parsesDockerCompatibleLogTimestamps() throws {
+        let reference = Date(timeIntervalSince1970: 1_900_000_000)
+
+        #expect(ContainerLogTimestampParser.parse("2026-06-18T10:00:00Z") == date("2026-06-18T10:00:00Z"))
+        #expect(ContainerLogTimestampParser.parse("2026-06-18T10:00:00.123456789Z") != nil)
+        #expect(ContainerLogTimestampParser.parse("1781776800.25") == Date(timeIntervalSince1970: 1_781_776_800.25))
+        #expect(ContainerLogTimestampParser.parse("1m30s", relativeTo: reference) == reference.addingTimeInterval(-90))
+        #expect(ContainerLogTimestampParser.parse("250ms", relativeTo: reference) == reference.addingTimeInterval(-0.25))
+        #expect(ContainerLogTimestampParser.parse("1.5h", relativeTo: reference) == reference.addingTimeInterval(-5_400))
+    }
+
+    @Test func rejectsInvalidLogTimestamps() {
+        #expect(ContainerLogTimestampParser.parse("not-a-date") == nil)
+        #expect(ContainerLogTimestampParser.parse("-1s") == nil)
+        #expect(ContainerLogTimestampParser.parse("1781776800.") == nil)
+        #expect(ContainerLogTimestampParser.parse("1d") == nil)
+    }
+
+    private func date(_ value: String) -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions =
+            value.contains(".")
+            ? [.withInternetDateTime, .withFractionalSeconds]
+            : [.withInternetDateTime]
+        return formatter.date(from: value)!
+    }
 }

--- a/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
+++ b/Tests/ContainerResourceTests/ContainerLogOptionsTests.swift
@@ -69,6 +69,19 @@ struct ContainerLogOptionsTests {
         }
     }
 
+    @Test func parsesOnlyExplicitZoneTimestampsAsRecordPrefixes() {
+        #expect(
+            ContainerLogTimestampParser.parseRecordTimestampPrefix("2026-06-18T10:00:00Z")
+                == date("2026-06-18T10:00:00Z")
+        )
+        #expect(ContainerLogTimestampParser.parseRecordTimestampPrefix("2026-06-18T10:00:00.123456789Z") != nil)
+        #expect(ContainerLogTimestampParser.parseRecordTimestampPrefix("2026-06-18T10:00:00+01:00") != nil)
+        #expect(ContainerLogTimestampParser.parseRecordTimestampPrefix("2026-06-18") == nil)
+        #expect(ContainerLogTimestampParser.parseRecordTimestampPrefix("2026-06-18T10:00:00") == nil)
+        #expect(ContainerLogTimestampParser.parseRecordTimestampPrefix("1781776800") == nil)
+        #expect(ContainerLogTimestampParser.parseRecordTimestampPrefix("1m30s") == nil)
+    }
+
     @Test func parsesDateOnlyLogTimestampInLocalTime() throws {
         let previousTimeZone = NSTimeZone.default
         NSTimeZone.default = TimeZone(secondsFromGMT: 3_600)!

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -411,8 +411,10 @@ container logs [--boot] [--follow] [-n <n>] [--tail <n>] [--since <timestamp>] [
 *   `--boot`: Display the boot log for the container instead of stdio
 *   `-f, --follow`: Follow log output
 *   `-n, --tail <n>`: Number of lines to show from the end of the logs. If not provided this will print all of the logs
-*   `--since <timestamp>`: Show logs after the specified RFC 3339 timestamp
-*   `--until <timestamp>`: Show logs before the specified RFC 3339 timestamp
+*   `--since <timestamp>`: Show logs after the specified RFC 3339 timestamp, Unix timestamp, or relative duration
+*   `--until <timestamp>`: Show logs before the specified RFC 3339 timestamp, Unix timestamp, or relative duration
+
+Timestamp filters accept RFC 3339 timestamps such as `2026-06-18T10:00:00Z`, Unix timestamps such as `1781776800.25`, and relative durations such as `1m30s`.
 
 `--since` and `--until` apply to static stdio and boot log replay. Followed time filters are not supported by this change.
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -414,6 +414,8 @@ container logs [--boot] [--follow] [-n <n>] [--tail <n>] [--since <timestamp>] [
 *   `--since <timestamp>`: Show logs after the specified RFC 3339 timestamp
 *   `--until <timestamp>`: Show logs before the specified RFC 3339 timestamp
 
+`--since` and `--until` apply to static stdio and boot log replay. Followed stdio time filters are not supported by this change.
+
 ### `container inspect`
 
 Displays detailed container information in JSON. Pass one or more container IDs to inspect multiple containers.
@@ -1276,4 +1278,3 @@ container system property list
 # output as JSON for scripting
 container system property list --format json
 ```
-

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -414,7 +414,7 @@ container logs [--boot] [--follow] [-n <n>] [--tail <n>] [--since <timestamp>] [
 *   `--since <timestamp>`: Show logs after the specified RFC 3339 timestamp
 *   `--until <timestamp>`: Show logs before the specified RFC 3339 timestamp
 
-`--since` and `--until` apply to static stdio and boot log replay. Followed stdio time filters are not supported by this change.
+`--since` and `--until` apply to static stdio and boot log replay. Followed time filters are not supported by this change.
 
 ### `container inspect`
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -394,12 +394,12 @@ container export mycontainer > mycontainer.tar
 
 ### `container logs`
 
-Fetches logs from a container. You can follow the logs (`-f`/`--follow`), restrict the number of lines shown, or view boot logs.
+Fetches logs from a container. You can follow the logs (`-f`/`--follow`), restrict the number of lines shown, filter by RFC 3339 timestamp, or view boot logs.
 
 **Usage**
 
 ```bash
-container logs [--boot] [--follow] [-n <n>] [--debug] <container-id>
+container logs [--boot] [--follow] [-n <n>] [--tail <n>] [--since <timestamp>] [--until <timestamp>] [--debug] <container-id>
 ```
 
 **Arguments**
@@ -410,7 +410,9 @@ container logs [--boot] [--follow] [-n <n>] [--debug] <container-id>
 
 *   `--boot`: Display the boot log for the container instead of stdio
 *   `-f, --follow`: Follow log output
-*   `-n <n>`: Number of lines to show from the end of the logs. If not provided this will print all of the logs
+*   `-n, --tail <n>`: Number of lines to show from the end of the logs. If not provided this will print all of the logs
+*   `--since <timestamp>`: Show logs after the specified RFC 3339 timestamp
+*   `--until <timestamp>`: Show logs before the specified RFC 3339 timestamp
 
 ### `container inspect`
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -411,10 +411,10 @@ container logs [--boot] [--follow] [-n <n>] [--tail <n>] [--since <timestamp>] [
 *   `--boot`: Display the boot log for the container instead of stdio
 *   `-f, --follow`: Follow log output
 *   `-n, --tail <n>`: Number of lines to show from the end of the logs. If not provided this will print all of the logs
-*   `--since <timestamp>`: Show logs after the specified RFC 3339 timestamp, Unix timestamp, or relative duration
-*   `--until <timestamp>`: Show logs before the specified RFC 3339 timestamp, Unix timestamp, or relative duration
+*   `--since <timestamp>`: Show logs after the specified RFC 3339 timestamp, Unix timestamp, local timestamp, or relative duration
+*   `--until <timestamp>`: Show logs before the specified RFC 3339 timestamp, Unix timestamp, local timestamp, or relative duration
 
-Timestamp filters accept RFC 3339 timestamps such as `2026-06-18T10:00:00Z`, Unix timestamps such as `1781776800.25`, and relative durations such as `1m30s`.
+Timestamp filters accept RFC 3339 timestamps such as `2026-06-18T10:00:00Z`, Unix timestamps such as `1781776800.25`, local date/time values such as `2026-06-18` or `2026-06-18T10:00:00`, and relative durations such as `1m30s`. Local date/time values are interpreted in the current local timezone.
 
 `--since` and `--until` apply to static stdio and boot log replay. Followed time filters are not supported by this change.
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -394,7 +394,7 @@ container export mycontainer > mycontainer.tar
 
 ### `container logs`
 
-Fetches logs from a container. You can follow the logs (`-f`/`--follow`), restrict the number of lines shown, filter by RFC 3339 timestamp, or view boot logs.
+Fetches logs from a container. You can follow the logs (`-f`/`--follow`), restrict the number of lines shown, filter by timestamp, or view boot logs.
 
 **Usage**
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -414,7 +414,7 @@ container logs [--boot] [--follow] [-n <n>] [--tail <n>] [--since <timestamp>] [
 *   `--since <timestamp>`: Show logs after the specified RFC 3339 timestamp
 *   `--until <timestamp>`: Show logs before the specified RFC 3339 timestamp
 
-`--since` and `--until` apply to static stdio and boot log replay. `--follow --until` stops following once the requested deadline is reached.
+`--since` and `--until` apply to static stdio and boot log replay. Followed time filters are not supported by this change.
 
 ### `container inspect`
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -414,7 +414,7 @@ container logs [--boot] [--follow] [-n <n>] [--tail <n>] [--since <timestamp>] [
 *   `--since <timestamp>`: Show logs after the specified RFC 3339 timestamp
 *   `--until <timestamp>`: Show logs before the specified RFC 3339 timestamp
 
-`--since` and `--until` apply to static stdio and boot log replay. Followed time filters are not supported by this change.
+`--since` and `--until` apply to static stdio and boot log replay. `--follow --until` stops following once the requested deadline is reached.
 
 ### `container inspect`
 

--- a/docs/upstream/PR-1764.md
+++ b/docs/upstream/PR-1764.md
@@ -17,27 +17,29 @@ Linked work:
 - apple/container#1592
 - apple/container#1752
 
-Local code commit:
+Local code commits:
 
 - `3b5aa9b822639be5cd41df3bcbdb5e2936860e26` (`fix(logs): tighten filtered replay semantics`)
+- `be319dd43757d24571d6f5b68ea91d7369cd0b32` (`fix(logs): scope followed time filters`)
 
 Design notes:
 
 - `container logs --follow --tail -1` now treats a negative tail as "all" instead of passing a negative value to local suffix handling.
-- `--follow --since` and `--follow --until` are accepted. The initial replay path applies the time filters, and `--follow --until` stops follow output when the deadline is reached.
+- `--follow --since` and `--follow --until` remain rejected by validation because this PR does not add a live structured-follow stream that can honor time filters safely.
 - Service-side time filtering no longer starts by reading the entire log into memory via `readToEnd()`. It scans the file in bounded chunks, rebuilds logical lines, and keeps only the requested retained tail when `tail > 0`.
 - Raw stdio logs without parseable timestamp prefixes now fail closed for time filters, matching the explicit API contract from the #1592 follow-up.
 - Tail-only paths still preserve raw, non-UTF8 bytes and unparseable lines because no timestamp decision is needed.
+- `ContainerizationError` failures raised by the filter path are preserved so callers see `invalidArgument` instead of a generic log-open failure.
 
 Compatibility impact:
 
-- This brings the CLI closer to Docker log option behavior for negative tail, followed logs, and bounded replay.
+- This brings the CLI closer to Docker log option behavior for negative tail and bounded static replay.
 - It deliberately avoids claiming complete Docker timestamp parity for raw stdio logs. Durable timestamp parity needs the structured log-record work tracked under #1752 and related follow-ups.
-- Compose can use this as an interim direct API contract, while full Docker Compose v2 log parity should depend on structured records and line-oriented replay.
+- Compose can use this as an interim static direct API contract, while full Docker Compose v2 followed timestamp parity should depend on structured records and line-oriented replay.
 
 Remaining risks:
 
-- `--follow --since` only constrains the initial replay for raw stdio follow. Newly appended raw bytes are streamed as they arrive because raw append data has no durable timestamp metadata. Structured log records should close this gap.
+- Followed time filters remain outside this PR. Structured log records and a live record-follow API should close that gap without following a filtered temporary snapshot.
 - The bounded scan avoids full-log `readToEnd()`, but the filtered output is still materialized before being exposed as a handle. A future streaming API would be stronger for very large filtered result sets.
 
 ## Testing
@@ -54,8 +56,9 @@ Local validation:
 
 Test coverage added or updated:
 
-- Follow validation accepts `--since` and `--until`.
-- Follow validation preserves `since` / `until` while leaving `tail` for local follow handling.
+- Follow validation rejects `--since` and `--until` so the CLI cannot follow a filtered temporary snapshot.
+- Follow validation still accepts tail-only follow and leaves `tail` for local follow handling.
 - Tail-only paths preserve non-UTF8 and unparseable lines.
 - Time-filter paths reject unparseable or non-UTF8 log data.
+- Time-filter failures assert the `invalidArgument` error code.
 - Negative tail writes all bytes on the local raw follow path.

--- a/docs/upstream/PR-1764.md
+++ b/docs/upstream/PR-1764.md
@@ -23,6 +23,7 @@ Local code commits:
 - `be319dd43757d24571d6f5b68ea91d7369cd0b32` (`fix(logs): scope followed time filters`)
 - `d44a12225f9ed7afbdc0c13f45f33ada1909d254` (`fix(logs): align filtered tail replay`)
 - `e03b5c92f7be86eb6a457e820311696b175d9b55` (`fix(logs): avoid eager tail allocation`)
+- `dbbb0f2727a1d48f4e24a615be17ce33f000ce46` (`fix(logs): filter selected log stream`)
 
 Design notes:
 
@@ -35,12 +36,15 @@ Design notes:
 - Tail-only paths still preserve raw, non-UTF8 bytes and unparseable lines because no timestamp decision is needed.
 - `ContainerizationError` failures raised by the filter path are preserved so callers see `invalidArgument` instead of a generic log-open failure.
 - The ring buffer grows as retained lines are found instead of preallocating the full caller-provided `tail` value, which avoids turning a large option value into an eager allocation.
+- `ContainerLogOptions.stream` lets callers identify the stream that should receive filters. The CLI sets it from `--boot`, so a normal stdio request is not rejected because the unselected boot log cannot satisfy stdio timestamp-filter rules.
+- Raw blank log records now fail closed under timestamp filters, matching the documented rule that timestamp filtering requires parseable timestamp prefixes. Empty log files still filter to empty output without error.
 
 Compatibility impact:
 
 - This brings the CLI closer to Docker log option behavior for negative tail and bounded static replay.
 - It deliberately avoids claiming complete Docker timestamp parity for raw stdio logs. Durable timestamp parity needs the structured log-record work tracked under #1752 and related follow-ups.
 - Compose can use this as an interim static direct API contract, while full Docker Compose v2 followed timestamp parity should depend on structured records and line-oriented replay.
+- The stream selector keeps the existing two-handle return shape intact while giving CLI and direct API callers a way to avoid filtering streams they will not consume.
 
 Remaining risks:
 
@@ -55,9 +59,9 @@ Remaining risks:
 
 Local validation:
 
-- `swift format lint --strict --configuration .swift-format-nolint Sources/ContainerCommands/LogFileOutput.swift Sources/ContainerCommands/Container/ContainerLogs.swift Sources/ContainerResource/Container/ContainerLogOptions.swift Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift Tests/ContainerAPIServiceTests/ContainerLogsTests.swift Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift`
+- `swift format lint --strict --configuration .swift-format-nolint Sources/ContainerCommands/LogFileOutput.swift Sources/ContainerCommands/Container/ContainerLogs.swift Sources/ContainerResource/Container/ContainerLogOptions.swift Sources/Services/ContainerAPIService/Client/ContainerClient.swift Sources/Services/ContainerAPIService/Client/XPC+.swift Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift Tests/ContainerAPIServiceTests/ContainerLogsTests.swift Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift Tests/ContainerResourceTests/ContainerLogOptionsTests.swift`
 - `git diff --check`
-- `swift test --filter ContainerLogsTests --filter ContainerLogsCommandTests`
+- `swift test --filter ContainerLogsTests --filter ContainerLogsCommandTests --filter ContainerLogOptionsTests`
 
 Test coverage added or updated:
 
@@ -65,6 +69,8 @@ Test coverage added or updated:
 - Follow validation still accepts tail-only follow and leaves `tail` for local follow handling.
 - Tail-only paths preserve non-UTF8 and unparseable lines.
 - Time-filter paths reject unparseable or non-UTF8 log data.
+- Time-filter paths reject blank raw application log records.
 - Time-filter failures assert the `invalidArgument` error code.
 - Negative tail writes all bytes on the local raw follow path.
 - Filtered replay retains the requested tail count in chronological order after applying time filters.
+- Stream selection is covered across the CLI option builder, XPC harness decoding, Codable option round trip, and API-service filtering helper.

--- a/docs/upstream/PR-1764.md
+++ b/docs/upstream/PR-1764.md
@@ -22,6 +22,7 @@ Local code commits:
 - `3b5aa9b822639be5cd41df3bcbdb5e2936860e26` (`fix(logs): tighten filtered replay semantics`)
 - `be319dd43757d24571d6f5b68ea91d7369cd0b32` (`fix(logs): scope followed time filters`)
 - `d44a12225f9ed7afbdc0c13f45f33ada1909d254` (`fix(logs): align filtered tail replay`)
+- `e03b5c92f7be86eb6a457e820311696b175d9b55` (`fix(logs): avoid eager tail allocation`)
 
 Design notes:
 
@@ -33,6 +34,7 @@ Design notes:
 - Raw stdio logs without parseable timestamp prefixes now fail closed for time filters, matching the explicit API contract from the #1592 follow-up.
 - Tail-only paths still preserve raw, non-UTF8 bytes and unparseable lines because no timestamp decision is needed.
 - `ContainerizationError` failures raised by the filter path are preserved so callers see `invalidArgument` instead of a generic log-open failure.
+- The ring buffer grows as retained lines are found instead of preallocating the full caller-provided `tail` value, which avoids turning a large option value into an eager allocation.
 
 Compatibility impact:
 

--- a/docs/upstream/PR-1764.md
+++ b/docs/upstream/PR-1764.md
@@ -24,6 +24,7 @@ Local code commits:
 - `d44a12225f9ed7afbdc0c13f45f33ada1909d254` (`fix(logs): align filtered tail replay`)
 - `e03b5c92f7be86eb6a457e820311696b175d9b55` (`fix(logs): avoid eager tail allocation`)
 - `dbbb0f2727a1d48f4e24a615be17ce33f000ce46` (`fix(logs): filter selected log stream`)
+- `4501c0d2212efac5e5475a2526857a9df4febdea` (`fix(logs): align zero-tail filtering`)
 
 Design notes:
 
@@ -38,6 +39,7 @@ Design notes:
 - The ring buffer grows as retained lines are found instead of preallocating the full caller-provided `tail` value, which avoids turning a large option value into an eager allocation.
 - `ContainerLogOptions.stream` lets callers identify the stream that should receive filters. The CLI sets it from `--boot`, so a normal stdio request is not rejected because the unselected boot log cannot satisfy stdio timestamp-filter rules.
 - Raw blank log records now fail closed under timestamp filters, matching the documented rule that timestamp filtering requires parseable timestamp prefixes. Empty log files still filter to empty output without error.
+- Zero-tail replay returns an empty result before timestamp parsing in both the in-memory helper and file-handle path, so `tail: 0` never rejects existing unparseable log bytes.
 
 Compatibility impact:
 
@@ -74,3 +76,4 @@ Test coverage added or updated:
 - Negative tail writes all bytes on the local raw follow path.
 - Filtered replay retains the requested tail count in chronological order after applying time filters.
 - Stream selection is covered across the CLI option builder, XPC harness decoding, Codable option round trip, and API-service filtering helper.
+- Zero-tail replay is covered for timestamped logs and unparseable logs combined with timestamp filters.

--- a/docs/upstream/PR-1764.md
+++ b/docs/upstream/PR-1764.md
@@ -21,12 +21,15 @@ Local code commits:
 
 - `3b5aa9b822639be5cd41df3bcbdb5e2936860e26` (`fix(logs): tighten filtered replay semantics`)
 - `be319dd43757d24571d6f5b68ea91d7369cd0b32` (`fix(logs): scope followed time filters`)
+- `d44a12225f9ed7afbdc0c13f45f33ada1909d254` (`fix(logs): align filtered tail replay`)
 
 Design notes:
 
 - `container logs --follow --tail -1` now treats a negative tail as "all" instead of passing a negative value to local suffix handling.
 - `--follow --since` and `--follow --until` remain rejected by validation because this PR does not add a live structured-follow stream that can honor time filters safely.
 - Service-side time filtering no longer starts by reading the entire log into memory via `readToEnd()`. It scans the file in bounded chunks, rebuilds logical lines, and keeps only the requested retained tail when `tail > 0`.
+- The public `ContainerLogOptions.tail` contract now states the Docker-shaped semantics explicitly: positive means last N lines, zero means no lines, and negative means all lines.
+- Filtered replay now retains requested tail lines in a fixed-size ring buffer instead of repeatedly trimming from the front of an array while scanning large logs.
 - Raw stdio logs without parseable timestamp prefixes now fail closed for time filters, matching the explicit API contract from the #1592 follow-up.
 - Tail-only paths still preserve raw, non-UTF8 bytes and unparseable lines because no timestamp decision is needed.
 - `ContainerizationError` failures raised by the filter path are preserved so callers see `invalidArgument` instead of a generic log-open failure.
@@ -62,3 +65,4 @@ Test coverage added or updated:
 - Time-filter paths reject unparseable or non-UTF8 log data.
 - Time-filter failures assert the `invalidArgument` error code.
 - Negative tail writes all bytes on the local raw follow path.
+- Filtered replay retains the requested tail count in chronological order after applying time filters.

--- a/docs/upstream/PR-1764.md
+++ b/docs/upstream/PR-1764.md
@@ -1,0 +1,61 @@
+<!-- markdownlint-disable MD013 MD041 -->
+
+## Type of Change
+
+- [x] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [x] Documentation update
+
+## Motivation and Context
+
+This follow-up fixes the strict review findings on #1764 by making followed and static log filtering safer, more Docker-shaped, and less memory-heavy. The branch remains scoped to CLI/API log filtering behavior and does not introduce Compose-specific functionality into apple/container.
+
+Linked work:
+
+- apple/container#1764
+- apple/container#1592
+- apple/container#1752
+
+Local code commit:
+
+- `3b5aa9b822639be5cd41df3bcbdb5e2936860e26` (`fix(logs): tighten filtered replay semantics`)
+
+Design notes:
+
+- `container logs --follow --tail -1` now treats a negative tail as "all" instead of passing a negative value to local suffix handling.
+- `--follow --since` and `--follow --until` are accepted. The initial replay path applies the time filters, and `--follow --until` stops follow output when the deadline is reached.
+- Service-side time filtering no longer starts by reading the entire log into memory via `readToEnd()`. It scans the file in bounded chunks, rebuilds logical lines, and keeps only the requested retained tail when `tail > 0`.
+- Raw stdio logs without parseable timestamp prefixes now fail closed for time filters, matching the explicit API contract from the #1592 follow-up.
+- Tail-only paths still preserve raw, non-UTF8 bytes and unparseable lines because no timestamp decision is needed.
+
+Compatibility impact:
+
+- This brings the CLI closer to Docker log option behavior for negative tail, followed logs, and bounded replay.
+- It deliberately avoids claiming complete Docker timestamp parity for raw stdio logs. Durable timestamp parity needs the structured log-record work tracked under #1752 and related follow-ups.
+- Compose can use this as an interim direct API contract, while full Docker Compose v2 log parity should depend on structured records and line-oriented replay.
+
+Remaining risks:
+
+- `--follow --since` only constrains the initial replay for raw stdio follow. Newly appended raw bytes are streamed as they arrive because raw append data has no durable timestamp metadata. Structured log records should close this gap.
+- The bounded scan avoids full-log `readToEnd()`, but the filtered output is still materialized before being exposed as a handle. A future streaming API would be stronger for very large filtered result sets.
+
+## Testing
+
+- [x] Tested locally
+- [x] Added/updated tests
+- [x] Added/updated docs
+
+Local validation:
+
+- `swift format lint --strict --configuration .swift-format-nolint Sources/ContainerCommands/LogFileOutput.swift Sources/ContainerCommands/Container/ContainerLogs.swift Sources/ContainerResource/Container/ContainerLogOptions.swift Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift Tests/ContainerAPIServiceTests/ContainerLogsTests.swift Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift`
+- `git diff --check`
+- `swift test --filter ContainerLogsTests --filter ContainerLogsCommandTests`
+
+Test coverage added or updated:
+
+- Follow validation accepts `--since` and `--until`.
+- Follow validation preserves `since` / `until` while leaving `tail` for local follow handling.
+- Tail-only paths preserve non-UTF8 and unparseable lines.
+- Time-filter paths reject unparseable or non-UTF8 log data.
+- Negative tail writes all bytes on the local raw follow path.

--- a/docs/upstream/PR-1765.md
+++ b/docs/upstream/PR-1765.md
@@ -20,10 +20,10 @@ Linked work:
 
 Local code commits:
 
-- `d16db4776f7dbbd1390d89e771b53bdb50fd9d42` (`fix(logs): share timestamp prefix parsing`)
-- `6ad23e0dc6086b0c2fdc0f79dd809c685b4f7c80` (`fix(logs): reuse timestamp parser formatters`)
-- `6e7749c087a3b4fe5b26a74fc79c48ad43fee706` (`fix(logs): split timestamp parser boundaries`)
-- `0ba01343a2c0317248db37ef3363953db86ec369` (`test(logs): reject date-like raw prefixes`)
+- `551d159baf557fd72db2928eb8fae6405bc28b0d` (`fix(logs): share timestamp prefix parsing`)
+- `c3cff02b138b3e940fc461797c4d3377d3e4096c` (`fix(logs): reuse timestamp parser formatters`)
+- `91c914a132bb67506c3bac2627a04c2c24e4993b` (`fix(logs): split timestamp parser boundaries`)
+- `211312c674acbabd30af3ab9426bd954a3142086` (`test(logs): reject date-like raw prefixes`)
 
 Design notes:
 

--- a/docs/upstream/PR-1765.md
+++ b/docs/upstream/PR-1765.md
@@ -20,9 +20,10 @@ Linked work:
 
 Local code commits:
 
-- `318cd752f8c087a13d8183c15db28bbaa962e08d` (`fix(logs): share timestamp prefix parsing`)
-- `b56c091c131c90a7a055fb961d5bcc392c61e81e` (`fix(logs): reuse timestamp parser formatters`)
-- `9e91e2c9a212f653b4acc2fdf41f0860b8a54bf9` (`fix(logs): split timestamp parser boundaries`)
+- `d16db4776f7dbbd1390d89e771b53bdb50fd9d42` (`fix(logs): share timestamp prefix parsing`)
+- `6ad23e0dc6086b0c2fdc0f79dd809c685b4f7c80` (`fix(logs): reuse timestamp parser formatters`)
+- `6e7749c087a3b4fe5b26a74fc79c48ad43fee706` (`fix(logs): split timestamp parser boundaries`)
+- `0ba01343a2c0317248db37ef3363953db86ec369` (`test(logs): reject date-like raw prefixes`)
 
 Design notes:
 
@@ -52,7 +53,7 @@ Remaining risks:
 
 Local validation:
 
-- `swift format lint --strict --configuration .swift-format-nolint Sources/ContainerResource/Container/ContainerLogTimestampParser.swift Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift Tests/ContainerResourceTests/ContainerLogOptionsTests.swift`
+- `swift format lint --strict --configuration .swift-format-nolint Sources/ContainerResource/Container/ContainerLogTimestampParser.swift Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift Tests/ContainerResourceTests/ContainerLogOptionsTests.swift Tests/ContainerAPIServiceTests/ContainerLogsTests.swift`
 - `git diff --check`
 - `swift test --filter ContainerLogOptionsTests --filter ContainerLogsTests`
 
@@ -61,4 +62,4 @@ Test coverage relied on:
 - Existing shared parser tests cover Docker-compatible absolute timestamp forms, date-only timestamps, and invalid timestamps.
 - Repeated absolute timestamp parsing is covered to exercise the reused parser path.
 - Record-prefix parser tests cover strict acceptance of explicit-zone RFC 3339/RFC 3339 nano timestamps and rejection of local dates, Unix timestamps, and relative durations.
-- Existing service log tests continue to validate server-side filtering behavior through the parser boundary.
+- Service log tests validate server-side filtering behavior through the parser boundary, including date-like application output that must not be treated as a runtime timestamp prefix.

--- a/docs/upstream/PR-1765.md
+++ b/docs/upstream/PR-1765.md
@@ -1,0 +1,56 @@
+<!-- markdownlint-disable MD013 MD041 -->
+
+## Type of Change
+
+- [x] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+
+## Motivation and Context
+
+This follow-up removes duplicate timestamp parsing state from the service log filtering boundary in #1765 and delegates absolute timestamp parsing to the shared `ContainerLogTimestampParser`. That keeps Docker-compatible timestamp parsing behavior in one place and reduces drift between CLI option parsing and server-side log record filtering.
+
+Linked work:
+
+- apple/container#1765
+- apple/container#1764
+- apple/container#1592
+- apple/container#1752
+
+Local code commit:
+
+- `318cd752f8c087a13d8183c15db28bbaa962e08d` (`fix(logs): share timestamp prefix parsing`)
+
+Design notes:
+
+- `ContainersService.LogTimestampParser.timestampPrefix(fromTimestampToken:)` now calls `ContainerLogTimestampParser.parseAbsoluteTimestamp(_:)`.
+- The service no longer keeps separate ISO8601 formatter instances for timestamp tokens, so future parser extensions only need to be made at the shared parser boundary.
+- This is a surgical cleanup intended to make the timestamp parser PR easier to maintain and review.
+
+Compatibility impact:
+
+- No user-facing behavior change is intended. The point is to preserve identical accepted timestamp forms between CLI parsing and service replay filtering.
+- This supports later Compose log parity work by keeping timestamp semantics centralized.
+
+Remaining risks:
+
+- This cleanup depends on #1765's shared parser type being accepted as the common timestamp parsing surface.
+- Full Docker / Docker Compose parity still requires structured log records and replay semantics beyond this parser consolidation.
+
+## Testing
+
+- [x] Tested locally
+- [x] Added/updated tests
+- [ ] Added/updated docs
+
+Local validation:
+
+- `swift format lint --strict --configuration .swift-format-nolint Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift`
+- `git diff --check`
+- `swift test --filter ContainerLogOptionsTests --filter ContainerLogsTests`
+
+Test coverage relied on:
+
+- Existing shared parser tests cover Docker-compatible absolute timestamp forms, date-only timestamps, and invalid timestamps.
+- Existing service log tests continue to validate server-side filtering behavior through the parser boundary.

--- a/docs/upstream/PR-1765.md
+++ b/docs/upstream/PR-1765.md
@@ -28,6 +28,7 @@ Local code commits:
 - `128a20e0a1b9b3357d3e333c2499d3c2dd9dd96b` (`fix(logs): reuse timestamp parser formatters`)
 - `1a84b7d50cc980604f001d0ddf81b7564483c85a` (`fix(logs): split timestamp parser boundaries`)
 - `43cdb8aa9640d6bacccf27619ae943c1ab6fd7a7` (`test(logs): reject date-like raw prefixes`)
+- `ff2d7680927594b128e426ae768b99b355413fdc` (`test(logs): cover local datetime filters`)
 
 Design notes:
 
@@ -64,7 +65,8 @@ Local validation:
 
 Test coverage relied on:
 
-- Existing shared parser tests cover Docker-compatible absolute timestamp forms, date-only timestamps, and invalid timestamps.
+- Existing shared parser tests cover Docker-compatible absolute timestamp forms, date-only and local date-time timestamps, and invalid timestamps.
+- Command parser tests cover local date-time timestamp arguments so the CLI path stays aligned with the shared parser.
 - Repeated absolute timestamp parsing is covered to exercise the reused parser path.
 - Record-prefix parser tests cover strict acceptance of explicit-zone RFC 3339/RFC 3339 nano timestamps and rejection of local dates, Unix timestamps, and relative durations.
 - Service log tests validate server-side filtering behavior through the parser boundary, including date-like application output that must not be treated as a runtime timestamp prefix.

--- a/docs/upstream/PR-1765.md
+++ b/docs/upstream/PR-1765.md
@@ -9,7 +9,7 @@
 
 ## Motivation and Context
 
-This follow-up removes duplicate timestamp parsing state from the service log filtering boundary in #1765 and delegates absolute timestamp parsing to the shared `ContainerLogTimestampParser`. That keeps Docker-compatible timestamp parsing behavior in one place and reduces drift between CLI option parsing and server-side log record filtering.
+This follow-up removes duplicate timestamp parsing state from the service log filtering boundary in #1765 and delegates timestamp parsing to `ContainerLogTimestampParser`. It also keeps the parser boundary explicit: CLI filter arguments stay Docker-compatible and broad, while stored log record prefixes stay strict enough to avoid treating ordinary application output as runtime-authored timestamps.
 
 Linked work:
 
@@ -22,33 +22,37 @@ Local code commits:
 
 - `318cd752f8c087a13d8183c15db28bbaa962e08d` (`fix(logs): share timestamp prefix parsing`)
 - `b56c091c131c90a7a055fb961d5bcc392c61e81e` (`fix(logs): reuse timestamp parser formatters`)
+- `9e91e2c9a212f653b4acc2fdf41f0860b8a54bf9` (`fix(logs): split timestamp parser boundaries`)
 
 Design notes:
 
-- `ContainersService.LogTimestampParser.timestampPrefix(fromTimestampToken:)` now calls `ContainerLogTimestampParser.parseAbsoluteTimestamp(_:)`.
+- `ContainersService.LogTimestampParser.timestampPrefix(fromTimestampToken:)` now calls `ContainerLogTimestampParser.parseRecordTimestampPrefix(_:)`.
 - The service no longer keeps separate ISO8601 formatter instances for timestamp tokens, so future parser extensions only need to be made at the shared parser boundary.
 - The shared parser reuses guarded formatter instances for absolute timestamp parsing instead of allocating formatter state for each log line.
+- `parseRecordTimestampPrefix(_:)` accepts only RFC 3339-style timestamps with explicit timezone information; local dates, Unix timestamps, and relative durations remain CLI filter-argument forms only.
 - This is a surgical cleanup intended to make the timestamp parser PR easier to maintain and review.
 
 Compatibility impact:
 
-- No user-facing behavior change is intended. The point is to preserve identical accepted timestamp forms between CLI parsing and service replay filtering.
+- CLI timestamp filter behavior is unchanged.
+- Service replay filtering no longer treats broad CLI-only forms such as date-only values, Unix timestamps, or relative durations as stored log record prefixes.
 - This supports later Compose log parity work by keeping timestamp semantics centralized.
 
 Remaining risks:
 
 - This cleanup depends on #1765's shared parser type being accepted as the common timestamp parsing surface.
+- Stored raw application output that starts with a fully qualified RFC 3339 timestamp remains indistinguishable from a timestamped raw log prefix until structured log records become the durable replay source.
 - Full Docker / Docker Compose parity still requires structured log records and replay semantics beyond this parser consolidation.
 
 ## Testing
 
 - [x] Tested locally
 - [x] Added/updated tests
-- [ ] Added/updated docs
+- [x] Added/updated docs
 
 Local validation:
 
-- `swift format lint --strict --configuration .swift-format-nolint Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift`
+- `swift format lint --strict --configuration .swift-format-nolint Sources/ContainerResource/Container/ContainerLogTimestampParser.swift Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift Tests/ContainerResourceTests/ContainerLogOptionsTests.swift`
 - `git diff --check`
 - `swift test --filter ContainerLogOptionsTests --filter ContainerLogsTests`
 
@@ -56,4 +60,5 @@ Test coverage relied on:
 
 - Existing shared parser tests cover Docker-compatible absolute timestamp forms, date-only timestamps, and invalid timestamps.
 - Repeated absolute timestamp parsing is covered to exercise the reused parser path.
+- Record-prefix parser tests cover strict acceptance of explicit-zone RFC 3339/RFC 3339 nano timestamps and rejection of local dates, Unix timestamps, and relative durations.
 - Existing service log tests continue to validate server-side filtering behavior through the parser boundary.

--- a/docs/upstream/PR-1765.md
+++ b/docs/upstream/PR-1765.md
@@ -3,13 +3,13 @@
 ## Type of Change
 
 - [x] Bug fix
-- [ ] New feature
+- [x] New feature
 - [ ] Breaking change
-- [ ] Documentation update
+- [x] Documentation update
 
 ## Motivation and Context
 
-This follow-up removes duplicate timestamp parsing state from the service log filtering boundary in #1765 and delegates timestamp parsing to `ContainerLogTimestampParser`. It also keeps the parser boundary explicit: CLI filter arguments stay Docker-compatible and broad, while stored log record prefixes stay strict enough to avoid treating ordinary application output as runtime-authored timestamps.
+This PR broadens `container logs --since` and `container logs --until` to accept Docker-compatible timestamp filter arguments and centralizes that parsing in `ContainerLogTimestampParser`. It also keeps the replay boundary explicit: CLI filter arguments stay Docker-compatible and broad, while stored log record prefixes stay strict enough to avoid treating ordinary application output as runtime-authored timestamps.
 
 Linked work:
 
@@ -20,28 +20,33 @@ Linked work:
 
 Local code commits:
 
-- `551d159baf557fd72db2928eb8fae6405bc28b0d` (`fix(logs): share timestamp prefix parsing`)
-- `c3cff02b138b3e940fc461797c4d3377d3e4096c` (`fix(logs): reuse timestamp parser formatters`)
-- `91c914a132bb67506c3bac2627a04c2c24e4993b` (`fix(logs): split timestamp parser boundaries`)
-- `211312c674acbabd30af3ab9426bd954a3142086` (`test(logs): reject date-like raw prefixes`)
+- `bd7d1a7caf4845c40fca603d7acc4014759d13f1` (`feat(logs): accept docker-compatible timestamps`)
+- `e5c469d691192d8916d7bfd977d969ddd1f7c9da` (`test(logs): cover relative timestamp arguments`)
+- `f243369f67bf8ff6b2c4f8c13117cb76ac1c6496` (`fix(logs): parse date-only filters in local time`)
+- `10a035f289e62ae1056c4cffbc0e032704528362` (`fix(logs): accept signed relative durations`)
+- `6a673b6e3d72a11c50e064f36ccc3111bcf3c226` (`fix(logs): share timestamp prefix parsing`)
+- `128a20e0a1b9b3357d3e333c2499d3c2dd9dd96b` (`fix(logs): reuse timestamp parser formatters`)
+- `1a84b7d50cc980604f001d0ddf81b7564483c85a` (`fix(logs): split timestamp parser boundaries`)
+- `43cdb8aa9640d6bacccf27619ae943c1ab6fd7a7` (`test(logs): reject date-like raw prefixes`)
 
 Design notes:
 
+- `ContainerLogTimestampParser.parse(_:)` accepts RFC 3339/RFC 3339 nano timestamps, Unix timestamps with optional fractional seconds, local date/time forms, and Go-style relative durations.
 - `ContainersService.LogTimestampParser.timestampPrefix(fromTimestampToken:)` now calls `ContainerLogTimestampParser.parseRecordTimestampPrefix(_:)`.
 - The service no longer keeps separate ISO8601 formatter instances for timestamp tokens, so future parser extensions only need to be made at the shared parser boundary.
 - The shared parser reuses guarded formatter instances for absolute timestamp parsing instead of allocating formatter state for each log line.
 - `parseRecordTimestampPrefix(_:)` accepts only RFC 3339-style timestamps with explicit timezone information; local dates, Unix timestamps, and relative durations remain CLI filter-argument forms only.
-- This is a surgical cleanup intended to make the timestamp parser PR easier to maintain and review.
+- Local date/time filter arguments are interpreted in the user's current local timezone, matching Docker's local timestamp behavior when no explicit timezone is supplied.
 
 Compatibility impact:
 
-- CLI timestamp filter behavior is unchanged.
+- CLI timestamp filters now accept Docker-compatible absolute timestamps, Unix timestamps, local date/time values, and relative durations.
 - Service replay filtering no longer treats broad CLI-only forms such as date-only values, Unix timestamps, or relative durations as stored log record prefixes.
 - This supports later Compose log parity work by keeping timestamp semantics centralized.
 
 Remaining risks:
 
-- This cleanup depends on #1765's shared parser type being accepted as the common timestamp parsing surface.
+- This change depends on #1765's shared parser type being accepted as the common timestamp parsing surface.
 - Stored raw application output that starts with a fully qualified RFC 3339 timestamp remains indistinguishable from a timestamped raw log prefix until structured log records become the durable replay source.
 - Full Docker / Docker Compose parity still requires structured log records and replay semantics beyond this parser consolidation.
 
@@ -53,9 +58,9 @@ Remaining risks:
 
 Local validation:
 
-- `swift format lint --strict --configuration .swift-format-nolint Sources/ContainerResource/Container/ContainerLogTimestampParser.swift Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift Tests/ContainerResourceTests/ContainerLogOptionsTests.swift Tests/ContainerAPIServiceTests/ContainerLogsTests.swift`
+- `swift format lint --strict --configuration .swift-format-nolint Sources/ContainerCommands/Container/ContainerLogs.swift Sources/ContainerResource/Container/ContainerLogTimestampParser.swift Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift Tests/ContainerResourceTests/ContainerLogOptionsTests.swift Tests/ContainerAPIServiceTests/ContainerLogsTests.swift Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift`
 - `git diff --check`
-- `swift test --filter ContainerLogOptionsTests --filter ContainerLogsTests`
+- `swift test --filter ContainerLogsTests --filter ContainerLogsCommandTests --filter ContainerLogOptionsTests`
 
 Test coverage relied on:
 

--- a/docs/upstream/PR-1765.md
+++ b/docs/upstream/PR-1765.md
@@ -18,14 +18,16 @@ Linked work:
 - apple/container#1592
 - apple/container#1752
 
-Local code commit:
+Local code commits:
 
 - `318cd752f8c087a13d8183c15db28bbaa962e08d` (`fix(logs): share timestamp prefix parsing`)
+- `b56c091c131c90a7a055fb961d5bcc392c61e81e` (`fix(logs): reuse timestamp parser formatters`)
 
 Design notes:
 
 - `ContainersService.LogTimestampParser.timestampPrefix(fromTimestampToken:)` now calls `ContainerLogTimestampParser.parseAbsoluteTimestamp(_:)`.
 - The service no longer keeps separate ISO8601 formatter instances for timestamp tokens, so future parser extensions only need to be made at the shared parser boundary.
+- The shared parser reuses guarded formatter instances for absolute timestamp parsing instead of allocating formatter state for each log line.
 - This is a surgical cleanup intended to make the timestamp parser PR easier to maintain and review.
 
 Compatibility impact:
@@ -53,4 +55,5 @@ Local validation:
 Test coverage relied on:
 
 - Existing shared parser tests cover Docker-compatible absolute timestamp forms, date-only timestamps, and invalid timestamps.
+- Repeated absolute timestamp parsing is covered to exercise the reused parser path.
 - Existing service log tests continue to validate server-side filtering behavior through the parser boundary.


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context

This is a draft stacked follow-up to #1592 and #1764. Once log retrieval filters are exposed through `ContainerLogOptions`, the CLI should accept the timestamp forms users expect from Docker-compatible log commands instead of only accepting RFC 3339 values.

Docker-compatible log workflows commonly use Unix timestamps, fractional Unix timestamps, and relative Go-style durations such as `1m30s`. External orchestrators need the same parser behavior as the `container logs` CLI, so this draft moves timestamp parsing into `ContainerResource` as a small reusable helper rather than leaving ad hoc parsing in the command layer.

Draft/stacking note: this branch is based on the updated `logs-tail-until-options` branch from #1764, which is itself based on #1592. Because GitHub PRs to `apple/container` target `main`, this diff includes #1592 and #1764. The intended review delta for this draft is:

- `d7cc54c feat(logs): accept docker-compatible timestamps`
- `eaf8fce test(logs): cover relative timestamp arguments`
- `fdb387e fix(logs): parse date-only filters in local time`
- `b3929ca fix(logs): accept signed relative durations`

## What Changed

- Adds `ContainerLogTimestampParser` in `ContainerResource`.
- Supports RFC 3339 timestamps with or without fractional seconds.
- Parses date-only and no-zone timestamps using the local timezone, matching Docker-style CLI behavior.
- Supports Unix timestamps with optional fractional seconds.
- Supports Go-style relative durations such as `1m30s`, `250ms`, and `1.5h`.
- Supports signed Go-style relative durations such as `+1s`, `-1s`, and `-.5h`.
- Rejects non-finite duration components instead of letting overflow produce invalid dates.
- Updates `container logs --since` and `--until` argument parsing to use the shared parser.
- Documents accepted timestamp formats in `docs/command-reference.md`.
- Adds focused parser and CLI argument tests.

## Relationship to Existing Work

- Depends on #1592 for the initial log options API direction.
- Depends on #1764 for the `tail` / `until` retrieval filter surface.
- Related to #1591 and #1752.
- This remains generic `container logs` behavior; no Compose-specific behavior is included.

## Non-Goals

- This does not add structured log records.
- This does not change runtime log storage.
- This does not add timestamp rendering.
- This does not add day-based duration units; Docker's duration parser is Go-duration based, so supported units are `ns`, `us`/`µs`/`μs`, `ms`, `s`, `m`, and `h`.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [x] Added/updated docs

Local verification:

```bash
swift format lint --strict --configuration .swift-format-nolint Sources/ContainerResource/Container/ContainerLogTimestampParser.swift Sources/ContainerCommands/Container/ContainerLogs.swift Tests/ContainerCommandsTests/ContainerLogsCommandTests.swift Tests/ContainerResourceTests/ContainerLogOptionsTests.swift Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift Tests/ContainerAPIServiceTests/ContainerLogsTests.swift
git diff --check
swift build
swift test --filter ContainerLogsCommandTests
swift test --filter ContainerLogsTests
swift test --filter ContainerLogOptionsTests
```

Result: focused validation passed locally. The focused tests ran 31 tests across `ContainerLogsCommandTests`, `ContainerLogsTests`, and `ContainerLogOptionsTests`.