### PR TITLE
Documentiation fixes for typos and grammar.

### DIFF
--- a/Sources/ContainerLog/ServiceLogger.swift
+++ b/Sources/ContainerLog/ServiceLogger.swift
@@ -24,7 +24,7 @@ public struct ServiceLogger {
     /// - Parameters:
     ///   - label: A unique identifier for the application.
     ///   - category: An identifier for the application subsystem.
-    ///   - metadata: Metadata to include for all messsages. A message
+    ///   - metadata: Metadata to include for all messages. A message
     ///     specific value for a duplicate key overrides these values.
     ///   - debug: Enable debug logging.
     ///   - logPath: If supplied, create log files under the named

--- a/Sources/ContainerResource/Common/ResourceLabels.swift
+++ b/Sources/ContainerResource/Common/ResourceLabels.swift
@@ -100,7 +100,7 @@ extension AppErrorCode {
 
 /// System-defined keys for resource labels.
 public struct ResourceLabelKeys {
-    /// Indicates a owner of a resource managed by a plugin.
+    /// Indicates an owner of a resource managed by a plugin.
     public static let plugin = "com.apple.container.plugin"
 
     /// Indicates a resource with a reserved or dedicated purpose.

--- a/Sources/ContainerResource/Container/Filesystem.swift
+++ b/Sources/ContainerResource/Container/Filesystem.swift
@@ -159,7 +159,7 @@ public struct Filesystem: Sendable, Codable {
         }
     }
 
-    /// Returns true if the Filesystem is backed by a in-memory mount type.
+    /// Returns true if the Filesystem is backed by an in-memory mount type.
     public var isTmpfs: Bool {
         switch type {
         case .tmpfs: true

--- a/Sources/Services/ContainerAPIService/Client/Archiver.swift
+++ b/Sources/Services/ContainerAPIService/Client/Archiver.swift
@@ -116,7 +116,7 @@ public final class Archiver: Sendable {
         defer { readBuffer.deallocate() }
         try writer.writeHeader(entry: entry)
         if entry.fileType == .regular {
-            // We need to write the data into the archive only if its a regular file
+            // We need to write the data into the archive only if it's a regular file
             // Symlinks and directories require us to only write the archive header
             guard let stream = InputStream(url: item) else {
                 throw Error.failedToCreateInputStream(item)

--- a/Sources/Services/ContainerAPIService/Client/ClientImage.swift
+++ b/Sources/Services/ContainerAPIService/Client/ClientImage.swift
@@ -362,7 +362,7 @@ extension ClientImage {
         do {
             let match = try await self.get(reference: reference, containerSystemConfig: containerSystemConfig)
             if let platform {
-                // The image exists, but we dont know if we have the right platform pulled
+                // The image exists, but we don't know if we have the right platform pulled
                 // Check if we do, if not pull the requested platform
                 _ = try await match.config(for: platform)
             }


### PR DESCRIPTION
Corrects small spelling and grammar mistakes in source documentation comments (no behavior change):

- ServiceLogger.swift: "messsages" -> "messages"
- ClientImage.swift: "we dont know" -> "we don't know"
- Filesystem.swift: "a in-memory" -> "an in-memory"
- ResourceLabels.swift: "a owner" -> "an owner"
- Archiver.swift: "if its a regular file" -> "if it's a regular file"

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ X] Documentation update

## Motivation and Context
I don't have any Swift experience but I wanted to help contribute to Apple's eco system because my first computer I ever touched was an Apple IIe. 

## Testing
- [] Tested locally
- [ ] Added/updated tests
- [X ] Added/updated docs


Am I a bot? Negative, I am a meat-popsicle.

CryptoJones