### PR TITLE
Fix machine run ENOEXEC for amd64 machines on arm64 host

### DIFF
--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -334,7 +334,6 @@ public actor ContainersService {
             }
 
             let path = self.containerRoot.appendingPathComponent(configuration.id)
-            let systemPlatform = kernel.platform
 
             // Fetch init image (custom or default)
             self.log.debug(

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -343,7 +343,7 @@ public actor ContainersService {
                     "id": "\(configuration.id)"
                 ]
             )
-            let initFilesystem = try await self.getInitBlock(for: systemPlatform.ociPlatform(), imageRef: initImage)
+            let initFilesystem = try await self.getInitBlock(for: SystemPlatform.current.ociPlatform(), imageRef: initImage)
 
             do {
                 self.log.debug(

--- a/Sources/Services/MachineAPIService/Server/MachinesService.swift
+++ b/Sources/Services/MachineAPIService/Server/MachinesService.swift
@@ -378,7 +378,7 @@ public actor MachinesService {
                     platform: self.systemPlatform(from: state.snapshot.configuration.platform)
                 )
             } else {
-                kernel = try await ClientKernel.getDefaultKernel(for: .current)
+                kernel = try await ClientKernel.getDefaultKernel(for: self.systemPlatform(from: state.snapshot.configuration.platform))
             }
 
             var fhs: [FileHandle] = []


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context

Fixes #1843.

`MachinesService.boot()` calls `ClientKernel.getDefaultKernel(for: .current)` when no custom kernel path is configured. On Apple Silicon, `.current` resolves to `.linuxArm`, so AMD64 machines boot with the `default-arm64` kernel binary instead of `default-amd64`.

The two are distinct binaries. The `default-amd64` kernel is compiled with the Rosetta and binfmt_misc support required to run AMD64 userspace on ARM64 hosts. Without it, non-root exec processes fail with `ENOEXEC` (errno=8) when attempting to run AMD64 binaries through the binfmt_misc handler.

This is why the machine itself boots (PID 1 runs as root, unaffected) but `container machine run -n ubuntu uname` fails (uses the host user uid, which is non-root).

The custom kernel path branch in the same function already handled this correctly via `self.systemPlatform(from: state.snapshot.configuration.platform)`. The default kernel path branch was inconsistent with it.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

Reproduced with the steps in #1843 and confirmed `container machine run -n ubuntu uname -a` succeeds after the fix.
