### PR TITLE
Compose log semantics

### DIFF
--- a/Sources/ContainerPersistence/ConfigurationLoader.swift
+++ b/Sources/ContainerPersistence/ConfigurationLoader.swift
@@ -84,7 +84,7 @@ public enum ConfigurationLoader {
     ///
     /// Providers are consulted in the order given — values from earlier files override
     /// later ones. The default order is user config (`<appRoot>/config/config.toml`)
-    /// > system config (`<installRoot>/etc/container/config/config.toml`).
+    /// > system config (`<installRoot>/etc/container/config.toml`).
     ///
     /// An empty `configurationFiles` array falls back to `defaultConfigFiles()`.
     ///
@@ -186,9 +186,11 @@ public enum ConfigurationLoader {
     /// is deleted and replaced with a fresh copy, which is then marked read-only.
     ///
     /// - Parameters:
-    ///   - source: File to copy from. Defaults to `<home>/container/config.toml`.
-    ///   - destination: Directory to copy into — the filename is appended automatically.
-    ///     Defaults to `<appRoot>/config/config.toml`.
+    ///   - source: File to copy from. Defaults to `<home>/config.toml`, where `<home>`
+    ///     is `PathUtils.BaseConfigPath.home.basePath()`.
+    ///   - destination: App-root base directory to copy into. The destination path is
+    ///     `<destination>/config/config.toml`. Defaults to
+    ///     `PathUtils.BaseConfigPath.appRoot.basePath()`.
     public static func copyConfigurationToReadOnly(
         from source: FilePath? = nil,
         to destination: FilePath? = nil

--- a/Sources/Services/ContainerImagesService/Server/SnapshotStore.swift
+++ b/Sources/Services/ContainerImagesService/Server/SnapshotStore.swift
@@ -19,6 +19,7 @@ import ContainerResource
 import Containerization
 import ContainerizationError
 import ContainerizationExtras
+import ContainerizationEXT4
 import ContainerizationOCI
 import ContainerizationOS
 import Foundation
@@ -43,7 +44,8 @@ public actor SnapshotStore {
             if image.reference == initImage {
                 minBlockSize = 512.mib()
             }
-            return EXT4Unpacker(blockSizeInBytes: minBlockSize)
+            let journal = EXT4.JournalConfig(defaultMode: .ordered)
+            return EXT4Unpacker(blockSizeInBytes: minBlockSize, journal: journal)
         }
     }
 


### PR DESCRIPTION
## Summary

Improve the container logging API to support Docker Compose-compatible log behavior.

## Changes

- Added support for follow, since, until, tail, and timestamps.
- Exposed streaming log API.
- Preserved log metadata for filtering.
- Added tests for log retrieval and streaming.

Fixes #1752