### PR TITLE
Add checksum validation to hawkeye installation

### DIFF
--- a/scripts/ensure-hawkeye-exists.sh
+++ b/scripts/ensure-hawkeye-exists.sh
@@ -58,11 +58,9 @@ cat <<EOF
 
 hawkeye is not installed.
 
-scripts/install-hawkeye.sh will install it by running:
+scripts/install-hawkeye.sh will install hawkeye by downloading the official release tarball
 
-    curl -LsSf https://github.com/korandoru/hawkeye/releases/download/<version>/hawkeye-installer.sh | sh
-
-and performs the installation by passing the downloaded content to \`sh\`.
+and installing the binary under `.local/bin`.
 
 (See scripts/install-hawkeye.sh for the pinned version.)
 EOF

--- a/scripts/install-hawkeye.sh
+++ b/scripts/install-hawkeye.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash 
+#!/usr/bin/env bash
 # Copyright © 2025-2026 Apple Inc. and the container project authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,10 +13,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -euo pipefail
+
 if command -v .local/bin/hawkeye >/dev/null 2>&1; then
     echo "hawkeye already installed"
-else
-    echo "Installing hawkeye"
-    export VERSION=v6.5.1
-    curl --proto '=https' --tlsv1.2 -LsSf https://github.com/korandoru/hawkeye/releases/download/${VERSION}/hawkeye-installer.sh | CARGO_HOME=.local sh -s -- --no-modify-path
+    exit 0
 fi
+
+# This installer supports Apple silicon (arm64 macOS) only.
+if [ "$(uname -s)" != "Darwin" ] || [ "$(uname -m)" != "arm64" ]; then
+    echo "error: install-hawkeye.sh supports Apple silicon (arm64 macOS) only" >&2
+    exit 1
+fi
+
+VERSION=v6.5.1
+ARTIFACT="hawkeye-aarch64-apple-darwin.tar.xz"
+ARTIFACT_URL="https://github.com/korandoru/hawkeye/releases/download/${VERSION}/${ARTIFACT}"
+# Pinned SHA-256 of ${ARTIFACT} for ${VERSION}; update when bumping VERSION.
+EXPECTED_SHA256="99777f21e4e56c9946ed93621885532c6a0476377f497565c583f5911f2cbb1f"
+
+echo "Installing hawkeye ${VERSION}"
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+tarball="${workdir}/${ARTIFACT}"
+
+# Download the tarball, verify it against the pinned checksum (aborts on
+# mismatch), then extract just the hawkeye binary into .local/bin.
+curl --proto '=https' --tlsv1.2 -LsSf "${ARTIFACT_URL}" -o "${tarball}"
+echo "${EXPECTED_SHA256}  ${tarball}" | shasum -a 256 -c -
+
+tar -xf "${tarball}" --strip-components 1 -C "${workdir}"
+mkdir -p .local/bin
+mv "${workdir}/hawkeye" .local/bin/hawkeye
+chmod +x .local/bin/hawkeye
+
+echo "hawkeye ${VERSION} installed to .local/bin/hawkeye"


### PR DESCRIPTION
## Motivation and Context
[Hawkeye](https://github.com/korandoru/hawkeye) is used to ensure files in this repository contain the correct licensing information. Hawkeye is used both by developers when preparing a pull request and by our CI workflows as a gate check for pull request approval. 

This PR changes our Hawkeye installation script away from that provided in the Hawkeye release to one that validates the checksum of the downloaded release archive. This PR will break existing anyone using the `scripts/install-hawkeye.sh` script to install Hawkeye on architectures other than Apple Silicon. Since Apple Silicon is required for building this repository, I do not consider this a breaking change. 

## Testing
- [x] Tested locally