### PR TITLE
Log expected route-handler not-found at debug instead of error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -473,6 +473,13 @@ let package = Package(
                 "CAuditToken",
             ]
         ),
+        .testTarget(
+            name: "ContainerXPCTests",
+            dependencies: [
+                "ContainerXPC",
+                .product(name: "Logging", package: "swift-log"),
+            ]
+        ),
         .target(
             name: "ContainerOS",
             dependencies: [

--- a/Sources/ContainerXPC/XPCServer.swift
+++ b/Sources/ContainerXPC/XPCServer.swift
@@ -14,6 +14,9 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerizationError
+import Logging
+
 #if os(macOS)
 import CAuditToken
 import ContainerizationError
@@ -208,7 +211,13 @@ public struct XPCServer: Sendable {
                 let response = try await handler(message, session)
                 xpc_connection_send_message(connection, response.underlying)
             } catch let error as ContainerizationError {
-                log.error(
+                // A `notFound` result is an expected, recoverable outcome for many
+                // routes (for example, looking up an image snapshot before it has
+                // been unpacked). Log it at debug level so it does not surface as a
+                // misleading error, while still replying with the error so the
+                // client can act on it.
+                log.log(
+                    level: error.routeHandlerLogLevel,
                     "route handler threw an error",
                     metadata: [
                         "route": "\(route)",
@@ -286,3 +295,15 @@ extension xpc_object_t {
 }
 
 #endif
+
+extension ContainerizationError {
+    /// The log level to use when a route handler surfaces this error.
+    ///
+    /// A `notFound` error is an expected, recoverable outcome for many routes
+    /// (for example, looking up an image snapshot before it has been unpacked),
+    /// so it is logged at `debug` to avoid emitting misleading errors. All other
+    /// failures are logged at `error`.
+    var routeHandlerLogLevel: Logging.Logger.Level {
+        self.code == .notFound ? .debug : .error
+    }
+}

--- a/Tests/ContainerXPCTests/RouteHandlerLogLevelTests.swift
+++ b/Tests/ContainerXPCTests/RouteHandlerLogLevelTests.swift
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerizationError
+import Logging
+import Testing
+
+@testable import ContainerXPC
+
+struct RouteHandlerLogLevelTests {
+    @Test func notFoundIsLoggedAtDebug() {
+        // A missing image snapshot is an expected, recoverable outcome and must
+        // not be surfaced as an error in the logs (see issue #589).
+        let error = ContainerizationError(
+            .notFound,
+            message: "image snapshot for docker.io/library/ubuntu:24.04 with platform linux/amd64"
+        )
+        #expect(error.routeHandlerLogLevel == .debug)
+    }
+
+    @Test func otherErrorsAreLoggedAtError() {
+        for code in [
+            ContainerizationError.Code.invalidArgument,
+            .invalidState,
+            .internalError,
+            .unknown,
+        ] {
+            let error = ContainerizationError(code, message: "boom")
+            #expect(error.routeHandlerLogLevel == .error)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Logs an expected `notFound` result from an XPC route handler at `debug` instead
of `error`. Looking up a resource that does not yet exist (for example, a
snapshot before it has been unpacked) is a normal, recoverable outcome, but it
was being logged as `handler for snapshotGet threw error notFound`, which is
misleading. The error is still returned to the client unchanged; only the
server-side log level is lowered. All other error codes continue to log at
`error`.

## Testing

- `make check` passes (formatting + license headers).
- Unit tests: new `RouteHandlerLogLevelTests` (2 tests, in a new `ContainerXPCTests`
  target) assert `notFound` maps to `debug` and other codes map to `error`. All pass.

Fixes #589
