### PR TITLE
fix: replace try! with try for createDirectory in SystemStart

### DIFF
--- a/Sources/ContainerCommands/System/SystemStart.swift
+++ b/Sources/ContainerCommands/System/SystemStart.swift
@@ -104,7 +104,7 @@ extension Application {
 
             let apiServerDataPath = appRoot.appending(FilePath.Component("apiserver"))
             let apiServerDataURL = URL(fileURLWithPath: apiServerDataPath.string)
-            try! FileManager.default.createDirectory(at: apiServerDataURL, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(at: apiServerDataURL, withIntermediateDirectories: true)
 
             var env = PluginLoader.filterEnvironment()
             env[ApplicationRoot.environmentName] = appRoot.string


### PR DESCRIPTION
Fixes #1802.

`run()` in `SystemStart.swift` is `async throws`, and every other filesystem and configuration call in it propagates errors with plain `try`. Line 107 was the exception — a `try!` on `FileManager.default.createDirectory` that crashes with a fatal error if the app-root directory isn't writable, instead of surfacing a clean error message.

**Before:**
```
ContainerCommands/SystemStart.swift:107: Fatal error: 'try!' expression unexpectedly raised an error: Error Domain=NSCocoaErrorDomain Code=513 "You don't have permission to save the file "apiserver" in the folder "test-approot"." ...
```
exit code 133 (abort)

**After:**
```
Error: You don't have permission to save the file "apiserver" in the folder "test-approot".
```
exit code 1

One character change: `try!` → `try`.

**Reproduce:**
```bash
rm -rf test-data && make APP_ROOT=test-data all
mkdir -p /tmp/test-approot && chmod 555 /tmp/test-approot
bin/container system start --app-root /tmp/test-approot
```

Tested on macOS 26.5.1, Swift 6.2.4, commit `1d70dd6`.