### PR TITLE
commands: replace force-try with try in DNS create and delete

### DIFF
--- a/Sources/ContainerCommands/System/DNS/DNSCreate.swift
+++ b/Sources/ContainerCommands/System/DNS/DNSCreate.swift
@@ -64,7 +64,7 @@ extension Application {
 
             let pf = PacketFilter()
             if let from = localhostIP {
-                let to = try! IPAddress("127.0.0.1")
+                let to = try IPAddress("127.0.0.1")
                 do {
                     try pf.createRedirectRule(from: from, to: to, domain: domainName)
                 } catch {

--- a/Sources/ContainerCommands/System/DNS/DNSDelete.swift
+++ b/Sources/ContainerCommands/System/DNS/DNSDelete.swift
@@ -62,7 +62,7 @@ extension Application {
             }
 
             let pf = PacketFilter()
-            try pf.removeRedirectRule(from: localhostIP, to: try! IPAddress("127.0.0.1"), domain: domainName)
+            try pf.removeRedirectRule(from: localhostIP, to: try IPAddress("127.0.0.1"), domain: domainName)
 
             do {
                 try pf.reinitialize()


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context
`IPAddress("127.0.0.1")` is called inside `async throws` functions in `DNSCreate` and `DNSDelete`. The force-try (`try!`) is unnecessary — the surrounding function already propagates errors. This replaces both with `try` to comply with the `NeverUseForceTry` rule enforced by swift-format.

## Testing
- [x] Tested locally
- [x] `make test` passes (561 tests)