### PR TITLE
fix(version): preserve unspecified commit placeholder

### DIFF
--- a/Sources/ContainerVersion/ReleaseVersion.swift
+++ b/Sources/ContainerVersion/ReleaseVersion.swift
@@ -20,10 +20,17 @@ import Foundation
 public struct ReleaseVersion {
     public static func singleLine(appName: String) -> String {
         var versionDetails: [String: String] = ["build": buildType()]
-        versionDetails["commit"] = gitCommit().map { String($0.prefix(7)) } ?? "unspecified"
+        versionDetails["commit"] = displayCommit(gitCommit())
         let extras: String = versionDetails.map { "\($0): \($1)" }.sorted().joined(separator: ", ")
 
         return "\(appName) version \(version()) (\(extras))"
+    }
+
+    static func displayCommit(_ commit: String?) -> String {
+        guard let commit, !commit.isEmpty, commit != "unspecified" else {
+            return "unspecified"
+        }
+        return String(commit.prefix(7))
     }
 
     public static func buildType() -> String {

--- a/Tests/ContainerVersionTests/ReleaseVersionTests.swift
+++ b/Tests/ContainerVersionTests/ReleaseVersionTests.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import ContainerVersion
+
+struct ReleaseVersionTests {
+    @Test func displayCommitKeepsUnspecifiedPlaceholder() {
+        #expect(ReleaseVersion.displayCommit(nil) == "unspecified")
+        #expect(ReleaseVersion.displayCommit("") == "unspecified")
+        #expect(ReleaseVersion.displayCommit("unspecified") == "unspecified")
+    }
+
+    @Test func displayCommitShortensGitCommit() {
+        #expect(ReleaseVersion.displayCommit("1234567890abcdef") == "1234567")
+    }
+}


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
When `container` is built without a `GIT_COMMIT` value, the C version shim falls back to `unspecified`. `ReleaseVersion.singleLine(appName:)` shortened every non-nil commit string to seven characters, so the user-facing version banner displayed `commit: unspeci` instead of the complete placeholder.

This keeps missing or placeholder commit values as `unspecified`, while preserving the seven-character display for real commit hashes.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

Validated with:

```sh
swift test --disable-automatic-resolution --filter ContainerVersionTests
env -u GIT_COMMIT swift build --disable-automatic-resolution --product container
.build/debug/container --version
```

The local version smoke check prints:

```text
container CLI version 0.0.0 (build: debug, commit: unspecified)
```
