### PR TITLE
Log the graceful-stop error instead of silently discarding it in gracefulStopContainer

### DIFF
--- a/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
+++ b/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
@@ -1242,7 +1242,9 @@ public actor RuntimeService {
 
                 return code
             }
-        } catch {}
+        } catch {
+            self.log.error("graceful stop failed; forcing vm shutdown", metadata: ["error": "\(error)"])
+        }
 
         // Now actually bring down the vm.
         try await lc.stop()


### PR DESCRIPTION
Closes #1756.

`RuntimeService.gracefulStopContainer(_:signal:timeout:)` wraps the graceful-stop attempt in `do { … } catch {}` — an empty catch that silently discards any thrown error before falling through to the unconditional `lc.stop()`. It is the only catch in this file that does not log; every other one uses `self.log.error(…, metadata: ["error": "\(error)"])`.

This adds a single log line matching that convention, so a failed graceful stop (and the resulting fall-through to a forced VM shutdown) is diagnosable. The intentional fall-through to `lc.stop()` is unchanged.
