### PR TITLE
commands: replace force-unwrap with optional chaining in ImagePrune

### DIFF
--- a/Sources/ContainerCommands/Image/ImagePrune.swift
+++ b/Sources/ContainerCommands/Image/ImagePrune.swift
@@ -88,7 +88,7 @@ extension Application {
         private func hasTag(_ reference: String) -> Bool {
             do {
                 let ref = try ContainerizationOCI.Reference.parse(reference)
-                return ref.tag != nil && !ref.tag!.isEmpty
+                return ref.tag?.isEmpty == false
             } catch {
                 return false
             }


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context
In `ImagePrune.hasTag(_:)`, `ref.tag` is checked for `nil` and then immediately force-unwrapped on the same line:

```swift
return ref.tag != nil && !ref.tag!.isEmpty
```

This is unnecessary — Swift's optional chaining handles both cases without a crash risk:

```swift
return ref.tag?.isEmpty == false
```

This complies with the `NeverForceUnwrap` rule enforced by swift-format.

## Testing
- [x] Tested locally
- [x] `make test` passes (561 tests)