### PR TITLE
Add `container image import` to create an image from a rootfs tarball

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -212,6 +212,15 @@ let package = Package(
                 "ContainerRuntimeClient",
             ]
         ),
+        .testTarget(
+            name: "ContainerImagesServiceTests",
+            dependencies: [
+                .product(name: "Containerization", package: "containerization"),
+                .product(name: "ContainerizationArchive", package: "containerization"),
+                .product(name: "ContainerizationOCI", package: "containerization"),
+                "ContainerImagesService",
+            ]
+        ),
         .target(
             name: "ContainerAPIClient",
             dependencies: [

--- a/Sources/ContainerCommands/Image/ImageCommand.swift
+++ b/Sources/ContainerCommands/Image/ImageCommand.swift
@@ -26,6 +26,7 @@ extension Application {
             abstract: "Manage images",
             subcommands: [
                 ImageDelete.self,
+                ImageImport.self,
                 ImageInspect.self,
                 ImageList.self,
                 ImageLoad.self,

--- a/Sources/ContainerCommands/Image/ImageImport.swift
+++ b/Sources/ContainerCommands/Image/ImageImport.swift
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025-2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ContainerAPIClient
+import ContainerPersistence
+import ContainerizationError
+import ContainerizationOS
+import Foundation
+import SystemPackage
+
+extension Application {
+    public struct ImageImport: AsyncLoggableCommand {
+        public init() {}
+        public static let configuration = CommandConfiguration(
+            commandName: "import",
+            abstract: "Create an image from a root filesystem tarball"
+        )
+
+        @Argument(help: "Path to the root filesystem tar archive (supports .tar and compressed .tar.gz)", completion: .file())
+        var tarball: String
+
+        @Argument(help: "The reference to assign to the imported image (format: image-name[:tag])")
+        var reference: String
+
+        @Option(help: "Set the OS for the imported image")
+        var os: String = "linux"
+
+        @Option(help: "Set the architecture for the imported image")
+        var arch: String = Arch.hostArchitecture().rawValue
+
+        @Option(
+            help: "Set the platform for the imported image (format: os/arch[/variant], takes precedence over --os and --arch) [environment: CONTAINER_DEFAULT_PLATFORM]"
+        )
+        var platform: String?
+
+        @OptionGroup
+        public var logOptions: Flags.Logging
+
+        public func run() async throws {
+            let tarballPath = FilePathOps.absolutePath(FilePath(tarball))
+            guard FileManager.default.fileExists(atPath: tarballPath.string) else {
+                throw ContainerizationError(.notFound, message: "tarball does not exist at path \(tarballPath)")
+            }
+
+            let containerSystemConfig: ContainerSystemConfig = try await Application.loadContainerSystemConfig()
+            let p = try DefaultPlatform.resolveWithDefaults(platform: platform, os: os, arch: arch, log: log)
+
+            let image = try await ClientImage.`import`(
+                from: tarballPath.string,
+                reference: reference,
+                platform: p,
+                containerSystemConfig: containerSystemConfig
+            )
+            print(image.reference)
+        }
+    }
+}

--- a/Sources/Plugins/CoreImages/ImagesHelper.swift
+++ b/Sources/Plugins/CoreImages/ImagesHelper.swift
@@ -113,6 +113,7 @@ extension ImagesHelper {
             routes[ImagesServiceXPCRoute.imagePush.rawValue] = XPCServer.route(harness.push)
             routes[ImagesServiceXPCRoute.imageSave.rawValue] = XPCServer.route(harness.save)
             routes[ImagesServiceXPCRoute.imageLoad.rawValue] = XPCServer.route(harness.load)
+            routes[ImagesServiceXPCRoute.imageImport.rawValue] = XPCServer.route(harness.importImage)
             routes[ImagesServiceXPCRoute.imageUnpack.rawValue] = XPCServer.route(harness.unpack)
             routes[ImagesServiceXPCRoute.imageCleanupOrphanedBlobs.rawValue] = XPCServer.route(harness.cleanUpOrphanedBlobs)
             routes[ImagesServiceXPCRoute.imageDiskUsage.rawValue] = XPCServer.route(harness.calculateDiskUsage)

--- a/Sources/Services/ContainerAPIService/Client/ClientImage.swift
+++ b/Sources/Services/ContainerAPIService/Client/ClientImage.swift
@@ -322,6 +322,18 @@ extension ClientImage {
         return ImageLoadResult(images: images, rejectedMembers: rejectedMembers)
     }
 
+    public static func `import`(from tarFile: String, reference: String, platform: Platform, containerSystemConfig: ContainerSystemConfig) async throws -> ClientImage {
+        let reference = try self.normalizeReference(reference, containerSystemConfig: containerSystemConfig)
+        let client = newXPCClient()
+        let request = newRequest(.imageImport)
+        request.set(key: .filePath, value: tarFile)
+        request.set(key: .imageReference, value: reference)
+        try request.set(platform: platform)
+        let reply = try await client.send(request)
+        let description = try reply.imageDescription()
+        return ClientImage(description: description)
+    }
+
     public static func cleanUpOrphanedBlobs() async throws -> ([String], UInt64) {
         let client = newXPCClient()
         let request = newRequest(.imageCleanupOrphanedBlobs)

--- a/Sources/Services/ContainerImagesService/Client/ImageServiceXPCRoutes.swift
+++ b/Sources/Services/ContainerImagesService/Client/ImageServiceXPCRoutes.swift
@@ -27,6 +27,7 @@ public enum ImagesServiceXPCRoute: String {
     case imageDelete
     case imageSave
     case imageLoad
+    case imageImport
     case imageCleanupOrphanedBlobs
     case imageDiskUsage
 

--- a/Sources/Services/ContainerImagesService/Server/ImageImporter.swift
+++ b/Sources/Services/ContainerImagesService/Server/ImageImporter.swift
@@ -1,0 +1,169 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025-2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Containerization
+import ContainerizationArchive
+import ContainerizationError
+import ContainerizationExtras
+import ContainerizationOCI
+import Foundation
+
+/// Builds a single-layer OCI image from a root filesystem tarball, analogous to `docker import`.
+///
+/// The input archive (a plain `.tar` or a compressed `.tar.gz`/`.tar.zst`/... archive) is treated
+/// as the contents of a single image layer. The archive is normalized into a canonical, uncompressed
+/// tar (to compute the layer's `diffID`) and a gzip-compressed tar (the layer blob). A minimal image
+/// config, manifest, and index are synthesized and written to the content store, after which the
+/// image is registered in the image store under the supplied reference.
+public enum ImageImporter {
+    /// Build and register a single-layer image from a filesystem tarball.
+    ///
+    /// - Parameters:
+    ///   - tarball: Path to the rootfs archive (`.tar` or a compressed tar archive).
+    ///   - reference: The fully normalized reference under which to register the new image.
+    ///   - platform: The platform to associate with the image. Defaults to the current host platform.
+    ///   - contentStore: The content store into which the image blobs are written.
+    ///   - imageStore: The image store into which the image reference is registered.
+    /// - Returns: The `Image.Description` of the newly created image.
+    @discardableResult
+    public static func `import`(
+        tarball: URL,
+        reference: String,
+        platform: Platform,
+        contentStore: ContentStore,
+        imageStore: ImageStore
+    ) async throws -> Containerization.Image.Description {
+        guard FileManager.default.fileExists(atPath: tarball.path) else {
+            throw ContainerizationError(.notFound, message: "tarball does not exist at path \(tarball.path)")
+        }
+
+        // Validate the reference up front so that we fail before touching the content store.
+        _ = try Reference.parse(reference)
+
+        // Extract the (possibly compressed) input archive into a scratch directory. ArchiveReader
+        // auto-detects the compression filter, so this handles both `.tar` and `.tar.gz` inputs.
+        let extractDir = FileManager.default.uniqueTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: extractDir) }
+        let reader = try ArchiveReader(file: tarball)
+        let rejected = try reader.extractContents(to: extractDir)
+        guard rejected.isEmpty else {
+            throw ContainerizationError(.invalidArgument, message: "tarball contains invalid members: \(rejected)")
+        }
+
+        let (id, ingestDir) = try await contentStore.newIngestSession()
+        let description: Containerization.Image.Description
+        do {
+            description = try Self.buildImage(
+                rootfs: extractDir,
+                reference: reference,
+                platform: platform,
+                ingestDir: ingestDir
+            )
+            _ = try await contentStore.completeIngestSession(id)
+        } catch {
+            try? await contentStore.cancelIngestSession(id)
+            throw error
+        }
+        let image = try await imageStore.create(description: description)
+        return image.description
+    }
+
+    /// Build the OCI blobs (layer, config, manifest, index) for a single-layer image from an
+    /// extracted root filesystem directory, writing them into `ingestDir`.
+    ///
+    /// This is the pure, side-effect-light core of the import operation: it only writes blobs into
+    /// the supplied directory and returns the resulting `Image.Description`. It does not register the
+    /// image or complete any ingest session, which makes it convenient to exercise in tests.
+    static func buildImage(
+        rootfs: URL,
+        reference: String,
+        platform: Platform,
+        ingestDir: URL,
+        created: String = ISO8601DateFormatter().string(from: Date())
+    ) throws -> Containerization.Image.Description {
+        let writer = try ContentWriter(for: ingestDir)
+
+        // 1. Canonical uncompressed tar to compute the diffID (sha256 of the uncompressed layer).
+        let scratch = FileManager.default.uniqueTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+
+        let plainTar = scratch.appendingPathComponent("layer.tar")
+        let plainWriter = try ArchiveWriter(format: .pax, filter: .none, file: plainTar)
+        try plainWriter.archiveDirectory(rootfs)
+        try plainWriter.finishEncoding()
+        let diffID = try Self.digestString(of: plainTar)
+
+        // 2. Gzip-compressed tar: this is the layer blob stored in the content store.
+        let gzipTar = scratch.appendingPathComponent("layer.tar.gz")
+        let gzipWriter = try ArchiveWriter(format: .pax, filter: .gzip, file: gzipTar)
+        try gzipWriter.archiveDirectory(rootfs)
+        try gzipWriter.finishEncoding()
+        let layerResult = try writer.create(from: gzipTar)
+        let layerDescriptor = Descriptor(
+            mediaType: MediaTypes.imageLayerGzip,
+            digest: layerResult.digest.digestString,
+            size: layerResult.size
+        )
+
+        // 3. Image config referencing the layer's diffID.
+        let config = ContainerizationOCI.Image(
+            created: created,
+            architecture: platform.architecture,
+            os: platform.os,
+            variant: platform.variant,
+            rootfs: Rootfs(type: "layers", diffIDs: [diffID]),
+            history: [
+                History(created: created, createdBy: "container image import", comment: "imported from tarball", emptyLayer: false)
+            ]
+        )
+        let configResult = try writer.create(from: config)
+        let configDescriptor = Descriptor(
+            mediaType: MediaTypes.imageConfig,
+            digest: configResult.digest.digestString,
+            size: configResult.size
+        )
+
+        // 4. Manifest tying the config and layer together.
+        let manifest = Manifest(config: configDescriptor, layers: [layerDescriptor])
+        let manifestResult = try writer.create(from: manifest)
+        let manifestDescriptor = Descriptor(
+            mediaType: MediaTypes.imageManifest,
+            digest: manifestResult.digest.digestString,
+            size: manifestResult.size,
+            platform: platform
+        )
+
+        // 5. Index referencing the manifest. This is the top-level descriptor for the image.
+        let index = Index(manifests: [manifestDescriptor])
+        let indexResult = try writer.create(from: index)
+        let indexDescriptor = Descriptor(
+            mediaType: MediaTypes.index,
+            digest: indexResult.digest.digestString,
+            size: indexResult.size
+        )
+
+        return Containerization.Image.Description(reference: reference, descriptor: indexDescriptor)
+    }
+
+    /// Compute the `sha256:<hex>` digest of a file by streaming it through a throwaway content writer.
+    private static func digestString(of file: URL) throws -> String {
+        let scratch = FileManager.default.uniqueTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let writer = try ContentWriter(for: scratch)
+        let result = try writer.create(from: file)
+        return result.digest.digestString
+    }
+}

--- a/Sources/Services/ContainerImagesService/Server/ImagesService.swift
+++ b/Sources/Services/ContainerImagesService/Server/ImagesService.swift
@@ -251,6 +251,36 @@ public actor ImagesService {
         return (images, rejectedMembers)
     }
 
+    public func `import`(from tarFile: URL, reference: String, platform: Platform) async throws -> ImageDescription {
+        self.log.debug(
+            "ImagesService: enter",
+            metadata: [
+                "func": "\(#function)",
+                "tarFile": "\(tarFile.path)",
+                "reference": "\(reference)",
+                "platform": "\(platform.description)",
+            ]
+        )
+        defer {
+            self.log.debug(
+                "ImagesService: exit",
+                metadata: [
+                    "func": "\(#function)",
+                    "reference": "\(reference)",
+                ]
+            )
+        }
+
+        let description = try await ImageImporter.`import`(
+            tarball: tarFile,
+            reference: reference,
+            platform: platform,
+            contentStore: self.contentStore,
+            imageStore: self.imageStore
+        )
+        return description.fromCZ
+    }
+
     public func cleanUpOrphanedBlobs() async throws -> ([String], UInt64) {
         self.log.debug(
             "ImagesService: enter",

--- a/Sources/Services/ContainerImagesService/Server/ImagesServiceHarness.swift
+++ b/Sources/Services/ContainerImagesService/Server/ImagesServiceHarness.swift
@@ -182,6 +182,37 @@ public struct ImagesServiceHarness: Sendable {
     }
 
     @Sendable
+    public func importImage(_ message: XPCMessage) async throws -> XPCMessage {
+        let input = message.string(key: .filePath)
+        guard let input else {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "missing input file path"
+            )
+        }
+        let reference = message.string(key: .imageReference)
+        guard let reference else {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "missing image reference"
+            )
+        }
+        guard let platformData = message.dataNoCopy(key: .ociPlatform) else {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "missing OCI platform"
+            )
+        }
+        let platform = try JSONDecoder().decode(ContainerizationOCI.Platform.self, from: platformData)
+
+        let description = try await service.`import`(from: URL(filePath: input), reference: reference, platform: platform)
+        let reply = message.reply()
+        let descData = try JSONEncoder().encode(description)
+        reply.set(key: .imageDescription, value: descData)
+        return reply
+    }
+
+    @Sendable
     public func cleanUpOrphanedBlobs(_ message: XPCMessage) async throws -> XPCMessage {
         let (deleted, size) = try await service.cleanUpOrphanedBlobs()
         let reply = message.reply()

--- a/Tests/ContainerImagesServiceTests/ImageImporterTests.swift
+++ b/Tests/ContainerImagesServiceTests/ImageImporterTests.swift
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025-2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Containerization
+import ContainerizationArchive
+import ContainerizationOCI
+import Foundation
+import Testing
+
+@testable import ContainerImagesService
+
+struct ImageImporterTests {
+    /// Build a single-layer image from a rootfs directory and verify that the synthesized index,
+    /// manifest, and config blobs are well-formed and reference one another correctly.
+    @Test
+    func testBuildImageProducesSingleLayerImage() throws {
+        let fm = FileManager.default
+
+        // Create a small root filesystem to import.
+        let rootfs = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: rootfs, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: rootfs) }
+        try "hello from imported rootfs\n".write(to: rootfs.appendingPathComponent("hello.txt"), atomically: true, encoding: .utf8)
+
+        // Ingest directory where the OCI blobs will be written.
+        let ingestDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: ingestDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: ingestDir) }
+
+        let platform = Platform(arch: "arm64", os: "linux")
+        let description = try ImageImporter.buildImage(
+            rootfs: rootfs,
+            reference: "example.com/imported:latest",
+            platform: platform,
+            ingestDir: ingestDir
+        )
+
+        // The top-level descriptor must be an OCI index.
+        #expect(description.reference == "example.com/imported:latest")
+        #expect(description.descriptor.mediaType == MediaTypes.index)
+
+        // Decode the index and follow it down to the manifest.
+        let index: Index = try LocalContent(path: blobURL(ingestDir, description.descriptor.digest)).decode()
+        #expect(index.manifests.count == 1)
+        let manifestDescriptor = index.manifests[0]
+        #expect(manifestDescriptor.mediaType == MediaTypes.imageManifest)
+        #expect(manifestDescriptor.platform?.architecture == "arm64")
+        #expect(manifestDescriptor.platform?.os == "linux")
+
+        let manifest: Manifest = try LocalContent(path: blobURL(ingestDir, manifestDescriptor.digest)).decode()
+        #expect(manifest.config.mediaType == MediaTypes.imageConfig)
+        #expect(manifest.layers.count == 1)
+        #expect(manifest.layers[0].mediaType == MediaTypes.imageLayerGzip)
+        #expect(manifest.layers[0].size > 0)
+
+        // The config must declare exactly one diffID matching the single layer, and carry platform info.
+        let config: ContainerizationOCI.Image = try LocalContent(path: blobURL(ingestDir, manifest.config.digest)).decode()
+        #expect(config.architecture == "arm64")
+        #expect(config.os == "linux")
+        #expect(config.rootfs.type == "layers")
+        #expect(config.rootfs.diffIDs.count == 1)
+        #expect(config.rootfs.diffIDs[0].hasPrefix("sha256:"))
+
+        // Every referenced blob must actually exist in the ingest directory.
+        for digest in [description.descriptor.digest, manifestDescriptor.digest, manifest.config.digest, manifest.layers[0].digest] {
+            #expect(fm.fileExists(atPath: blobURL(ingestDir, digest).path))
+        }
+    }
+
+    private func blobURL(_ ingestDir: URL, _ digest: String) -> URL {
+        ingestDir.appendingPathComponent(digest.trimmingDigestPrefix)
+    }
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -627,6 +627,27 @@ container image load --input <input> [--force] [--debug]
 *   `-i, --input <input>`: Path to the image tar archive
 *   `-f, --force`: Load images even if invalid member files are detected
 
+### `container image import`
+
+Creates an image from a root filesystem tarball, analogous to `docker import`. The archive may be a plain `.tar` or a compressed `.tar.gz` (and other tar compression formats). Its contents become a single image layer.
+
+**Usage**
+
+```bash
+container image import [--os <os>] [--arch <arch>] [--platform <platform>] [--debug] <tarball> <reference>
+```
+
+**Arguments**
+
+*   `<tarball>`: Path to the root filesystem tar archive
+*   `<reference>`: The reference to assign to the imported image (format: image-name[:tag])
+
+**Options**
+
+*   `--os <os>`: OS for the imported image (default `linux`)
+*   `--arch <arch>`: Architecture for the imported image (default: host architecture)
+*   `--platform <platform>`: Platform for the imported image (format: os/arch[/variant], takes precedence over --os and --arch)
+
 ### `container image tag`
 
 Applies a new tag to an existing image. The original image reference remains unchanged.


### PR DESCRIPTION
## Summary

Adds `container image import <tarball> <reference>` — the analog of
`docker import` — which builds a single-layer OCI image from a root filesystem
tarball (`.tar` or `.tar.gz`, compression auto-detected). The resulting image is
tagged with the given reference and can be run like any other image.

## Testing

- `make check` passes (formatting + license headers).
- Unit tests: new `ImageImporterTests` verify that the importer produces a
  well-formed index -> manifest -> config -> single layer with a `sha256:` diffID.
  Passes.
- Manual: `tar -cf rootfs.tar -C rootfs .` then
  `container image import rootfs.tar myimg:latest`; the image appears in
  `container image ls` and `container run --rm myimg:latest cat /hello.txt`
  prints the expected file contents.

Fixes #426
