### PR TITLE
xpc: replace precondition+force-unwrap with guard-let in XPCMessage

### DIFF
--- a/Sources/ContainerXPC/XPCMessage.swift
+++ b/Sources/ContainerXPC/XPCMessage.swift
@@ -78,10 +78,10 @@ extension XPCMessage {
     public func error() throws {
         let data = data(key: Self.errorKey)
         if let data {
-            let item = try? JSONDecoder().decode(ContainerXPCError.self, from: data)
-            precondition(item != nil, "expected to receive a ContainerXPCXPCError")
-
-            throw ContainerizationError(item!.code, message: item!.message)
+            guard let item = try? JSONDecoder().decode(ContainerXPCError.self, from: data) else {
+                preconditionFailure("expected to receive a ContainerXPCError")
+            }
+            throw ContainerizationError(item.code, message: item.message)
         }
     }
 
@@ -91,10 +91,10 @@ extension XPCMessage {
             message += " (cause: \"\(cause)\")"
         }
         let serializableError = ContainerXPCError(code: error.code.description, message: message)
-        let data = try? JSONEncoder().encode(serializableError)
-        precondition(data != nil)
-
-        set(key: Self.errorKey, value: data!)
+        guard let data = try? JSONEncoder().encode(serializableError) else {
+            preconditionFailure("failed to encode ContainerXPCError")
+        }
+        set(key: Self.errorKey, value: data)
     }
 }
 


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context
In `XPCMessage`, two methods use a `precondition(x != nil)` + immediate force-unwrap pattern, which violates `NeverForceUnwrap`:

```swift
// error()
let item = try? JSONDecoder().decode(ContainerXPCError.self, from: data)
precondition(item != nil, "expected to receive a ContainerXPCXPCError")
throw ContainerizationError(item!.code, message: item!.message)

// set(error:)
let data = try? JSONEncoder().encode(serializableError)
precondition(data != nil)
set(key: Self.errorKey, value: data!)
```

Both replaced with `guard let` + `preconditionFailure`, which expresses the same invariant without force-unwrap. Also fixed a typo in the error message (`ContainerXPCXPCError` → `ContainerXPCError`).

## Testing
- [x] Tested locally
- [x] `make test` passes