### PR TITLE
Fix bootstrap readonly etc

### DIFF
--- a/Sources/ContainerPersistence/ConfigurationLoader.swift
+++ b/Sources/ContainerPersistence/ConfigurationLoader.swift
@@ -84,7 +84,7 @@ public enum ConfigurationLoader {
     ///
     /// Providers are consulted in the order given — values from earlier files override
     /// later ones. The default order is user config (`<appRoot>/config/config.toml`)
-    /// > system config (`<installRoot>/etc/container/config/config.toml`).
+    /// > system config (`<installRoot>/etc/container/config.toml`).
     ///
     /// An empty `configurationFiles` array falls back to `defaultConfigFiles()`.
     ///
@@ -186,9 +186,11 @@ public enum ConfigurationLoader {
     /// is deleted and replaced with a fresh copy, which is then marked read-only.
     ///
     /// - Parameters:
-    ///   - source: File to copy from. Defaults to `<home>/container/config.toml`.
-    ///   - destination: Directory to copy into — the filename is appended automatically.
-    ///     Defaults to `<appRoot>/config/config.toml`.
+    ///   - source: File to copy from. Defaults to `<home>/config.toml`, where `<home>`
+    ///     is `PathUtils.BaseConfigPath.home.basePath()`.
+    ///   - destination: App-root base directory to copy into. The destination path is
+    ///     `<destination>/config/config.toml`. Defaults to
+    ///     `PathUtils.BaseConfigPath.appRoot.basePath()`.
     public static func copyConfigurationToReadOnly(
         from source: FilePath? = nil,
         to destination: FilePath? = nil

--- a/Sources/ContainerResource/Container/ContainerConfiguration.swift
+++ b/Sources/ContainerResource/Container/ContainerConfiguration.swift
@@ -36,6 +36,8 @@ public struct ContainerConfiguration: Sendable, Codable {
     public var networks: [AttachmentConfiguration] = []
     /// The DNS configuration for the container.
     public var dns: DNSConfiguration? = nil
+    /// Whether to configure /etc/hosts during bootstrap.
+    public var hostsConfigured: Bool = true
     /// Whether to enable rosetta x86-64 translation for the container.
     public var rosetta: Bool = false
     /// Initial or main process of the container.
@@ -75,6 +77,7 @@ public struct ContainerConfiguration: Sendable, Codable {
         case sysctls
         case networks
         case dns
+        case hostsConfigured
         case rosetta
         case initProcess
         case platform
@@ -111,6 +114,7 @@ public struct ContainerConfiguration: Sendable, Codable {
         }
 
         dns = try container.decodeIfPresent(DNSConfiguration.self, forKey: .dns)
+        hostsConfigured = try container.decodeIfPresent(Bool.self, forKey: .hostsConfigured) ?? true
         rosetta = try container.decodeIfPresent(Bool.self, forKey: .rosetta) ?? false
         initProcess = try container.decode(ProcessConfiguration.self, forKey: .initProcess)
         platform = try container.decodeIfPresent(ContainerizationOCI.Platform.self, forKey: .platform) ?? .current

--- a/Sources/Services/ContainerAPIService/Client/ClientProcess.swift
+++ b/Sources/Services/ContainerAPIService/Client/ClientProcess.swift
@@ -19,6 +19,7 @@ import Containerization
 import ContainerizationError
 import ContainerizationOCI
 import ContainerizationOS
+import Darwin
 import Foundation
 import NIOCore
 import NIOPosix
@@ -80,9 +81,26 @@ struct ClientProcessImpl: ClientProcess, Sendable {
         let request = XPCMessage(route: .containerKill)
         request.set(key: .id, value: containerId)
         request.set(key: .processIdentifier, value: id)
-        request.set(key: .signal, value: Int64(signal))
+        request.set(key: .signal, value: Self.signalName(for: signal))
 
         try await xpcClient.send(request)
+    }
+
+    static func signalName(for signal: Int32) -> String {
+        switch signal {
+        case SIGTERM:
+            return "SIGTERM"
+        case SIGINT:
+            return "SIGINT"
+        case SIGUSR1:
+            return "SIGUSR1"
+        case SIGUSR2:
+            return "SIGUSR2"
+        case SIGWINCH:
+            return "SIGWINCH"
+        default:
+            return "\(signal)"
+        }
     }
 
     /// Resize the processes PTY if it has one.

--- a/Sources/Services/ContainerAPIService/Client/Flags.swift
+++ b/Sources/Services/ContainerAPIService/Client/Flags.swift
@@ -174,6 +174,8 @@ public struct Flags {
             dns: Flags.DNS,
             dnsDisabled: Bool,
             entrypoint: String?,
+            hostConfigDisabled: Bool,
+            hostsDisabled: Bool,
             initImage: String?,
             kernel: String?,
             labels: [String],
@@ -203,6 +205,8 @@ public struct Flags {
             self.dns = dns
             self.dnsDisabled = dnsDisabled
             self.entrypoint = entrypoint
+            self.hostConfigDisabled = hostConfigDisabled
+            self.hostsDisabled = hostsDisabled
             self.initImage = initImage
             self.kernel = kernel
             self.labels = labels
@@ -292,6 +296,12 @@ public struct Flags {
         @Flag(name: [.customLong("no-dns")], help: "Do not configure DNS in the container")
         public var dnsDisabled = false
 
+        @Flag(name: [.customLong("no-host-config")], help: "Do not configure host files such as /etc/resolv.conf or /etc/hosts in the container")
+        public var hostConfigDisabled = false
+
+        @Flag(name: [.customLong("no-hosts")], help: "Do not configure /etc/hosts in the container")
+        public var hostsDisabled = false
+
         @Option(name: .long, help: "Set OS if image can target multiple operating systems")
         public var os = "linux"
 
@@ -348,7 +358,7 @@ public struct Flags {
         public var volumes: [String] = []
 
         public func validate() throws {
-            if dnsDisabled {
+            if dnsDisabled || hostConfigDisabled {
                 let hasDNSConfig =
                     !dns.nameservers.isEmpty
                     || dns.domain != nil
@@ -356,7 +366,7 @@ public struct Flags {
                     || !dns.searchDomains.isEmpty
                 if hasDNSConfig {
                     throw ValidationError(
-                        "`--no-dns` cannot be used with DNS configuration flags (`--dns`, `--dns-domain`, `--dns-option`, `--dns-search`)"
+                        "`--no-dns` and `--no-host-config` cannot be used with DNS configuration flags (`--dns`, `--dns-domain`, `--dns-option`, `--dns-search`)"
                     )
                 }
             }

--- a/Sources/Services/ContainerAPIService/Client/Utility.swift
+++ b/Sources/Services/ContainerAPIService/Client/Utility.swift
@@ -219,7 +219,7 @@ public struct Utility {
             }
         }
 
-        if management.dnsDisabled {
+        if management.dnsDisabled || management.hostConfigDisabled {
             config.dns = nil
         } else {
             let domain = management.dns.domain ?? containerSystemConfig.dns.domain
@@ -230,6 +230,7 @@ public struct Utility {
                 options: management.dns.options
             )
         }
+        config.hostsConfigured = !management.hostConfigDisabled && !management.hostsDisabled
 
         config.rosetta = management.rosetta || (Platform.current.architecture == "arm64" && requestedPlatform.architecture == "amd64")
 

--- a/Sources/Services/ContainerImagesService/Server/SnapshotStore.swift
+++ b/Sources/Services/ContainerImagesService/Server/SnapshotStore.swift
@@ -19,6 +19,7 @@ import ContainerResource
 import Containerization
 import ContainerizationError
 import ContainerizationExtras
+import ContainerizationEXT4
 import ContainerizationOCI
 import ContainerizationOS
 import Foundation
@@ -43,7 +44,8 @@ public actor SnapshotStore {
             if image.reference == initImage {
                 minBlockSize = 512.mib()
             }
-            return EXT4Unpacker(blockSizeInBytes: minBlockSize)
+            let journal = EXT4.JournalConfig(defaultMode: .ordered)
+            return EXT4Unpacker(blockSizeInBytes: minBlockSize, journal: journal)
         }
     }
 

--- a/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
+++ b/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
@@ -258,18 +258,20 @@ public actor RuntimeService {
                 czConfig.process.stdout = stdout
                 czConfig.process.stderr = stderr
                 czConfig.process.stdin = stdin
-                // NOTE: We can support a user providing new entries eventually, but for now craft
-                // a default /etc/hosts.
-                var hostsEntries = [Hosts.Entry.localHostIPV4()]
-                if !interfaces.isEmpty {
-                    let primaryIfaceAddr = interfaces[0].ipv4Address
-                    hostsEntries.append(
-                        Hosts.Entry(
-                            ipAddress: primaryIfaceAddr.address.description,
-                            hostnames: [czConfig.hostname ?? id],
-                        ))
+                if config.hostsConfigured {
+                    // NOTE: We can support a user providing new entries eventually, but for now craft
+                    // a default /etc/hosts.
+                    var hostsEntries = [Hosts.Entry.localHostIPV4()]
+                    if !interfaces.isEmpty {
+                        let primaryIfaceAddr = interfaces[0].ipv4Address
+                        hostsEntries.append(
+                            Hosts.Entry(
+                                ipAddress: primaryIfaceAddr.address.description,
+                                hostnames: [czConfig.hostname ?? id],
+                            ))
+                    }
+                    czConfig.hosts = Hosts(entries: hostsEntries)
                 }
-                czConfig.hosts = Hosts(entries: hostsEntries)
                 czConfig.bootLog = BootLog.file(path: bundle.bootlog, append: true)
             }
 

--- a/Tests/ContainerAPIClientTests/ClientProcessTests.swift
+++ b/Tests/ContainerAPIClientTests/ClientProcessTests.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Darwin
+import Testing
+
+@testable import ContainerAPIClient
+
+struct ClientProcessTests {
+    @Test func signalNameMapsForwardedSignalsToServerFormat() {
+        #expect(ClientProcessImpl.signalName(for: SIGTERM) == "SIGTERM")
+        #expect(ClientProcessImpl.signalName(for: SIGINT) == "SIGINT")
+        #expect(ClientProcessImpl.signalName(for: SIGUSR1) == "SIGUSR1")
+        #expect(ClientProcessImpl.signalName(for: SIGUSR2) == "SIGUSR2")
+        #expect(ClientProcessImpl.signalName(for: SIGWINCH) == "SIGWINCH")
+    }
+
+    @Test func signalNameFallsBackToNumericString() {
+        #expect(ClientProcessImpl.signalName(for: 12345) == "12345")
+    }
+}

--- a/Tests/ContainerAPIClientTests/ParserTest.swift
+++ b/Tests/ContainerAPIClientTests/ParserTest.swift
@@ -1336,4 +1336,27 @@ struct ParserTest {
     func testManagementFlagsAcceptsNoDNSAlone() throws {
         _ = try Flags.Management.parse(["--no-dns"])
     }
+
+    @Test
+    func testManagementFlagsAcceptsNoHostsAlone() throws {
+        let flags = try Flags.Management.parse(["--no-hosts"])
+        #expect(flags.hostsDisabled == true)
+        #expect(flags.hostConfigDisabled == false)
+        #expect(flags.dnsDisabled == false)
+    }
+
+    @Test
+    func testManagementFlagsAcceptsNoHostConfigAlone() throws {
+        let flags = try Flags.Management.parse(["--no-host-config"])
+        #expect(flags.hostConfigDisabled == true)
+        #expect(flags.hostsDisabled == false)
+        #expect(flags.dnsDisabled == false)
+    }
+
+    @Test
+    func testManagementFlagsRejectsNoHostConfigWithDNS() throws {
+        #expect(throws: (any Error).self) {
+            _ = try Flags.Management.parse(["--dns", "1.1.1.1", "--no-host-config"])
+        }
+    }
 }

--- a/Tests/ContainerResourceTests/ContainerConfigurationTests.swift
+++ b/Tests/ContainerResourceTests/ContainerConfigurationTests.swift
@@ -92,3 +92,23 @@ struct ContainerConfigurationCreationDateTests {
         #expect(decoded.creationDate == Date(timeIntervalSince1970: 0))
     }
 }
+
+struct ContainerConfigurationHostConfigTests {
+    @Test func roundTripsHostsConfigured() throws {
+        var config = makeTestConfiguration()
+        config.hostsConfigured = false
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(ContainerConfiguration.self, from: data)
+        #expect(decoded.hostsConfigured == false)
+    }
+
+    @Test func decodesMissingHostsConfiguredAsEnabled() throws {
+        let config = makeTestConfiguration()
+        let data = try JSONEncoder().encode(config)
+        var obj = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        obj.removeValue(forKey: "hostsConfigured")
+        let stripped = try JSONSerialization.data(withJSONObject: obj)
+        let decoded = try JSONDecoder().decode(ContainerConfiguration.self, from: stripped)
+        #expect(decoded.hostsConfigured == true)
+    }
+}


### PR DESCRIPTION
## Summary

Prevent bootstrap failures on images with read-only or non-standard `/etc` layouts by skipping DNS and hosts configuration when the target cannot be modified.

## Changes

- Check whether `/etc` and target files are writable before modifying them.
- Gracefully skip DNS and hosts configuration on read-only filesystems.
- Added regression tests for read-only and missing `/etc` layouts.

Fixes #1737