### PR TITLE
fix: avoid UInt32 underflow sizing the address allocator for small subnets

### DIFF
--- a/Sources/Services/Network/Server/DefaultNetworkService.swift
+++ b/Sources/Services/Network/Server/DefaultNetworkService.swift
@@ -37,7 +37,16 @@ public actor DefaultNetworkService: NetworkService {
         }
 
         let subnet = status.ipv4Subnet
-        let size = Int(subnet.upper.value - subnet.lower.value - 3)
+        // Widen to Int before subtracting: doing the arithmetic in UInt32 traps
+        // on underflow when the subnet is too small (e.g. a /31 where
+        // upper - lower < 3).
+        let size = Int(subnet.upper.value) - Int(subnet.lower.value) - 3
+        guard size > 0 else {
+            throw ContainerizationError(
+                .invalidState,
+                message: "network \(network.id) subnet is too small to allocate addresses"
+            )
+        }
         self.network = network
         self.log = log
         self.allocator = try AttachmentAllocator(lower: subnet.lower.value + 2, size: size)


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
`DefaultNetworkService.init` computes the allocatable address count as `Int(subnet.upper.value - subnet.lower.value - 3)`. `upper.value` and `lower.value` are `UInt32`, so the subtraction happens in `UInt32` **before** the widening to `Int`. For a subnet where `upper - lower < 3` (e.g. a `/31`), this underflows and traps at runtime instead of producing a non-positive count.

This change widens to `Int` before subtracting, and guards that the resulting size is positive — throwing `invalidState` for a subnet too small to allocate from, rather than trapping. No change for normally-sized subnets; this only affects degenerate small subnets that previously crashed.

## Testing
- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

_Verified by static / code-level review; not built locally (no macOS 26 toolchain available here) — CI build will validate._
