### PR TITLE
fix: avoid writing image references to stdout during image save

### DIFF
--- a/Sources/ContainerCommands/Image/ImageSave.swift
+++ b/Sources/ContainerCommands/Image/ImageSave.swift
@@ -140,7 +140,7 @@ extension Application {
 
             progress.finish()
             for reference in references {
-                print(reference)
+                log.info("saved image \(reference)")
             }
         }
     }

--- a/Tests/CLITests/Subcommands/Images/TestCLIImagesCommand.swift
+++ b/Tests/CLITests/Subcommands/Images/TestCLIImagesCommand.swift
@@ -492,6 +492,11 @@ class TestCLIImagesCommand: CLITest {
                 throw CLIError.executionFailed("command failed: \(error)")
             }
 
+            // Tar archives must end with two 512-byte zero blocks.
+            #expect(stdoutData.count >= 1024, "expected save output to contain tar EOF blocks")
+            let trailingBlocks = stdoutData.suffix(1024)
+            #expect(trailingBlocks.allSatisfy({ $0 == 0 }), "expected save output to end with tar EOF markers and no extra stdout")
+
             // 4. remove the image through container
             try doRemoveImages(images: [alpineTagged, busyboxTagged])
 


### PR DESCRIPTION
## Summary
Fixes corruption of tar archives when `container image save` writes to stdout.

## Changes
- Moved status messages from stdout to stderr.
- Ensured stdout contains only archive data.
- Added a regression test covering stdout output.

Fixes #1801