### PR TITLE
Normalize network hostname lookup

### DIFF
--- a/Sources/Services/Network/Server/AttachmentAllocator.swift
+++ b/Sources/Services/Network/Server/AttachmentAllocator.swift
@@ -30,6 +30,7 @@ actor AttachmentAllocator {
 
     /// Allocate a network address for a host.
     func allocate(hostname: String) async throws -> UInt32 {
+        let hostname = Self.normalized(hostname: hostname)
         // Client is responsible for ensuring two containers don't use same hostname, so provide existing IP if hostname exists
         if let index = hostnames[hostname] {
             return index
@@ -44,6 +45,7 @@ actor AttachmentAllocator {
     /// Free an allocated network address by hostname.
     @discardableResult
     func deallocate(hostname: String) async throws -> UInt32? {
+        let hostname = Self.normalized(hostname: hostname)
         guard let index = hostnames.removeValue(forKey: hostname) else {
             return nil
         }
@@ -54,6 +56,12 @@ actor AttachmentAllocator {
 
     /// Retrieve the allocator index for a hostname.
     func lookup(hostname: String) async throws -> UInt32? {
-        hostnames[hostname]
+        let hostname = Self.normalized(hostname: hostname)
+        return hostnames[hostname]
+    }
+
+    private static func normalized(hostname: String) -> String {
+        let hostname = hostname.hasSuffix(".") ? String(hostname.dropLast()) : hostname
+        return hostname.lowercased()
     }
 }

--- a/Tests/ContainerNetworkServerTests/AttachmentAllocatorTest.swift
+++ b/Tests/ContainerNetworkServerTests/AttachmentAllocatorTest.swift
@@ -58,6 +58,33 @@ struct AttachmentAllocatorTest {
         #expect(lookedUpAddress == allocatedAddress)
     }
 
+    @Test func testLookupAllocatedHostnameWithTrailingDot() async throws {
+        let allocator = try AttachmentAllocator(lower: 100, size: 10)
+
+        let allocatedAddress = try await allocator.allocate(hostname: "test-host")
+        let lookedUpAddress = try await allocator.lookup(hostname: "test-host.")
+
+        #expect(lookedUpAddress == allocatedAddress)
+    }
+
+    @Test func testHostnameLookupIsCaseInsensitive() async throws {
+        let allocator = try AttachmentAllocator(lower: 100, size: 10)
+
+        let allocatedAddress = try await allocator.allocate(hostname: "Test-Host.")
+        let lookedUpAddress = try await allocator.lookup(hostname: "test-host")
+
+        #expect(lookedUpAddress == allocatedAddress)
+    }
+
+    @Test func testAllocateEquivalentHostnames() async throws {
+        let allocator = try AttachmentAllocator(lower: 100, size: 10)
+
+        let address1 = try await allocator.allocate(hostname: "test-host")
+        let address2 = try await allocator.allocate(hostname: "TEST-HOST.")
+
+        #expect(address1 == address2)
+    }
+
     @Test func testLookupNonExistentHostname() async throws {
         let allocator = try AttachmentAllocator(lower: 100, size: 10)
 
@@ -75,6 +102,18 @@ struct AttachmentAllocatorTest {
         #expect(deallocatedAddress == allocatedAddress)
 
         // After deallocation, lookup should return nil
+        let lookedUpAddress = try await allocator.lookup(hostname: "test-host")
+        #expect(lookedUpAddress == nil)
+    }
+
+    @Test func testDeallocateAllocatedHostnameWithEquivalentName() async throws {
+        let allocator = try AttachmentAllocator(lower: 100, size: 10)
+
+        let allocatedAddress = try await allocator.allocate(hostname: "test-host")
+        let deallocatedAddress = try await allocator.deallocate(hostname: "TEST-HOST.")
+
+        #expect(deallocatedAddress == allocatedAddress)
+
         let lookedUpAddress = try await allocator.lookup(hostname: "test-host")
         #expect(lookedUpAddress == nil)
     }


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Network attachments are allocated under the hostname supplied by the runtime, while DNS queries are canonical DNS names and may include a trailing dot. DNS hostnames are also case-insensitive. Because `AttachmentAllocator` keyed hostnames exactly as supplied, a container allocated as `web` could fail lookup when the embedded DNS path queried `web.`.

This normalizes allocator keys by lowercasing hostnames and treating a single trailing dot as optional across allocate, lookup, and deallocate. The original hostname remains preserved in the returned attachment.

This is a narrow fix for the embedded DNS lookup path. First-class Compose-style bare service discovery from containers through the network gateway is a separate feature request: https://github.com/apple/container/issues/1809. Related DNS discussion: https://github.com/apple/container/issues/856.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

Checks run:

```sh
swift test --filter AttachmentAllocatorTest
swift test -c debug -Xswiftc -warnings-as-errors --filter AttachmentAllocatorTest
```

Additional manual validation:

- On released `container` 1.0.0, created a custom network and container; direct `dig @127.0.0.1 -p 2053 <container-name> A` returned no A record.
- With this patched debug build installed under a temporary `/tmp` install root, the same direct queries returned the allocated container IP for both `<container-name>` and `<container-name>.`.
