### PR TITLE
fix: re-validate container status under lock before delete (TOCTOU)

### DIFF
--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -869,6 +869,20 @@ public actor ContainersService {
             )
         default:
             try await self.lock.withLock(logMetadata: ["acquirer": "\(#function)", "id": "\(id)"]) { context in
+                // Re-read status under the lock. The check above ran unlocked, and
+                // startProcess holds this same lock while transitioning a container
+                // to .running — without this re-check we could delete the bundle of
+                // a container that started in the meantime (TOCTOU).
+                let current = try self.getContainerState(id: id, context: context)
+                switch current.snapshot.status {
+                case .running, .stopping:
+                    throw ContainerizationError(
+                        .invalidState,
+                        message: "container \(id) is \(current.snapshot.status) and can not be deleted"
+                    )
+                default:
+                    break
+                }
                 try await self.cleanUp(id: id, context: context)
             }
         }


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
`ContainersService.delete` reads the container status **outside** the lock, then in the `default` branch acquires the lock and calls `cleanUp` without re-checking status. `startProcess` holds the same lock while transitioning a container to `.running` and writing the state back. Between the unlocked read and acquiring the lock, a container observed as stopped can start; `cleanUp` only guards on `containers[id] == nil`, not status, so it then deletes the bundle of a now-running container (TOCTOU).

This change re-reads the status **inside** the lock in the `default` branch and refuses the delete if the container has since become `.running`/`.stopping`, mirroring the existing message used for the non-forced running case. Only the non-forced delete path changes; the `--force` path is unchanged.

## Testing
- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

_Verified by static / code-level review; not built locally (no macOS 26 toolchain available here) — CI build will validate._
