### PR TITLE
persistence: replace .first! with guard-let in basePath(env:)

### DIFF
--- a/Sources/ContainerPersistence/PathUtils.swift
+++ b/Sources/ContainerPersistence/PathUtils.swift
@@ -38,11 +38,15 @@ public enum PathUtils {
                 if let envPath = env["CONTAINER_APP_ROOT"], !envPath.isEmpty {
                     return FilePath(envPath)
                 }
-                let appSupportURL = FileManager.default.urls(
-                    for: .applicationSupportDirectory,
-                    in: .userDomainMask
-                ).first!.appendingPathComponent("com.apple.container")
-                return FilePath(appSupportURL.path(percentEncoded: false))
+                guard
+                    let appSupportURL = FileManager.default.urls(
+                        for: .applicationSupportDirectory,
+                        in: .userDomainMask
+                    ).first
+                else {
+                    fatalError("applicationSupportDirectory unavailable in userDomainMask")
+                }
+                return FilePath(appSupportURL.appendingPathComponent("com.apple.container").path(percentEncoded: false))
             case .installRoot:
                 if let envPath = env["CONTAINER_INSTALL_ROOT"], !envPath.isEmpty {
                     return FilePath(envPath)


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context
In `PathUtils.BaseConfigPath.basePath(env:)`, the `.appRoot` case calls `FileManager.default.urls(for:in:)` and immediately force-unwraps `.first!`:

```swift
let appSupportURL = FileManager.default.urls(
    for: .applicationSupportDirectory,
    in: .userDomainMask
).first!.appendingPathComponent("com.apple.container")
```

This violates `NeverForceUnwrap`. Replaced with `guard let` + `fatalError`:

```swift
guard let appSupportURL = FileManager.default.urls(
    for: .applicationSupportDirectory,
    in: .userDomainMask
).first else {
    fatalError("applicationSupportDirectory unavailable in userDomainMask")
}
return FilePath(appSupportURL.appendingPathComponent("com.apple.container").path(percentEncoded: false))
```

## Testing
- [x] Tested locally
- [x] `make test` passes