### PR TITLE
Add container run hostname flag

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/Flags.swift
+++ b/Sources/Services/ContainerAPIService/Client/Flags.swift
@@ -174,6 +174,7 @@ public struct Flags {
             dns: Flags.DNS,
             dnsDisabled: Bool,
             entrypoint: String?,
+            hostname: String?,
             initImage: String?,
             kernel: String?,
             labels: [String],
@@ -203,6 +204,7 @@ public struct Flags {
             self.dns = dns
             self.dnsDisabled = dnsDisabled
             self.entrypoint = entrypoint
+            self.hostname = hostname
             self.initImage = initImage
             self.kernel = kernel
             self.labels = labels
@@ -257,6 +259,9 @@ public struct Flags {
             )
         )
         public var entrypoint: String?
+
+        @Option(name: .long, help: .init("Set the container hostname", valueName: "hostname"))
+        public var hostname: String?
 
         @Flag(name: .customLong("init"), help: "Run an init process inside the container that forwards signals and reaps processes")
         public var useInit = false

--- a/Sources/Services/ContainerAPIService/Client/Utility.swift
+++ b/Sources/Services/ContainerAPIService/Client/Utility.swift
@@ -215,6 +215,7 @@ public struct Utility {
             let builtinNetworkId = try await networkClient.builtin?.id
             config.networks = try getAttachmentConfigurations(
                 containerId: config.id,
+                hostname: management.hostname,
                 builtinNetworkId: builtinNetworkId,
                 networks: parsedNetworks,
                 dnsDomain: containerSystemConfig.dns.domain,
@@ -274,6 +275,7 @@ public struct Utility {
 
     static func getAttachmentConfigurations(
         containerId: String,
+        hostname: String?,
         builtinNetworkId: String?,
         networks: [Parser.ParsedNetwork],
         dnsDomain: String?,
@@ -286,17 +288,19 @@ public struct Utility {
         }
 
         // make an FQDN for the first interface
+        let rawHostname = hostname ?? containerId
+        let hostname = rawHostname.hasSuffix(".") ? String(rawHostname.dropLast()) : rawHostname
         let fqdn: String?
-        if !containerId.contains(".") {
-            // add default domain if it exists, and container ID is unqualified
+        if !hostname.contains(".") {
+            // add default domain if it exists, and the hostname is unqualified
             if let dnsDomain {
-                fqdn = "\(containerId).\(dnsDomain)."
+                fqdn = "\(hostname).\(dnsDomain)."
             } else {
                 fqdn = nil
             }
         } else {
-            // use container ID directly if fully qualified
-            fqdn = "\(containerId)."
+            // use hostname directly if fully qualified
+            fqdn = "\(hostname)."
         }
 
         guard networks.isEmpty else {
@@ -322,7 +326,7 @@ public struct Utility {
                 }
                 return AttachmentConfiguration(
                     network: item.element.name,
-                    options: AttachmentOptions(hostname: fqdn ?? containerId, macAddress: macAddress, mtu: mtu)
+                    options: AttachmentOptions(hostname: fqdn ?? hostname, macAddress: macAddress, mtu: mtu)
                 )
             }
         }
@@ -331,7 +335,7 @@ public struct Utility {
         guard let builtinNetworkId else {
             throw ContainerizationError(.invalidState, message: "builtin network is not present")
         }
-        return [AttachmentConfiguration(network: builtinNetworkId, options: AttachmentOptions(hostname: fqdn ?? containerId, macAddress: nil, mtu: 1280))]
+        return [AttachmentConfiguration(network: builtinNetworkId, options: AttachmentOptions(hostname: fqdn ?? hostname, macAddress: nil, mtu: 1280))]
     }
 
     private static func getKernel(management: Flags.Management) async throws -> Kernel {

--- a/Tests/ContainerAPIClientTests/ParserTest.swift
+++ b/Tests/ContainerAPIClientTests/ParserTest.swift
@@ -928,6 +928,13 @@ struct ParserTest {
     }
 
     @Test
+    func testManagementFlagsParseHostname() throws {
+        let managementFlags = try Flags.Management.parse(["--hostname", "custom-host"])
+
+        #expect(managementFlags.hostname == "custom-host")
+    }
+
+    @Test
     func testUlimitParserSoftAndHard() throws {
         let result = try Parser.rlimits(["nofile=1024:2048"])
         #expect(result.count == 1)

--- a/Tests/ContainerAPIClientTests/UtilityTests.swift
+++ b/Tests/ContainerAPIClientTests/UtilityTests.swift
@@ -131,4 +131,33 @@ struct UtilityTests {
         #expect(ports[1].proto == .udp)
         #expect(ports[1].count == 100)
     }
+
+    @Test("Custom hostname sets default attachment hostname")
+    func testCustomHostnameSetsDefaultAttachmentHostname() throws {
+        let attachments = try Utility.getAttachmentConfigurations(
+            containerId: "container-id",
+            hostname: "custom-host",
+            builtinNetworkId: "default",
+            networks: [],
+            dnsDomain: nil
+        )
+
+        #expect(attachments.count == 1)
+        #expect(attachments[0].network == "default")
+        #expect(attachments[0].options.hostname == "custom-host")
+    }
+
+    @Test("Custom hostname uses configured DNS domain")
+    func testCustomHostnameUsesConfiguredDNSDomain() throws {
+        let attachments = try Utility.getAttachmentConfigurations(
+            containerId: "container-id",
+            hostname: "custom-host",
+            builtinNetworkId: "default",
+            networks: [],
+            dnsDomain: "test"
+        )
+
+        #expect(attachments.count == 1)
+        #expect(attachments[0].options.hostname == "custom-host.test.")
+    }
 }

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -53,6 +53,7 @@ container run [<options>] <image> [<arguments> ...]
 *   `--dns-option <option>`: DNS options
 *   `--dns-search <domain>`: DNS search domains
 *   `--entrypoint <cmd>`: Override the entrypoint of the image
+*   `--hostname <hostname>`: Set the container hostname
 *   `--init`: Run an init process inside the container that forwards signals and reaps processes
 *   `--init-image <image>`: Use a custom init image instead of the default. This allows customizing boot-time behavior before the OCI container starts, such as running VM-level daemons, configuring eBPF filters, or debugging the init process.
 *   `-k, --kernel <path>`: Set a custom kernel path
@@ -226,6 +227,7 @@ container create [<options>] <image> [<arguments> ...]
 *   `--dns-option <option>`: DNS options
 *   `--dns-search <domain>`: DNS search domains
 *   `--entrypoint <cmd>`: Override the entrypoint of the image
+*   `--hostname <hostname>`: Set the container hostname
 *   `--init`: Run an init process inside the container that forwards signals and reaps processes
 *   `--init-image <image>`: Use a custom init image instead of the default. This allows customizing boot-time behavior before the OCI container starts, such as running VM-level daemons, configuring eBPF filters, or debugging the init process.
 *   `-k, --kernel <path>`: Set a custom kernel path


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context
Apple `container run` and `container create` currently use the container name as the guest hostname through the first network attachment. Docker Compose also has a separate `hostname:` field, where the requested guest hostname can differ from the container management name.

This PR adds `--hostname <hostname>` to the shared management flags and uses it as the hostname for the first network attachment. The Linux runtime already derives the guest hostname from the first attachment hostname, so the change uses the existing persisted network attachment model rather than introducing a separate container configuration field.

## Design status

This is separate from the alias work in #1815/#1839. Aliases may cover most Compose `hostname:` translation cases while keeping the container name and guest hostname coupled. This PR keeps the explicit hostname-override path available for review, but it is not required for the alias PR.

Related to Compose compatibility work in Mcrich23/Container-Compose#119 and service/alias work in #1815/#1839.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [x] Added/updated docs

Checks run:

```sh
git diff --check origin/main..HEAD
swift test -c debug -Xswiftc -warnings-as-errors --filter 'ParserTest|UtilityTests'
```

The focused test run passed 122 tests after rebasing onto current `origin/main` and linked the CLI stack as part of the package test build.

Earlier manual smoke test against the normal running service:

```sh
.build/arm64-apple-macosx/debug/container run --rm --name codex-hostname-flag --hostname custom-host busybox hostname
```

The command printed:

```text
custom-host
```