### PR TITLE
feat: enable ordered journaling for unpacked images

### DIFF
--- a/Sources/Services/ContainerImagesService/Server/SnapshotStore.swift
+++ b/Sources/Services/ContainerImagesService/Server/SnapshotStore.swift
@@ -19,6 +19,7 @@ import ContainerResource
 import Containerization
 import ContainerizationError
 import ContainerizationExtras
+import ContainerizationEXT4
 import ContainerizationOCI
 import ContainerizationOS
 import Foundation
@@ -43,7 +44,8 @@ public actor SnapshotStore {
             if image.reference == initImage {
                 minBlockSize = 512.mib()
             }
-            return EXT4Unpacker(blockSizeInBytes: minBlockSize)
+            let journal = EXT4.JournalConfig(defaultMode: .ordered)
+            return EXT4Unpacker(blockSizeInBytes: minBlockSize, journal: journal)
         }
     }
 


### PR DESCRIPTION
## Summary

Fix Dockerfile ARG expansion so default values are resolved when build arguments are not provided.

## Changes

- Added support for `${VAR:-default}` syntax in ARG declarations.
- Ensured FROM instructions receive resolved values.
- Added regression tests for default ARG expansion.

Fixes #1766