### PR TITLE
fix(builder): auto-detect Rosetta 2 availability, fall back to QEMU

### DIFF
--- a/Sources/ContainerCommands/Builder/BuilderStart.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStart.swift
@@ -193,7 +193,7 @@ extension Application {
                 }
             }
 
-            let useRosetta = containerSystemConfig.build.rosetta
+            let useRosetta = containerSystemConfig.build.rosetta && FileManager.default.fileExists(atPath: "/Library/Apple/usr/libexec/oah/libRosettaRuntime")
             let shimArguments = [
                 "--debug",
                 "--vsock",

--- a/docs/container-system-config.md
+++ b/docs/container-system-config.md
@@ -30,7 +30,7 @@ Resources and image used for the builder VM that runs `container build`.
 
 | Key       | Type        | Default                                              | Description                                                                 |
 |-----------|-------------|------------------------------------------------------|-----------------------------------------------------------------------------|
-| `rosetta` | `Bool`      | `true`                                               | Whether the builder VM uses Rosetta translation for non-native architectures. |
+| `rosetta` | `Bool`      | `true`                                               | Whether the builder VM uses Rosetta translation for non-native architectures. Rosetta is automatically disabled if not installed on the host; QEMU is used as a fallback. |
 | `cpus`    | `Int`       | `2`                                                  | CPU count for the builder VM.                                              |
 | `memory`  | [MemorySize](#memorysize-format)  | `"2048mb"`                                           | RAM allocation for the builder VM. |
 | `image`   | `String`    | `ghcr.io/apple/container-builder-shim/builder:<tag>` | Reference for the builder image. The tag segment is taken from the project's bundled `container-builder-shim` version. |

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -671,16 +671,16 @@ domain = "docker.io"
 image = "ghcr.io/apple/containerization/vminit:0.34.0"
 ```
 
-### Example: Disable Rosetta for builds
+### Rosetta and cross-platform builds
 
-If you want to prevent the use of Rosetta translation during container builds on Apple Silicon Macs, set the following in `~/.config/container/config.toml`:
+Rosetta translation is enabled by default when Rosetta 2 is installed. When building `amd64` images on an `arm64` Mac, the builder VM uses Rosetta 2 for x86-64 emulation if available. If Rosetta 2 is not installed, the builder falls back to QEMU automatically — no configuration needed.
+
+To always use QEMU instead of Rosetta, set the following in `~/.config/container/config.toml`:
 
 ```toml
 [build]
 rosetta = false
 ```
-
-This is useful when you want to ensure builds only produce native arm64 images and avoid any x86_64 emulation.
 
 ## View system logs
 


### PR DESCRIPTION
The builder VM enables Rosetta translation by default for x86_64 builds on Apple Silicon. This crashes when Rosetta 2 is not installed on the host.

**Root cause:** `BuilderStart.swift` unconditionally uses `containerSystemConfig.build.rosetta` (defaults to `true`) as the Rosetta enable flag for the builder VM. If Rosetta 2 is not installed, the VM creation fails.

**Fix:** Auto-detect Rosetta 2 at runtime by checking for the Rosetta runtime library at `/Library/Apple/usr/libexec/oah/libRosettaRuntime`. The builder only enables Rosetta if it's configured AND actually available. When unavailable, QEMU handles cross-architecture builds via `--enable-qemu`.

**Behavior matrix:**

| Rosetta 2 installed | Config `rosetta` | Result |
|---------------------|-------------------|--------|
| Yes | `true` (default) | Rosetta enabled (performance) |
| No | `true` (default) | QEMU fallback (no crash) |
| Yes/No | `false` | QEMU always (user explicit) |

**Changes:**
- `BuilderStart.swift`: 1-line change — add `&& FileManager.default.fileExists(...)` check
- `container-system-config.md`: document auto-detection behavior
- `how-to.md`: update Rosetta section to explain auto-detection

**AI disclosure:** Assisted by Claude Code (Claude Opus 4.8)

Closes #1825