### PR TITLE
ContainerLog: add metadataProvider to LogHandler implementations

### DIFF
--- a/Sources/ContainerLog/FileLogHandler.swift
+++ b/Sources/ContainerLog/FileLogHandler.swift
@@ -23,6 +23,7 @@ import SystemPackage
 public struct FileLogHandler: LogHandler {
     public var logLevel: Logger.Level = .info
     public var metadata: Logger.Metadata = [:]
+    public var metadataProvider: Logger.MetadataProvider?
 
     private let label: String
     private let category: String
@@ -76,8 +77,10 @@ public struct FileLogHandler: LogHandler {
         }()
         let timestamp = timestampFormatter.string(from: Date())
 
-        // Merge logger-level metadata with per-message metadata
         var effectiveMetadata = self.metadata
+        if let provided = self.metadataProvider?.get(), !provided.isEmpty {
+            effectiveMetadata.merge(provided) { _, new in new }
+        }
         if let metadata {
             effectiveMetadata.merge(metadata) { _, new in new }
         }

--- a/Sources/ContainerLog/OSLogHandler.swift
+++ b/Sources/ContainerLog/OSLogHandler.swift
@@ -24,13 +24,8 @@ public struct OSLogHandler: LogHandler {
     private let logger: os.Logger
 
     public var logLevel: Logger.Level = .info
-    private var formattedMetadata: String?
-
-    public var metadata = Logger.Metadata() {
-        didSet {
-            self.formattedMetadata = self.formatMetadata(self.metadata)
-        }
-    }
+    public var metadataProvider: Logger.MetadataProvider?
+    public var metadata = Logger.Metadata()
 
     public subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {
         get {
@@ -56,14 +51,14 @@ extension OSLogHandler {
         function: String,
         line: UInt
     ) {
-        var formattedMetadata = self.formattedMetadata
-        if let metadataOverride = metadata, !metadataOverride.isEmpty {
-            formattedMetadata = self.formatMetadata(
-                self.metadata.merging(metadataOverride) {
-                    $1
-                }
-            )
+        var effectiveMetadata = self.metadata
+        if let provided = self.metadataProvider?.get(), !provided.isEmpty {
+            effectiveMetadata.merge(provided) { _, new in new }
         }
+        if let metadataOverride = metadata, !metadataOverride.isEmpty {
+            effectiveMetadata.merge(metadataOverride) { _, new in new }
+        }
+        let formattedMetadata = self.formatMetadata(effectiveMetadata)
 
         var finalMessage = message.description
         if let formattedMetadata {

--- a/Sources/ContainerLog/StderrLogHandler.swift
+++ b/Sources/ContainerLog/StderrLogHandler.swift
@@ -22,6 +22,7 @@ import Logging
 public struct StderrLogHandler: LogHandler {
     public var logLevel: Logger.Level = .info
     public var metadata: Logger.Metadata = [:]
+    public var metadataProvider: Logger.MetadataProvider?
 
     public subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {
         get {
@@ -43,13 +44,21 @@ public struct StderrLogHandler: LogHandler {
         function: String,
         line: UInt
     ) {
+        var effectiveMetadata = self.metadata
+        if let provided = self.metadataProvider?.get(), !provided.isEmpty {
+            effectiveMetadata.merge(provided) { _, new in new }
+        }
+        if let metadata, !metadata.isEmpty {
+            effectiveMetadata.merge(metadata) { _, new in new }
+        }
+
         let data: Data
         switch logLevel {
         case .debug, .trace:
             let timestamp = isoTimestamp()
-            if let metadata, !metadata.isEmpty {
+            if !effectiveMetadata.isEmpty {
                 data =
-                    "\(timestamp) \(message.description): \(metadata.description)\n"
+                    "\(timestamp) \(message.description): \(effectiveMetadata.description)\n"
                     .data(using: .utf8) ?? Data()
             } else {
                 data =
@@ -57,9 +66,9 @@ public struct StderrLogHandler: LogHandler {
                     .data(using: .utf8) ?? Data()
             }
         default:
-            if let metadata, !metadata.isEmpty {
+            if !effectiveMetadata.isEmpty {
                 data =
-                    "\(message.description): \(metadata.description)\n"
+                    "\(message.description): \(effectiveMetadata.description)\n"
                     .data(using: .utf8) ?? Data()
             } else {
                 data =


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context

Resolves #1754.

The `LogHandler` protocol in swift-log 1.5+ requires conforming types to
declare `var metadataProvider: Logger.MetadataProvider? { get set }`. The
three handlers in `ContainerLog` — `StderrLogHandler`, `OSLogHandler`,
and `FileLogHandler` — were missing this property. The protocol's default
extension emits a runtime warning in DEBUG builds whenever a
`MetadataProvider` is attached to a handler that doesn't implement the
property, which surfaces as build noise in downstream projects that import
`ContainerLog` (e.g. reported in #1754 via `stephenlclarke/container-compose`).

**Changes per handler:**

- **`StderrLogHandler`**: Added `metadataProvider` property. Also corrected
  a pre-existing gap: the original `log()` used only the per-call `metadata`
  parameter and silently ignored handler-level `self.metadata`. The updated
  implementation merges all three sources in the canonical priority order
  (handler-level → provider → per-call), matching `StreamLogHandler.prepareMetadata`.

- **`OSLogHandler`**: Added `metadataProvider` property. Removed the
  `formattedMetadata` cache and its `didSet` observer — a dynamic provider
  (which may read task-local values) requires per-call computation, making
  the cached value incorrect. Updated `log()` to merge all three sources in
  the same priority order.

- **`FileLogHandler`**: Added `metadataProvider` property. Inserted the
  provider merge step between handler-level and per-call metadata in the
  existing `log()` merge sequence.

All three handlers now follow the merge order defined in
`StreamLogHandler.prepareMetadata`: handler-level metadata as the base,
provider overwrites it, per-call metadata overwrites that.

## Testing
- [x] Tested locally
- [x] `make test` passes