### PR TITLE
Read registry credentials in the CLI, not the images helper

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -307,6 +307,15 @@ let package = Package(
             ],
             path: "Sources/Services/ContainerImagesService/Client"
         ),
+        .testTarget(
+            name: "ContainerImagesServiceTests",
+            dependencies: [
+                .product(name: "ContainerizationOCI", package: "containerization"),
+                "ContainerImagesService",
+                "ContainerImagesServiceClient",
+                "ContainerXPC",
+            ]
+        ),
         .executableTarget(
             name: "container-network-vmnet",
             dependencies: [

--- a/Sources/Services/ContainerAPIService/Client/ClientImage.swift
+++ b/Sources/Services/ContainerAPIService/Client/ClientImage.swift
@@ -271,6 +271,10 @@ extension ClientImage {
         request.set(key: .insecureFlag, value: insecure)
         request.set(key: .maxConcurrentDownloads, value: Int64(maxConcurrentDownloads))
 
+        if let authorization = try await Self.registryAuthorization(for: reference) {
+            request.set(key: .registryAuthorization, value: authorization)
+        }
+
         var progressUpdateClient: ProgressUpdateClient?
         if let progressUpdate {
             progressUpdateClient = await ProgressUpdateClient(for: progressUpdate, request: request)
@@ -282,6 +286,35 @@ extension ClientImage {
 
         await progressUpdateClient?.finish()
         return image
+    }
+
+    /// Resolve registry credentials from the keychain and return the
+    /// `Authorization` header value to forward to the images helper.
+    ///
+    /// The lookup runs in this client process, which for `container image
+    /// pull`/`push` and `container build` is always the `container` CLI binary
+    /// (`com.apple.container.cli`). That is the same code identity that
+    /// `container registry login` uses when it writes the keychain item, so the
+    /// item's access control accepts this read. The images helper runs under a
+    /// different identity (`com.apple.container.container-core-images`) and is
+    /// rejected by that access control, so it must not read the keychain itself.
+    ///
+    /// Returns `nil` when no stored credentials exist for the reference's host.
+    private static func registryAuthorization(for reference: String) async throws -> String? {
+        guard let host = try Reference.parse(reference).resolvedDomain else {
+            return nil
+        }
+        let keychain = KeychainHelper(securityDomain: Constants.keychainID)
+        let auth: Authentication
+        do {
+            auth = try keychain.lookup(hostname: host)
+        } catch let err as KeychainHelper.Error {
+            guard case .keyNotFound = err else {
+                throw ContainerizationError(.internalError, message: "error querying keychain for \(host)", cause: err)
+            }
+            return nil
+        }
+        return try await auth.token()
     }
 
     public static func delete(reference: String, garbageCollect: Bool = false) async throws {
@@ -394,6 +427,10 @@ extension ClientImage {
         request.set(key: .insecureFlag, value: insecure)
 
         try request.set(platform: platform)
+
+        if let authorization = try await Self.registryAuthorization(for: reference) {
+            request.set(key: .registryAuthorization, value: authorization)
+        }
 
         var progressUpdateClient: ProgressUpdateClient?
         if let progressUpdate {

--- a/Sources/Services/ContainerImagesService/Client/ImageServiceXPCKeys.swift
+++ b/Sources/Services/ContainerImagesService/Client/ImageServiceXPCKeys.swift
@@ -38,6 +38,9 @@ public enum ImagesServiceXPCKeys: String {
     case maxConcurrentDownloads
     case forceLoad
     case rejectedMembers
+    /// Pre-resolved registry `Authorization` header value, read from the
+    /// keychain on the client (CLI) side and forwarded to the images helper.
+    case registryAuthorization
 
     /// ContentStore
     case digest

--- a/Sources/Services/ContainerImagesService/Server/ImagesService.swift
+++ b/Sources/Services/ContainerImagesService/Server/ImagesService.swift
@@ -79,7 +79,7 @@ public actor ImagesService {
         return try await imageStore.list().map { $0.description.fromCZ }
     }
 
-    public func pull(reference: String, platform: Platform?, insecure: Bool, progressUpdate: ProgressUpdateHandler?, maxConcurrentDownloads: Int = 3) async throws
+    public func pull(reference: String, platform: Platform?, insecure: Bool, auth: Authentication?, progressUpdate: ProgressUpdateHandler?, maxConcurrentDownloads: Int = 3) async throws
         -> ImageDescription
     {
         self.log.debug(
@@ -103,7 +103,7 @@ public actor ImagesService {
             )
         }
 
-        let img = try await Self.withAuthentication(ref: reference) { auth in
+        let img = try await Self.withAuthentication(ref: reference, auth: auth) { auth in
             try await self.imageStore.pull(
                 reference: reference, platform: platform, insecure: insecure, auth: auth, progress: ContainerizationProgressAdapter.handler(from: progressUpdate),
                 maxConcurrentDownloads: maxConcurrentDownloads)
@@ -114,7 +114,7 @@ public actor ImagesService {
         return img.description.fromCZ
     }
 
-    public func push(reference: String, platform: Platform?, insecure: Bool, progressUpdate: ProgressUpdateHandler?) async throws {
+    public func push(reference: String, platform: Platform?, insecure: Bool, auth: Authentication?, progressUpdate: ProgressUpdateHandler?) async throws {
         self.log.debug(
             "ImagesService: enter",
             metadata: [
@@ -135,7 +135,7 @@ public actor ImagesService {
             )
         }
 
-        try await Self.withAuthentication(ref: reference) { auth in
+        try await Self.withAuthentication(ref: reference, auth: auth) { auth in
             try await self.imageStore.push(
                 reference: reference, platform: platform, insecure: insecure, auth: auth, progress: ContainerizationProgressAdapter.handler(from: progressUpdate))
         }
@@ -412,25 +412,20 @@ extension ImagesService {
 
 extension ImagesService {
     private static func withAuthentication<T>(
-        ref: String, _ body: @Sendable @escaping (_ auth: Authentication?) async throws -> T?
+        ref: String, auth: Authentication?, _ body: @Sendable @escaping (_ auth: Authentication?) async throws -> T?
     ) async throws -> T? {
-        var authentication: Authentication?
         let ref = try Reference.parse(ref)
         guard let host = ref.resolvedDomain else {
             throw ContainerizationError(.invalidArgument, message: "no host specified in image reference: \(ref)")
         }
-        authentication = Self.authenticationFromEnv(host: host)
-        if let authentication {
-            return try await body(authentication)
-        }
-        let keychain = KeychainHelper(securityDomain: Constants.keychainID)
-        do {
-            authentication = try keychain.lookup(hostname: host)
-        } catch let err as KeychainHelper.Error {
-            guard case .keyNotFound = err else {
-                throw ContainerizationError(.internalError, message: "error querying keychain for \(host)", cause: err)
-            }
-        }
+        // Environment credentials take precedence, preserving prior behavior.
+        // Keychain credentials are resolved on the client (CLI) side and passed
+        // in as `auth`. This helper must not read the keychain itself: its code
+        // identity (`com.apple.container.container-core-images`) differs from the
+        // writer's (`com.apple.container.cli`), so the keychain item's access
+        // control would reject the read and securityd would fail it with
+        // errSecInteractionNotAllowed in this non-interactive process.
+        let authentication = Self.authenticationFromEnv(host: host) ?? auth
         do {
             return try await body(authentication)
         } catch let err as RegistryClient.Error {
@@ -456,6 +451,19 @@ extension ImagesService {
             return nil
         }
         return BasicAuthentication(username: user, password: password)
+    }
+}
+
+/// An `Authentication` backed by a pre-resolved `Authorization` header value.
+///
+/// Registry credentials are read from the keychain on the client (CLI) side and
+/// the resulting header is forwarded to the images helper over XPC, so the
+/// helper never reads the keychain itself.
+struct ResolvedAuthentication: Authentication {
+    let authorization: String
+
+    func token() async throws -> String {
+        authorization
     }
 }
 

--- a/Sources/Services/ContainerImagesService/Server/ImagesServiceHarness.swift
+++ b/Sources/Services/ContainerImagesService/Server/ImagesServiceHarness.swift
@@ -33,6 +33,19 @@ public struct ImagesServiceHarness: Sendable {
         self.service = service
     }
 
+    /// Build the registry `Authentication` forwarded from the CLI over XPC, or
+    /// nil when the request carried no credentials.
+    ///
+    /// Registry credentials are read from the keychain on the CLI side (the
+    /// `com.apple.container.cli` identity that wrote them) and forwarded here as
+    /// an `Authorization` header value. The images helper must not read the
+    /// keychain itself: its distinct code identity is rejected by the item's
+    /// access control, and securityd fails the read with
+    /// errSecInteractionNotAllowed (-25308) in this non-interactive process.
+    static func authentication(from message: XPCMessage) -> Authentication? {
+        message.string(key: .registryAuthorization).map { ResolvedAuthentication(authorization: $0) as Authentication }
+    }
+
     @Sendable
     public func pull(_ message: XPCMessage) async throws -> XPCMessage {
         let ref = message.string(key: .imageReference)
@@ -49,7 +62,7 @@ public struct ImagesServiceHarness: Sendable {
         }
         let insecure = message.bool(key: .insecureFlag)
         let maxConcurrentDownloads = message.int64(key: .maxConcurrentDownloads)
-        let auth = message.string(key: .registryAuthorization).map { ResolvedAuthentication(authorization: $0) }
+        let auth = Self.authentication(from: message)
 
         let progressUpdateService = ProgressUpdateService(message: message)
         let imageDescription = try await service.pull(
@@ -76,7 +89,7 @@ public struct ImagesServiceHarness: Sendable {
             platform = try JSONDecoder().decode(ContainerizationOCI.Platform.self, from: platformData)
         }
         let insecure = message.bool(key: .insecureFlag)
-        let auth = message.string(key: .registryAuthorization).map { ResolvedAuthentication(authorization: $0) }
+        let auth = Self.authentication(from: message)
 
         let progressUpdateService = ProgressUpdateService(message: message)
         try await service.push(reference: ref, platform: platform, insecure: insecure, auth: auth, progressUpdate: progressUpdateService?.handler)

--- a/Sources/Services/ContainerImagesService/Server/ImagesServiceHarness.swift
+++ b/Sources/Services/ContainerImagesService/Server/ImagesServiceHarness.swift
@@ -49,10 +49,11 @@ public struct ImagesServiceHarness: Sendable {
         }
         let insecure = message.bool(key: .insecureFlag)
         let maxConcurrentDownloads = message.int64(key: .maxConcurrentDownloads)
+        let auth = message.string(key: .registryAuthorization).map { ResolvedAuthentication(authorization: $0) }
 
         let progressUpdateService = ProgressUpdateService(message: message)
         let imageDescription = try await service.pull(
-            reference: ref, platform: platform, insecure: insecure, progressUpdate: progressUpdateService?.handler, maxConcurrentDownloads: Int(maxConcurrentDownloads))
+            reference: ref, platform: platform, insecure: insecure, auth: auth, progressUpdate: progressUpdateService?.handler, maxConcurrentDownloads: Int(maxConcurrentDownloads))
 
         let imageData = try JSONEncoder().encode(imageDescription)
         let reply = message.reply()
@@ -75,9 +76,10 @@ public struct ImagesServiceHarness: Sendable {
             platform = try JSONDecoder().decode(ContainerizationOCI.Platform.self, from: platformData)
         }
         let insecure = message.bool(key: .insecureFlag)
+        let auth = message.string(key: .registryAuthorization).map { ResolvedAuthentication(authorization: $0) }
 
         let progressUpdateService = ProgressUpdateService(message: message)
-        try await service.push(reference: ref, platform: platform, insecure: insecure, progressUpdate: progressUpdateService?.handler)
+        try await service.push(reference: ref, platform: platform, insecure: insecure, auth: auth, progressUpdate: progressUpdateService?.handler)
 
         let reply = message.reply()
         return reply

--- a/Tests/ContainerImagesServiceTests/RegistryAuthForwardingTests.swift
+++ b/Tests/ContainerImagesServiceTests/RegistryAuthForwardingTests.swift
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerImagesServiceClient
+import ContainerXPC
+import ContainerizationOCI
+import Testing
+
+@testable import ContainerImagesService
+
+/// Regression coverage for reading registry credentials in the CLI and forwarding
+/// them to the images helper over XPC (commit "Read registry credentials in the
+/// CLI, not the images helper").
+///
+/// The bug was that the `container-core-images` helper read the keychain itself
+/// and failed with errSecInteractionNotAllowed (-25308), because its code identity
+/// differs from the CLI that wrote the item. The fix forwards the resolved
+/// `Authorization` header over XPC. These tests pin that the helper consumes the
+/// forwarded credential rather than touching the keychain.
+@Suite
+struct RegistryAuthForwardingTests {
+    private let authorization = "Basic dXNlcjpwYXNz"  // base64("user:pass")
+
+    /// The wrapper must hand back the forwarded `Authorization` value unchanged,
+    /// including its scheme prefix, so the registry handshake sees what the CLI read.
+    @Test func resolvedAuthenticationReturnsAuthorizationVerbatim() async throws {
+        let auth = ResolvedAuthentication(authorization: authorization)
+        #expect(try await auth.token() == authorization)
+    }
+
+    /// A request carrying the credential must decode into an `Authentication`
+    /// whose token matches it — the helper consumes it instead of reading the keychain.
+    @Test func harnessDecodesForwardedAuthorization() async throws {
+        let message = XPCMessage(route: ImagesServiceXPCRoute.imagePull.rawValue)
+        message.set(key: .registryAuthorization, value: authorization)
+
+        let auth = try #require(ImagesServiceHarness.authentication(from: message))
+        #expect(try await auth.token() == authorization)
+    }
+
+    /// No forwarded credential means anonymous access (e.g. public image pulls),
+    /// so no `Authentication` is produced.
+    @Test func harnessReturnsNilWithoutForwardedAuthorization() {
+        let message = XPCMessage(route: ImagesServiceXPCRoute.imagePull.rawValue)
+        #expect(ImagesServiceHarness.authentication(from: message) == nil)
+    }
+}


### PR DESCRIPTION
## Summary

After a successful `container registry login`, `container image pull` and `container image push` (and base-image pulls during `container build`) fail to read registry credentials from the keychain, even when the login keychain is unlocked. This change moves the keychain read out of the `container-core-images` helper and into the `container` CLI, which is the process that wrote the item and therefore satisfies its access control. The resolved `Authorization` header is forwarded to the helper over XPC, and the helper no longer touches the keychain. This addresses the long-standing "Error querying keychain" / `-25308` family of reports, such as #1733, #1253, and #816.

## Symptom

```
container image pull --platform linux/amd64 docker.io/rubylang/all-ruby:latest
Error: error querying keychain for registry-1.docker.io
  (cause: "queryError("query failure: unhandledError(status: -25308)")")
```

`-25308` is `errSecInteractionNotAllowed`. It reproduces even for public images, because the pull and push paths resolve stored credentials before contacting the registry. `container registry login` itself succeeds, and `security find-internet-password -s registry-1.docker.io -w` returns the password, so the credential exists and is readable by the CLI. The failure happens only at pull and push time.

## Investigation

Credentials are stored in the macOS file-based login keychain. Both the store and the fetch live in the pinned `containerization` dependency (`ContainerizationOS/Keychain/KeychainQuery.swift`, surfaced through `ContainerizationOCI.KeychainHelper`). The write is a plain `SecItemAdd` with no `kSecAttrAccess` or `kSecAttrAccessControl`, and without `kSecUseDataProtectionKeychain`.

```swift
var query: [String: Any] = [
    kSecClass: kSecClassInternetPassword,
    kSecAttrSecurityDomain: securityDomain,   // "com.apple.container.registry"
    kSecAttrServer: hostname,
    kSecAttrAccount: username,
    kSecValueData: passwordEncoded,
    kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock,
    kSecAttrSynchronizable: false,
]
SecItemAdd(query as CFDictionary, nil)
```

Because no access control is supplied, macOS creates a default ACL that trusts only the creating process. As a result, the process that writes the credential and the process that reads it are different.

| Role | Process | Code identifier | Team |
|---|---|---|---|
| writer (`registry login` creates the ACL) | `/usr/local/bin/container` | `com.apple.container.cli` | UPBK2H6LZM |
| reader (pull/push lookup) | `container-core-images` helper | `com.apple.container.container-core-images` | UPBK2H6LZM |

The item's ACL, seen via `security dump-keychain -a`, trusts only the CLI.

```
class: "inet"  srvr="registry-1.docker.io"  sdmn="com.apple.container.registry"
access entry 0:
    authorizations: decrypt derive export_clear export_wrapped mac sign
    applications (1):
        0: /usr/local/bin/container
           requirement: identifier "com.apple.container.cli" and anchor apple generic ...
    partition_id entry: teamid:UPBK2H6LZM
```

When the helper performs the lookup, the decrypt ACL check fails and securityd tries to prompt for approval. The helper is a non-interactive XPC service, so it cannot show the prompt and the call fails.

```
container-core-images (Security) SecItemCopyMatching_ios
securityd: code requirement check failed (-67050), client is not Apple-signed
securityd: CSSMERR_CSP_NO_USER_INTERACTION
container-core-images [ImagesHelper] route handler threw [route=imagePull]
  error querying keychain ... unhandledError(status: -25308)
```

Adding the helper to the item's trusted-application list with `security ... -T` does not help. The modern `SecItemCopyMatching` path evaluates the partition list and code identity rather than the file ACL's application list. That is the direction taken by #997, and it is why that approach does not resolve the failure.

Tracing every keychain reader in the tree confirms the asymmetry. `container registry list`, `container registry logout`, and `MachineClient.fetchMachineArtifact` (which additionally swallows the error with `try?`) all run inside the `container` CLI process and so match the writer's ACL. The only reader that runs under a different identity is `ImagesService.withAuthentication`, shared by both `pull` and `push`. `container build` pulls base images through `ClientImage.pull` and `ClientImage.fetch`, which also run in the CLI process.

This fix was built with the project's supported toolchain (Swift 6.3 / macOS 26, matching CI) and verified end to end: after `registry login`, `container image pull` and `container run` succeed with no `-25308`.

## Why this approach

`KeychainQuery` and `KeychainHelper` live in the `containerization` dependency, pinned to an exact version, so changing the write-time access control to a team-scoped ACL, or switching to the data-protection keychain with a shared access group, cannot be done from this repository. The shared-access-group direction is tracked separately in #1257. Reading the credential in the CLI and forwarding it is the option that is both correct and achievable here, and it matches the direction of #1215, which extracts keychain access into a client-side `RegistryKeychainClient`.

## Code

`ClientImage.registryAuthorization(for:)` resolves the credential from the keychain on the client side and returns the `Authorization` header value. It keys the lookup by `resolvedDomain` (e.g. `registry-1.docker.io`), matching what `registry login` stores, and returns `nil` when no entry exists so anonymous pulls keep working. `ClientImage.pull` and `ClientImage.push` set this value on the XPC request under a new `registryAuthorization` key. These run in the `container` CLI binary, so the read satisfies the item's ACL.

`ImagesServiceHarness.authentication(from:)` decodes that key into an `Authentication` and hands it to `ImagesService.pull` and `push`, which now take an `auth` parameter. `ImagesService.withAuthentication` no longer reads the keychain. It uses the forwarded credential and keeps the existing environment-variable precedence (`CONTAINER_REGISTRY_*` still wins) and the 401/403 handling. The forwarded value is wrapped in a small `ResolvedAuthentication` whose `token()` returns it verbatim. No credential or token is logged.

Both readers are fixed because `pull` and `push` share `withAuthentication`, and `container build` is covered because it goes through `ClientImage.pull`.

## Testing

Built with the supported toolchain (Swift 6.3 / macOS 26) and verified manually: after `registry login`, `container image pull` and `container run` succeed with no `-25308`. The same build, packaged and installed on a macOS 27 beta, was confirmed to work there as well. A new `ContainerImagesServiceTests` target pins that the helper builds its `Authentication` from the forwarded `Authorization` header rather than reading the keychain, and returns `nil` when no credential is forwarded. The existing suite never exercised this path: it only pulls public images anonymously and never logs in, which is why the regression went unnoticed by CI.

## Related

Same failure: #1733, #1253, #816, #1310, #254, and the earlier #704, #532, #976. Competing fix directions: #1215 (client-side keychain client, the same direction as this change), #1257 (shared keychain access group), and #997 (grant the helper keychain access, which the investigation above shows does not work). The keychain identifier itself was settled in #644 and #652.
