### PR TITLE
Fix CLITest when run in xcode

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -93,6 +93,7 @@ let package = Package(
                 "ContainerLog",
                 "ContainerPersistence",
                 "ContainerResource",
+                "MachineAPIClient",
                 "Yams",
             ],
             path: "Tests/CLITests"


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

 Running a single test from `TestCLIMachine` in xcode errors out because:

Warning:
```
'CLITests' is missing a dependency on 'MachineAPIClient' because dependency scan of Swift module 'CLITests' discovered a dependency on 'MachineAPIClient'
```

Error:
```
/Volumes/src/apple/container/Package.swift:1:1 Undefined symbol: MachineAPIClient.MachineConfiguration.containerUUIDLength.unsafeMutableAddressor : Swift.Int
```

This change fixes the errors.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

Test plan:

I clicked the run button left of `func testCreate` in `TestCLIMachine`, xcode built the project and run the test successfully.