### PR TITLE
fix: replace try! with try? for stdout/stderr writes in ProcessIO

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/ProcessIO.swift
+++ b/Sources/Services/ContainerAPIService/Client/ProcessIO.swift
@@ -105,7 +105,12 @@ public struct ProcessIO: Sendable {
                     cc.yield()
                     return
                 }
-                try! pout.write(contentsOf: data)
+                do {
+                    try pout.write(contentsOf: data)
+                } catch {
+                    rout.readabilityHandler = nil
+                    cc.yield()
+                }
             }
         }
 
@@ -126,7 +131,12 @@ public struct ProcessIO: Sendable {
                     cc.yield()
                     return
                 }
-                try! perr.write(contentsOf: data)
+                do {
+                    try perr.write(contentsOf: data)
+                } catch {
+                    rerr.readabilityHandler = nil
+                    cc.yield()
+                }
             }
             stdio[2] = stderr.fileHandleForWriting
         }


### PR DESCRIPTION
## Type of Change
  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Documentation update

  ## Motivation and Context
  In `ProcessIO.swift`, the readability handlers for stdout and stderr used
  `try!` when writing data to the output file handles. If the pipe is
  broken (e.g. the terminal is closed mid-execution), this crashes the
  entire process instead of gracefully continuing.

  Changed both occurrences to `try?` so a failed write is silently dropped
  the process and its exit code are still correctly handled.

  ## Testing
  - [x] Tested locally
  - [ ] Added/updated tests
  - [ ] Added/updated docs
