### PR TITLE
Remove SIGWINCH from signal kill set

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/ProcessIO.swift
+++ b/Sources/Services/ContainerAPIService/Client/ProcessIO.swift
@@ -30,7 +30,6 @@ public struct ProcessIO: Sendable {
         SIGINT,
         SIGUSR1,
         SIGUSR2,
-        SIGWINCH,
     ]
 
     public struct IoTracker: Sendable {


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context

Fixes #1747.

`SIGWINCH` is a terminal geometry notification — its POSIX-defined purpose is to inform a process that the controlling terminal's window size has changed. It is not a process-control signal and has no meaningful effect when delivered via `kill(2)` to a process without a controlling terminal.

`ProcessIO.signalSet` included `SIGWINCH` alongside `SIGTERM`, `SIGINT`, `SIGUSR1`, and `SIGUSR2`. In non-TTY mode (`console == nil`), `handleProcess` iterates `signalSet` and forwards every received signal through `process.kill(sig)`. This caused host terminal resize events to produce a logged error on stderr:

```
failed to send signal: ["error": invalidArgument: "missing signal in xpc message", "signal": 28]
```

There is no valid use case for forwarding `SIGWINCH` as a kill signal in non-TTY mode — the container has no pseudo-terminal whose geometry could change.

**TTY mode is unaffected.** In TTY mode (`console != nil`), the `signals` task is never added to the task group. A separate `winchHandler` registers independently for `[SIGWINCH]` and routes it to `process.resize()`, which is the correct handler. Removing `SIGWINCH` from `signalSet` does not touch this path.

As a secondary benefit, this also eliminates a redundant `DispatchSourceSignal` registration for `SIGWINCH` in TTY mode: previously both `signals` (via `signalSet`) and `winchHandler` registered for the same signal, with `signals` never consumed in the TTY branch.

## Testing
- [x] Tested locally
- [x] `make test` passes