### PR TITLE
fix: preserve container bundles on load failure; write bundle files atomically

### DIFF
--- a/Sources/ContainerResource/Container/Bundle.swift
+++ b/Sources/ContainerResource/Container/Bundle.swift
@@ -160,7 +160,9 @@ extension Bundle {
 
     private static func write(_ path: URL, value: Encodable) throws {
         let data = try JSONEncoder().encode(value)
-        try data.write(to: path)
+        // Write atomically so a crash mid-write cannot leave a truncated file
+        // that later fails to decode (and gets the bundle deleted on reload).
+        try data.write(to: path, options: .atomic)
     }
 
     public func load<T>(filename: String) throws -> T where T: Decodable {

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -148,9 +148,11 @@ public actor ContainersService {
                     )
                 }
             } catch {
-                try? FileManager.default.removeItem(at: dir)
+                // Do not delete the bundle here: load failures can be transient
+                // (e.g. a runtime plugin that is not yet registered), and the
+                // on-disk bundle is the user's data. Leave it for the next boot.
                 log.warning(
-                    "failed to load container",
+                    "failed to load container; leaving bundle on disk",
                     metadata: [
                         "path": "\(dir.path)",
                         "error": "\(error)",


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
`ContainersService.loadAtBoot` wraps each container load in a `do/catch`, and the `catch` runs `try? FileManager.default.removeItem(at: dir)` — deleting the entire on-disk bundle on **any** error. Some of those errors are transient and unrelated to bundle integrity. For example, a runtime plugin that is not yet registered throws `internalError`, which then destroys the user's container directory.

A contributing root cause: `Bundle.write` persists JSON with a plain `data.write(to:)` (non-atomic). A crash or power loss mid-write can leave a truncated file that fails to decode on the next boot — which then triggers the deletion path above, turning a recoverable torn write into permanent data loss.

This change:
- `Bundle.write` now writes with `.atomic`, so an interrupted write cannot leave a corrupt file behind.
- `loadAtBoot` no longer deletes the bundle on load errors; it logs and leaves the bundle on disk so a transient failure (e.g. a plugin that registers later) does not cause data loss.

No behavior change on the success path.

## Testing
- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

_Verified by static / code-level review; not built locally (no macOS 26 toolchain available here) — CI build will validate._
