### PR TITLE
Disable flaky CLI test temporarily.

### DIFF
--- a/Tests/CLITests/Subcommands/Containers/TestCLIPrune.swift
+++ b/Tests/CLITests/Subcommands/Containers/TestCLIPrune.swift
@@ -23,7 +23,8 @@ class TestCLIPruneCommand: CLITest {
         Test.current!.name.trimmingCharacters(in: ["(", ")"]).lowercased()
     }
 
-    @Test func testContainerPruneNoContainers() throws {
+    @Test(.disabled("flaky — prune picks up containers from concurrent suites; tests being rewritten"))
+    func testContainerPruneNoContainers() throws {
         let (_, _, error, status) = try run(arguments: ["prune"])
         if status != 0 {
             throw CLIError.executionFailed("container prune failed: \(error)")


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
PRs are backed up. We need to rework the CLI tests to shorten test time and fix conflicts between tests.

## Testing
- [ ] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs
