### PR TITLE
fix: propagate error from createDirectory in system start

### DIFF
--- a/Sources/ContainerCommands/System/SystemStart.swift
+++ b/Sources/ContainerCommands/System/SystemStart.swift
@@ -104,7 +104,7 @@ extension Application {
 
             let apiServerDataPath = appRoot.appending(FilePath.Component("apiserver"))
             let apiServerDataURL = URL(fileURLWithPath: apiServerDataPath.string)
-            try! FileManager.default.createDirectory(at: apiServerDataURL, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(at: apiServerDataURL, withIntermediateDirectories: true)
 
             var env = PluginLoader.filterEnvironment()
             env[ApplicationRoot.environmentName] = appRoot.string


### PR DESCRIPTION
## Type of Change
  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Documentation update

  ## Motivation and Context
  `SystemStart` used `try!` when creating the apiserver data directory.
  File system operations can fail for legitimate reasons insufficient
  permissions, disk full, read-only volume and crashing the process
  in those cases gives the user no actionable error message.

  Replaced with `try` so the error propagates up and is surfaced cleanly.

  ## Testing
  - [x] Tested locally
  - [ ] Added/updated tests
  - [ ] Added/updated docs