### PR TITLE
Add insecure registry configuration for pull/push/login

### DIFF
--- a/Sources/ContainerCommands/Registry/RegistryLogin.swift
+++ b/Sources/ContainerCommands/Registry/RegistryLogin.swift
@@ -70,7 +70,9 @@ extension Application {
             }
 
             let server = Reference.resolveDomain(domain: server)
-            let scheme = try RequestScheme(registry.scheme).schemeFor(host: server, internalDnsDomain: containerSystemConfig.dns.domain)
+            let scheme = try RequestScheme(registry.scheme).schemeFor(
+                host: server, internalDnsDomain: containerSystemConfig.dns.domain,
+                insecureRegistries: containerSystemConfig.registry.insecureRegistries)
             let _url = "\(scheme)://\(server)"
             guard let url = URL(string: _url) else {
                 throw ContainerizationError(.invalidArgument, message: "cannot convert \(_url) to URL")

--- a/Sources/ContainerPersistence/ContainerSystemConfig.swift
+++ b/Sources/ContainerPersistence/ContainerSystemConfig.swift
@@ -227,12 +227,27 @@ final public class RegistryConfig: Codable, Sendable {
 
     public let domain: String
 
-    public init(domain: String = defaultDomain) {
+    /// Registry hosts (optionally with a `:port`) that should be accessed
+    /// insecurely, i.e. over plain-text HTTP. Empty by default; entries must be
+    /// added explicitly to opt in to insecure access for a specific registry.
+    public let insecureRegistries: [String]
+
+    public init(domain: String = defaultDomain, insecureRegistries: [String] = []) {
         self.domain = domain
+        self.insecureRegistries = insecureRegistries
     }
 
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.domain = try container.decodeIfPresent(String.self, forKey: .domain) ?? Self.defaultDomain
+        self.insecureRegistries = try container.decodeIfPresent([String].self, forKey: .insecureRegistries) ?? []
+    }
+
+    /// Returns `true` if the given registry `host` has been explicitly marked
+    /// as insecure in the configuration. Matching is case-insensitive and
+    /// compares the host exactly as configured (host or `host:port`).
+    public func isInsecure(host: String) -> Bool {
+        let host = host.lowercased()
+        return insecureRegistries.contains { $0.lowercased() == host }
     }
 }

--- a/Sources/Services/ContainerAPIService/Client/ClientImage.swift
+++ b/Sources/Services/ContainerAPIService/Client/ClientImage.swift
@@ -267,7 +267,10 @@ extension ClientImage {
         request.set(key: .imageReference, value: reference)
         try request.set(platform: platform)
 
-        let insecure = try scheme.schemeFor(host: host, internalDnsDomain: containerSystemConfig.dns.domain) == .http
+        let insecure =
+            try scheme.schemeFor(
+                host: host, internalDnsDomain: containerSystemConfig.dns.domain,
+                insecureRegistries: containerSystemConfig.registry.insecureRegistries) == .http
         request.set(key: .insecureFlag, value: insecure)
         request.set(key: .maxConcurrentDownloads, value: Int64(maxConcurrentDownloads))
 
@@ -390,7 +393,10 @@ extension ClientImage {
         }
         request.set(key: .imageReference, value: reference)
 
-        let insecure = try scheme.schemeFor(host: host, internalDnsDomain: containerSystemConfig.dns.domain) == .http
+        let insecure =
+            try scheme.schemeFor(
+                host: host, internalDnsDomain: containerSystemConfig.dns.domain,
+                insecureRegistries: containerSystemConfig.registry.insecureRegistries) == .http
         request.set(key: .insecureFlag, value: insecure)
 
         try request.set(platform: platform)

--- a/Sources/Services/ContainerAPIService/Client/RequestScheme.swift
+++ b/Sources/Services/ContainerAPIService/Client/RequestScheme.swift
@@ -42,8 +42,12 @@ public enum RequestScheme: String, Sendable {
     /// Returns the prescribed protocol to use while making a HTTP request to a webserver
     /// - Parameter host: The domain or IP address of the webserver
     /// - Parameter internalDnsDomain: The DNS domain used for container name resolution
+    /// - Parameter insecureRegistries: Hosts explicitly configured for insecure
+    ///   (plain-text HTTP) access. When `self` is `.auto`, a matching host
+    ///   resolves to `.http`. An explicit `.http`/`.https` always takes
+    ///   precedence over this list.
     /// - Returns: RequestScheme
-    public func schemeFor(host: String, internalDnsDomain: String?) throws -> Self {
+    public func schemeFor(host: String, internalDnsDomain: String?, insecureRegistries: [String] = []) throws -> Self {
         guard host.count > 0 else {
             throw ContainerizationError(.invalidArgument, message: "host cannot be empty")
         }
@@ -51,8 +55,19 @@ public enum RequestScheme: String, Sendable {
         case .http, .https:
             return self
         case .auto:
-            return Self.isInternalHost(host: host, internalDnsDomain: internalDnsDomain) ? .http : .https
+            if Self.isInternalHost(host: host, internalDnsDomain: internalDnsDomain) || Self.isInsecureRegistry(host: host, insecureRegistries: insecureRegistries) {
+                return .http
+            }
+            return .https
         }
+    }
+
+    /// Returns `true` if `host` is present in the explicitly configured list of
+    /// insecure registries. Matching is case-insensitive and exact (host or
+    /// `host:port`, as configured).
+    public static func isInsecureRegistry(host: String, insecureRegistries: [String]) -> Bool {
+        let host = host.lowercased()
+        return insecureRegistries.contains { $0.lowercased() == host }
     }
 
     /// Checks if the given `host` string is a private IP address

--- a/Tests/ContainerAPIClientTests/RequestSchemeTests.swift
+++ b/Tests/ContainerAPIClientTests/RequestSchemeTests.swift
@@ -72,4 +72,44 @@ struct RequestSchemeTests {
         let hostName = "some-dns-name.io.\(Self.defaultDnsDomain)"
         #expect(RequestScheme.isInternalHost(host: hostName, internalDnsDomain: Self.defaultDnsDomain))
     }
+
+    @Test func testInsecureRegistryResolvesToHTTPForAuto() throws {
+        let insecure = ["my-registry.local", "registry.example.com:5000"]
+        // Exact host match -> http.
+        #expect(
+            try RequestScheme.auto.schemeFor(
+                host: "my-registry.local", internalDnsDomain: Self.defaultDnsDomain, insecureRegistries: insecure) == .http)
+        // host:port match -> http.
+        #expect(
+            try RequestScheme.auto.schemeFor(
+                host: "registry.example.com:5000", internalDnsDomain: Self.defaultDnsDomain, insecureRegistries: insecure) == .http)
+        // Case-insensitive match -> http.
+        #expect(
+            try RequestScheme.auto.schemeFor(
+                host: "My-Registry.Local", internalDnsDomain: Self.defaultDnsDomain, insecureRegistries: insecure) == .http)
+        // Non-matching host -> https.
+        #expect(
+            try RequestScheme.auto.schemeFor(
+                host: "other-registry.com", internalDnsDomain: Self.defaultDnsDomain, insecureRegistries: insecure) == .https)
+    }
+
+    @Test func testExplicitSchemeIgnoresInsecureRegistries() throws {
+        let insecure = ["my-registry.local"]
+        // Explicit https wins even if host is in the insecure list.
+        #expect(
+            try RequestScheme.https.schemeFor(
+                host: "my-registry.local", internalDnsDomain: Self.defaultDnsDomain, insecureRegistries: insecure) == .https)
+        // Explicit http stays http regardless of list.
+        #expect(
+            try RequestScheme.http.schemeFor(
+                host: "other.com", internalDnsDomain: Self.defaultDnsDomain, insecureRegistries: insecure) == .http)
+    }
+
+    @Test func testIsInsecureRegistry() throws {
+        let insecure = ["my-registry.local", "registry.example.com:5000"]
+        #expect(RequestScheme.isInsecureRegistry(host: "my-registry.local", insecureRegistries: insecure))
+        #expect(RequestScheme.isInsecureRegistry(host: "MY-REGISTRY.LOCAL", insecureRegistries: insecure))
+        #expect(!RequestScheme.isInsecureRegistry(host: "my-registry.local:5000", insecureRegistries: insecure))
+        #expect(!RequestScheme.isInsecureRegistry(host: "unknown.com", insecureRegistries: []))
+    }
 }

