### PR TITLE
Route `container image save` reference list to stderr in stdout mode

### DIFF
--- a/Sources/ContainerCommands/Image/ImageSave.swift
+++ b/Sources/ContainerCommands/Image/ImageSave.swift
@@ -140,7 +140,15 @@ extension Application {
 
             progress.finish()
             for reference in references {
-                print(reference)
+                if output == nil {
+                    // stdout is carrying the OCI archive in this branch, so the
+                    // saved-reference list goes to stderr via the logger. Printing
+                    // it to stdout appends non-archive bytes after the tar EOF and
+                    // corrupts the stream for redirection and pipelines (#1801).
+                    log.info("\(reference)")
+                } else {
+                    print(reference)
+                }
             }
         }
     }

--- a/Tests/CLITests/Subcommands/Images/TestCLIImagesCommand.swift
+++ b/Tests/CLITests/Subcommands/Images/TestCLIImagesCommand.swift
@@ -266,6 +266,44 @@ class TestCLIImagesCommand: CLITest {
         }
     }
 
+    @Test func testImageSaveToStdoutProducesCleanArchive() throws {
+        do {
+            // 1. pull and tag an image to save
+            try doPull(imageName: alpine)
+            let alpineRef: Reference = try Reference.parse(alpine)
+            let alpineTagged = "\(alpineRef.name):testImageSaveToStdout"
+            try doImageTag(image: alpine, newName: alpineTagged)
+            defer {
+                try? doRemoveImages(images: [alpineTagged])
+            }
+
+            // 2. save to stdout (no --output): stdout is the archive stream
+            let saveArgs = [
+                "image",
+                "save",
+                alpineTagged,
+            ]
+            let (outputData, _, error, status) = try run(arguments: saveArgs)
+            if status != 0 {
+                throw CLIError.executionFailed("save to stdout failed: \(error)")
+            }
+
+            // 3. The archive on stdout must end at the tar EOF marker (two
+            //    512-byte zero blocks). With the bug, the saved-reference list
+            //    is printed to stdout after the archive, so the trailing bytes
+            //    are reference text rather than the tar EOF zeros (#1801).
+            #expect(outputData.count >= 1024, "stdout archive is too small to contain a tar EOF marker")
+            let trailer = outputData.suffix(1024)
+            #expect(trailer.allSatisfy { $0 == 0 }, "stdout archive has trailing non-archive bytes after the tar EOF marker")
+
+            // 4. The saved-reference list is still surfaced, on stderr.
+            #expect(error.contains(alpineTagged), "expected the saved image reference on stderr")
+        } catch {
+            Issue.record("failed to save image to stdout \(error)")
+            return
+        }
+    }
+
     @Test func testImageSaveMissingPlatform() throws {
         do {
             // 1. pull image


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Fixes #1801.

When `container image save` runs without `--output`, stdout carries the OCI tar archive. The command writes the archive bytes to stdout and then `print(reference)`s each saved image reference to stdout afterward, appending non-archive text after the tar EOF marker. That corrupts the stream for strict tar/OCI consumers, so a command like:

```bash
container image save alpine:latest > alpine.tar
```

produces an archive with trailing non-archive bytes. The existing round-trip test passes only because `container image load` tolerates the trailing data, while other tooling rejects or warns about it.

This routes the saved-reference list to stderr in the no-`--output` branch, so stdout contains only archive bytes. When saving to a file via `--output`, stdout is free, so the references continue to print to stdout exactly as before.

I used a raw `FileHandle.standardError.write(...)` to match the existing stderr writes in this codebase (e.g. `Application.swift`) and to keep the reference list as plain text rather than formatted log lines. Happy to route it through the logger instead if you'd prefer.

## Testing
- [ ] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

Added `testImageSaveToStdoutProducesCleanArchive`: it saves an image to stdout and asserts that the captured stdout ends at the tar EOF marker (1024 zero bytes), with the saved reference surfaced on stderr. With the bug, the trailing bytes are reference text and the assertion fails.

`swift build` and `swift format` are clean. I was not able to run the CLI integration suite locally (it needs the running container runtime), so I left "Tested locally" unchecked. The new test sits alongside the existing `image save`/`load` integration tests and is written to run in CI.
