### PR TITLE
Expose container ID to guest workloads via CONTAINER_ID env var

### DIFF
--- a/Sources/ContainerResource/Container/ProcessConfiguration.swift
+++ b/Sources/ContainerResource/Container/ProcessConfiguration.swift
@@ -70,6 +70,22 @@ public struct ProcessConfiguration: Sendable, Codable {
         }
     }
 
+    /// The environment variable used to expose the container ID to the guest workload.
+    public static let containerIDEnvVar = "CONTAINER_ID"
+
+    /// Returns `environment` with the container ID exposed via `CONTAINER_ID`.
+    ///
+    /// This lets tools running inside the guest recover the authoritative
+    /// container ID regardless of how the hostname is configured. If the
+    /// environment already defines `CONTAINER_ID`, it is left untouched so that
+    /// a user-supplied value takes precedence.
+    public static func environmentExposingContainerID(_ environment: [String], id: String) -> [String] {
+        guard !environment.contains(where: { $0.hasPrefix("\(containerIDEnvVar)=") }) else {
+            return environment
+        }
+        return environment + ["\(containerIDEnvVar)=\(id)"]
+    }
+
     public init(
         executable: String,
         arguments: [String],

--- a/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
+++ b/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
@@ -1073,7 +1073,9 @@ public actor RuntimeService {
         let process = config.initProcess
 
         czConfig.process.arguments = [process.executable] + process.arguments
-        czConfig.process.environmentVariables = process.environment
+        // Expose the container ID to the workload so tools running inside the
+        // guest can recover the authoritative ID regardless of the hostname.
+        czConfig.process.environmentVariables = ProcessConfiguration.environmentExposingContainerID(process.environment, id: config.id)
 
         if config.ssh {
             if !czConfig.process.environmentVariables.contains(where: { $0.starts(with: "\(Self.sshAuthSocketEnvVar)=") }) {
@@ -1123,7 +1125,9 @@ public actor RuntimeService {
         proc.stderr = stdio[2]
 
         proc.arguments = [config.executable] + config.arguments
-        proc.environmentVariables = config.environment
+        // Expose the container ID to the workload so tools running inside the
+        // guest can recover the authoritative ID regardless of the hostname.
+        proc.environmentVariables = ProcessConfiguration.environmentExposingContainerID(config.environment, id: containerConfig.id)
 
         if containerConfig.ssh {
             if !proc.environmentVariables.contains(where: { $0.starts(with: "\(Self.sshAuthSocketEnvVar)=") }) {

--- a/Tests/ContainerResourceTests/ProcessConfigurationTests.swift
+++ b/Tests/ContainerResourceTests/ProcessConfigurationTests.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import ContainerResource
+
+struct ProcessConfigurationContainerIDTests {
+    @Test func exposesContainerIDWhenAbsent() throws {
+        let result = ProcessConfiguration.environmentExposingContainerID(
+            ["PATH=/usr/bin"],
+            id: "my-container"
+        )
+        #expect(result.contains("CONTAINER_ID=my-container"))
+        #expect(result.contains("PATH=/usr/bin"))
+    }
+
+    @Test func preservesUserSuppliedContainerID() throws {
+        let result = ProcessConfiguration.environmentExposingContainerID(
+            ["CONTAINER_ID=override"],
+            id: "my-container"
+        )
+        #expect(result == ["CONTAINER_ID=override"])
+    }
+
+    @Test func addsContainerIDToEmptyEnvironment() throws {
+        let result = ProcessConfiguration.environmentExposingContainerID([], id: "abc-123")
+        #expect(result == ["CONTAINER_ID=abc-123"])
+    }
+}


### PR DESCRIPTION
## Summary

Exposes the container's ID to workloads running inside the guest by injecting a
`CONTAINER_ID` environment variable into both the init process and `exec`ed
processes. This gives in-guest tooling a stable, authoritative identifier that is
independent of the hostname or `--name`. A user-supplied `CONTAINER_ID` is
preserved and never overwritten.

## Testing

- `make check` passes (formatting + license headers).
- Unit tests: `ProcessConfigurationContainerIDTests` (3 tests) cover injection
  when absent, preservation of a user-supplied value, and an empty starting
  environment. All pass.
- Manual: `container run --rm --name myhost alpine printenv CONTAINER_ID` prints
  the ID even though `--name` set the hostname; `-e CONTAINER_ID=custom` prints
  `custom`.

Fixes #1430
