### PR TITLE
Log graceful-stop errors instead of silently swallowing them

### DIFF
--- a/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
+++ b/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
@@ -1242,7 +1242,12 @@ public actor RuntimeService {
 
                 return code
             }
-        } catch {}
+        } catch {
+            // The graceful stop (signal + timeout + kill) failed; we still
+            // power off the vm below, but log the error instead of silently
+            // swallowing it so failures are observable.
+            self.log.error("failed to gracefully stop container", metadata: ["error": "\(error)"])
+        }
 
         // Now actually bring down the vm.
         try await lc.stop()


### PR DESCRIPTION
## Summary

`gracefulStopContainer` wrapped its signal/timeout/kill logic in an empty `catch {}`, silently discarding any failure that occurred while attempting a graceful stop (for example, failing to obtain the container's exit code). The vm is still powered off on the next line, so the error is not fatal — but the swallowed error left graceful-stop failures with no trace in the logs, making them impossible to diagnose.

Fixes #1756.

## Change

Replace the empty `catch {}` in `Sources/Services/RuntimeLinux/Server/RuntimeService.swift` with an error log, matching the error logging already used by `cleanUpContainer` in the same file:

```swift
} catch {
    self.log.error("failed to gracefully stop container", metadata: ["error": "\(error)"])
}
```

Control flow is otherwise unchanged: the caught error remains non-fatal and the vm is still powered off. The only behavioral change is that the error is now observable.

## Verification

- `swift build --target ContainerRuntimeLinuxServer` — builds clean (`RuntimeService.swift` compiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)