### PR TITLE
feat: add configurable default DNS settings

### DIFF
--- a/Sources/ContainerCommands/Builder/BuilderStart.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStart.swift
@@ -114,6 +114,17 @@ extension Application {
 
             let builderPlatform = ContainerizationOCI.Platform(arch: "arm64", os: "linux", variant: "v8")
 
+            let resolvedDnsNameservers = !dnsNameservers.isEmpty
+                ? dnsNameservers
+                : containerSystemConfig.dns.nameservers
+            let resolvedDnsDomain = dnsDomain ?? containerSystemConfig.dns.domain
+            let resolvedDnsSearchDomains = !dnsSearchDomains.isEmpty
+                ? dnsSearchDomains
+                : containerSystemConfig.dns.searchDomains
+            let resolvedDnsOptions = !dnsOptions.isEmpty
+                ? dnsOptions
+                : containerSystemConfig.dns.options
+
             var targetEnvVars: [String] = []
             if let buildkitColors = ProcessInfo.processInfo.environment["BUILDKIT_COLORS"] {
                 targetEnvVars.append("BUILDKIT_COLORS=\(buildkitColors)")
@@ -146,25 +157,15 @@ extension Application {
 
                 let envChanged = existingManagedEnv != targetEnvVars
 
-                // Check if we need to recreate the builder due to different image
+                // Check if we need to recreate the builder due to different image or DNS defaults
                 let imageChanged = existingImage != builderImage
                 let cpuChanged = existingResources.cpus != resources.cpus
                 let memChanged = existingResources.memoryInBytes != resources.memoryInBytes
-                let dnsChanged = {
-                    if !dnsNameservers.isEmpty {
-                        return existingDNS?.nameservers != dnsNameservers
-                    }
-                    if dnsDomain != nil {
-                        return existingDNS?.domain != dnsDomain
-                    }
-                    if !dnsSearchDomains.isEmpty {
-                        return existingDNS?.searchDomains != dnsSearchDomains
-                    }
-                    if !dnsOptions.isEmpty {
-                        return existingDNS?.options != dnsOptions
-                    }
-                    return false
-                }()
+                let dnsChanged =
+                    existingDNS?.nameservers != resolvedDnsNameservers
+                    || existingDNS?.domain != resolvedDnsDomain
+                    || existingDNS?.searchDomains != resolvedDnsSearchDomains
+                    || existingDNS?.options != resolvedDnsOptions
 
                 switch existingContainer.status {
                 case .running:
@@ -270,10 +271,10 @@ extension Application {
                 AttachmentConfiguration(network: defaultNetwork.id, options: AttachmentOptions(hostname: Builder.builderContainerId))
             ]
             config.dns = ContainerConfiguration.DNSConfiguration(
-                nameservers: dnsNameservers,
-                domain: dnsDomain,
-                searchDomains: dnsSearchDomains,
-                options: dnsOptions
+                nameservers: resolvedDnsNameservers,
+                domain: resolvedDnsDomain,
+                searchDomains: resolvedDnsSearchDomains,
+                options: resolvedDnsOptions
             )
 
             let kernel = try await {

--- a/Sources/ContainerPersistence/ContainerSystemConfig.swift
+++ b/Sources/ContainerPersistence/ContainerSystemConfig.swift
@@ -133,14 +133,35 @@ final public class ContainerConfig: Codable, Sendable {
 
 final public class DNSConfig: Codable, Sendable {
     public let domain: String?
+    public let nameservers: [String]
+    public let searchDomains: [String]
+    public let options: [String]
 
-    public init(domain: String? = nil) {
+    public init(
+        domain: String? = nil,
+        nameservers: [String] = [],
+        searchDomains: [String] = [],
+        options: [String] = []
+    ) {
         self.domain = domain
+        self.nameservers = nameservers
+        self.searchDomains = searchDomains
+        self.options = options
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case domain
+        case nameservers
+        case searchDomains
+        case options
     }
 
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.domain = try container.decodeIfPresent(String.self, forKey: .domain)
+        self.nameservers = try container.decodeIfPresent([String].self, forKey: .nameservers) ?? []
+        self.searchDomains = try container.decodeIfPresent([String].self, forKey: .searchDomains) ?? []
+        self.options = try container.decodeIfPresent([String].self, forKey: .options) ?? []
     }
 }
 

--- a/Sources/Services/ContainerAPIService/Client/Utility.swift
+++ b/Sources/Services/ContainerAPIService/Client/Utility.swift
@@ -219,17 +219,10 @@ public struct Utility {
             }
         }
 
-        if management.dnsDisabled {
-            config.dns = nil
-        } else {
-            let domain = management.dns.domain ?? containerSystemConfig.dns.domain
-            config.dns = .init(
-                nameservers: management.dns.nameservers,
-                domain: domain,
-                searchDomains: management.dns.searchDomains,
-                options: management.dns.options
-            )
-        }
+        config.dns = dnsConfigurationFromFlags(
+            management: management,
+            containerSystemConfig: containerSystemConfig
+        )
 
         config.rosetta = management.rosetta || (Platform.current.architecture == "arm64" && requestedPlatform.architecture == "amd64")
 
@@ -265,6 +258,33 @@ public struct Utility {
         }
 
         return (config, kernel, management.initImage)
+    }
+
+    static func dnsConfigurationFromFlags(
+        management: Flags.Management,
+        containerSystemConfig: ContainerSystemConfig
+    ) -> ContainerConfiguration.DNSConfiguration? {
+        if management.dnsDisabled {
+            return nil
+        }
+
+        let nameservers = !management.dns.nameservers.isEmpty
+            ? management.dns.nameservers
+            : containerSystemConfig.dns.nameservers
+        let domain = management.dns.domain ?? containerSystemConfig.dns.domain
+        let searchDomains = !management.dns.searchDomains.isEmpty
+            ? management.dns.searchDomains
+            : containerSystemConfig.dns.searchDomains
+        let options = !management.dns.options.isEmpty
+            ? management.dns.options
+            : containerSystemConfig.dns.options
+
+        return .init(
+            nameservers: nameservers,
+            domain: domain,
+            searchDomains: searchDomains,
+            options: options
+        )
     }
 
     static func getAttachmentConfigurations(

--- a/Tests/ContainerAPIClientTests/UtilityTests.swift
+++ b/Tests/ContainerAPIClientTests/UtilityTests.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerPersistence
 import ContainerResource
 import ContainerizationError
 import Foundation
@@ -111,6 +112,77 @@ struct UtilityTests {
     @Test("Trim digest shorter than 12 chars returns value unchanged")
     func testTrimDigestShort() {
         #expect(Utility.trimDigest(digest: "sha256:abc") == "abc")
+    }
+
+    @Test
+    func testDNSConfigurationFromFlagsFallsBackToSystemConfigDefaults() throws {
+        let management = try Flags.Management.parse([])
+        let systemConfig = ContainerSystemConfig(
+            dns: DNSConfig(
+                domain: "custom",
+                nameservers: ["8.8.8.8", "8.8.4.4"],
+                searchDomains: ["example.com"],
+                options: ["ndots:5"]
+            )
+        )
+
+        let dnsConfig = Utility.dnsConfigurationFromFlags(
+            management: management,
+            containerSystemConfig: systemConfig
+        )
+
+        #expect(dnsConfig?.nameservers == ["8.8.8.8", "8.8.4.4"])
+        #expect(dnsConfig?.domain == "custom")
+        #expect(dnsConfig?.searchDomains == ["example.com"])
+        #expect(dnsConfig?.options == ["ndots:5"])
+    }
+
+    @Test
+    func testDNSConfigurationFromFlagsPrefersCLIFlagsOverSystemConfig() throws {
+        let management = try Flags.Management.parse([
+            "--dns", "1.1.1.1",
+            "--dns-domain", "cli.local",
+            "--dns-search", "cli.local",
+            "--dns-option", "timeout:2"
+        ])
+        let systemConfig = ContainerSystemConfig(
+            dns: DNSConfig(
+                domain: "custom",
+                nameservers: ["8.8.8.8"],
+                searchDomains: ["example.com"],
+                options: ["ndots:5"]
+            )
+        )
+
+        let dnsConfig = Utility.dnsConfigurationFromFlags(
+            management: management,
+            containerSystemConfig: systemConfig
+        )
+
+        #expect(dnsConfig?.nameservers == ["1.1.1.1"])
+        #expect(dnsConfig?.domain == "cli.local")
+        #expect(dnsConfig?.searchDomains == ["cli.local"])
+        #expect(dnsConfig?.options == ["timeout:2"])
+    }
+
+    @Test
+    func testDNSConfigurationFromFlagsReturnsNilWhenNoDNS() throws {
+        let management = try Flags.Management.parse(["--no-dns"])
+        let systemConfig = ContainerSystemConfig(
+            dns: DNSConfig(
+                domain: "custom",
+                nameservers: ["8.8.8.8"],
+                searchDomains: ["example.com"],
+                options: ["ndots:5"]
+            )
+        )
+
+        let dnsConfig = Utility.dnsConfigurationFromFlags(
+            management: management,
+            containerSystemConfig: systemConfig
+        )
+
+        #expect(dnsConfig == nil)
     }
 
     @Test

--- a/Tests/ContainerPersistenceTests/ConfigurationLoaderTests.swift
+++ b/Tests/ContainerPersistenceTests/ConfigurationLoaderTests.swift
@@ -91,6 +91,9 @@ struct ConfigurationLoaderTests {
             #expect(config.container.cpus == 4)
             #expect(config.container.memory == ContainerConfig.defaultMemory)
             #expect(config.dns.domain == nil)
+            #expect(config.dns.nameservers.isEmpty)
+            #expect(config.dns.searchDomains.isEmpty)
+            #expect(config.dns.options.isEmpty)
             #expect(!config.build.image.isEmpty)
             #expect(!config.vminit.image.isEmpty)
             #expect(!config.kernel.binaryPath.isEmpty)
@@ -116,6 +119,9 @@ struct ConfigurationLoaderTests {
 
                 [dns]
                 domain = "custom"
+                nameservers = ["8.8.8.8", "8.8.4.4"]
+                searchDomains = ["example.com", "svc.local"]
+                options = ["ndots:5", "timeout:2"]
 
                 [kernel]
                 binaryPath = "custom/path"
@@ -143,6 +149,9 @@ struct ConfigurationLoaderTests {
             let expectedContainerMemory = try MemorySize("8g")
             #expect(config.container.memory == expectedContainerMemory)
             #expect(config.dns.domain == "custom")
+            #expect(config.dns.nameservers == ["8.8.8.8", "8.8.4.4"])
+            #expect(config.dns.searchDomains == ["example.com", "svc.local"])
+            #expect(config.dns.options == ["ndots:5", "timeout:2"])
             #expect(config.build.image == "custom-builder:latest")
             #expect(config.vminit.image == "custom-init:latest")
             #expect(config.kernel.binaryPath == "custom/path")

--- a/docs/container-system-config.md
+++ b/docs/container-system-config.md
@@ -46,9 +46,12 @@ Defaults applied when `container run` / `container create` is invoked without `-
 
 ## `[dns]`
 
-| Key      | Type      | Default | Description                                                                |
-|----------|-----------|---------|----------------------------------------------------------------------------|
-| `domain` | `String?` | unset   | Local DNS domain appended to container hostnames (e.g. `"test"` makes `my-web-server` resolvable as `my-web-server.test`). When unset, no domain is appended. |
+| Key           | Type         | Default | Description                                                                 |
+|---------------|--------------|---------|-----------------------------------------------------------------------------|
+| `domain`      | `String?`    | unset   | Local DNS domain appended to container hostnames (e.g. `"test"` makes `my-web-server` resolvable as `my-web-server.test`). When unset, no domain is appended. |
+| `nameservers` | `[String]`   | `[]`    | Default DNS nameservers to configure inside containers when no `--dns` flag is passed. |
+| `searchDomains` | `[String]` | `[]`    | Default DNS search domains to configure when no `--dns-search` flag is passed. |
+| `options`     | `[String]`   | `[]`    | Default DNS resolver options to configure when no `--dns-option` flag is passed. |
 
 ## `[kernel]`
 


### PR DESCRIPTION
## Summary
Adds support for configuring default DNS servers through the system configuration file.

## Changes
- Added DNS configuration section.
- Applied configured DNS values when --dns is not specified.
- Added unit tests.

Fixes #1449