### PR TITLE
fix: use safe fallback instead of force-unwrapping FileManager.urls result

### DIFF
--- a/Sources/ContainerPersistence/PathUtils.swift
+++ b/Sources/ContainerPersistence/PathUtils.swift
@@ -38,11 +38,9 @@ public enum PathUtils {
                 if let envPath = env["CONTAINER_APP_ROOT"], !envPath.isEmpty {
                     return FilePath(envPath)
                 }
-                let appSupportURL = FileManager.default.urls(
-                    for: .applicationSupportDirectory,
-                    in: .userDomainMask
-                ).first!.appendingPathComponent("com.apple.container")
-                return FilePath(appSupportURL.path(percentEncoded: false))
+                let urls = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+                let base = urls.first?.path(percentEncoded: false) ?? NSHomeDirectory() + "/Library/Application Support"
+                return FilePath(base).appending("com.apple.container")
             case .installRoot:
                 if let envPath = env["CONTAINER_INSTALL_ROOT"], !envPath.isEmpty {
                     return FilePath(envPath)

--- a/Sources/ContainerPlugin/ApplicationRoot.swift
+++ b/Sources/ContainerPlugin/ApplicationRoot.swift
@@ -25,13 +25,11 @@ public struct ApplicationRoot {
 
     /// The default root directory used when ``environmentName`` is not set:
     /// `~/Library/Application Support/com.apple.container`.
-    public static let defaultPath = FilePath(
-        FileManager.default.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        ).first!.path(percentEncoded: false)
-    )
-    .appending(FilePath.Component("com.apple.container"))
+    public static let defaultPath: FilePath = {
+        let urls = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+        let base = urls.first?.path(percentEncoded: false) ?? NSHomeDirectory() + "/Library/Application Support"
+        return FilePath(base).appending(FilePath.Component("com.apple.container"))
+    }()
 
     /// The resolved root directory path, always lexically normalized.
     ///


### PR DESCRIPTION
## Type of Change
  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Documentation update

  ## Motivation and Context
  Both `ApplicationRoot.defaultPath` and `PathUtils.BaseConfigPath.appRoot`
  called `FileManager.urls(for:in:).first!` to resolve the Application
  Support directory. While uncommon, this array can be empty (e.g. in
  sandboxed or restricted environments), causing an immediate crash at
  static initialization time before any user-facing error handling runs.

  Replaced the force-unwrap with optional chaining and a hardcoded fallback
  to `~/Library/Application Support`  the same path the system would
  return under normal conditions.

  ## Testing
  - [x] Tested locally
  - [ ] Added/updated tests
  - [ ] Added/updated docs