--- a/Tests/ContainerPersistenceTests/ConfigurationLoaderTests.swift
+++ b/Tests/ContainerPersistenceTests/ConfigurationLoaderTests.swift
@@ -370,6 +370,37 @@ struct ConfigurationLoaderTests {
         }
     }
 
+    @Test func insecureRegistriesDecodeAndMatch() async throws {
+        try await TemporaryStorage.withTempDir { tempDir in
+            let toml = """
+                [registry]
+                domain = "ghcr.io"
+                insecureRegistries = ["my-registry.local", "192.168.1.10:5000"]
+                """
+            let tmpFile = tempDir.appending("test.toml")
+            try Self.writeToml(toml, to: tmpFile)
+
+            let config: ContainerSystemConfig = try await ConfigurationLoader.load(configurationFiles: [tmpFile])
+            #expect(config.registry.domain == "ghcr.io")
+            #expect(config.registry.insecureRegistries == ["my-registry.local", "192.168.1.10:5000"])
+            #expect(config.registry.isInsecure(host: "my-registry.local"))
+            #expect(config.registry.isInsecure(host: "My-Registry.Local"))
+            #expect(config.registry.isInsecure(host: "192.168.1.10:5000"))
+            #expect(!config.registry.isInsecure(host: "other-registry.io"))
+        }
+    }
+
+    @Test func insecureRegistriesDefaultsToEmpty() async throws {
+        try await TemporaryStorage.withTempDir { tempDir in
+            let tmpFile = tempDir.appending("test.toml")
+            try Self.writeToml("[registry]\ndomain = \"docker.io\"\n", to: tmpFile)
+
+            let config: ContainerSystemConfig = try await ConfigurationLoader.load(configurationFiles: [tmpFile])
+            #expect(config.registry.insecureRegistries.isEmpty)
+            #expect(!config.registry.isInsecure(host: "docker.io"))
+        }
+    }
+
     @Test func layeredPrecedence() async throws {
         try await TemporaryStorage.withTempDir { tempDir in
             let userFile = tempDir.appending("user.toml")

--- a/docs/container-system-config.md
+++ b/docs/container-system-config.md
@@ -70,9 +70,18 @@ Default subnets used when creating networks without explicit `--subnet` / `--sub
 
 ## `[registry]`
 
-| Key      | Type     | Default      | Description                                                                                                  |
-|----------|----------|--------------|--------------------------------------------------------------------------------------------------------------|
-| `domain` | `String` | `"docker.io"` | Registry assumed when an image reference omits the registry host (e.g. `alpine` → `docker.io/library/alpine`). |
+| Key                   | Type       | Default       | Description                                                                                                  |
+|-----------------------|------------|---------------|--------------------------------------------------------------------------------------------------------------|
+| `domain`              | `String`   | `"docker.io"`  | Registry assumed when an image reference omits the registry host (e.g. `alpine` → `docker.io/library/alpine`). |
+| `insecureRegistries`  | `[String]` | `[]`           | Registry hosts (optionally `host:port`) accessed over plain-text HTTP instead of HTTPS. Matching is case-insensitive and exact. Only applies when the scheme is left at the default (`auto`); an explicit `--scheme https`/`--scheme http` always wins. **Disables transport security for the listed registries — only add hosts you trust.** |
+
+Example:
+
+```toml
+[registry]
+domain = "docker.io"
+insecureRegistries = ["my-registry.local", "192.168.1.10:5000"]
+```
 
 ## `[vminit]`
 


### PR DESCRIPTION
## Summary

Adds an `insecureRegistries` list to the `[registry]` section of the system
configuration. Hosts listed there are accessed over plain-text **HTTP** when the
request scheme is left at the default `auto`, without requiring `--scheme http`
on every `pull`/`push`/`login` command. This mirrors the "insecure registries"
capability in other container tooling and addresses #731.

Behavior:
- The list is **empty by default**, so insecure access is strictly opt-in per host.
- Matching is case-insensitive and exact on the registry `host[:port]`.
- An explicit `--scheme http` / `--scheme https` always takes precedence over the list.
- Wired into the pull path (`ClientImage`) and `registry login` (`RegistryLogin`).

Example `config.toml`:

```toml
[registry]
insecureRegistries = ["myregistry.example.com:5000"]
```

## Scope

This implements plain-HTTP access for listed registries. It does **not** change
TLS certificate verification for HTTPS registries (i.e. it is not a
"skip-cert-verification" toggle). Self-signed-HTTPS support could be a follow-up.

## Testing

- `make check` — formatting and license headers pass.
- Unit tests (`make test`): added `RequestSchemeTests` and `ConfigurationLoaderTests`
  coverage (31 tests) for host matching, case-insensitivity, `host:port` handling,
  explicit-scheme precedence, and TOML decode/default. All pass.
- End-to-end against a local plain-HTTP registry, referencing it by a non-private
  hostname so the new code path is actually exercised (private IPs/localhost are
  already treated as insecure):
  - Pull **without** `insecureRegistries` → fails (`auto` → HTTPS against an HTTP
    registry).
  - Pull **with** the host listed → succeeds over HTTP; image unpacks and appears
    in `image ls`.
  - Removing the config makes it fail again; `--scheme https` with the host listed
    still fails — confirming explicit scheme overrides the list.

## Docs

Updated `docs/container-system-config.md` with the new field and a security note.

Fixes #731
