### PR TITLE
Add TestCLISystemLogs and TestCLITermIO integration tests in new integration test suite

### DIFF
--- a/Tests/IntegrationTests/Run/TestCLITermIO.swift
+++ b/Tests/IntegrationTests/Run/TestCLITermIO.swift
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+/// Tests that an interactive `-it` session with a pty attached does not panic.
+@Suite
+struct TestCLITermIO {
+    @Test func testTermIODoesNotPanic() async throws {
+        try await ContainerFixture.with { f in
+            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let name = "\(f.testID)-c"
+            f.addCleanup { try f.doRemoveIfExists(name, force: true, ignoreFailure: true) }
+
+            let uniqMessage = UUID().uuidString
+            let stdin = Data("echo \(uniqMessage)\nexit\n".utf8)
+            let result = try f.run(
+                ["run", "--rm", "--name", name, "-it", image, "/bin/sh"],
+                stdin: stdin,
+                pty: true
+            ).check("interactive run should not panic")
+
+            // The container's own pty echoes typed input back on stdout, so skip
+            // lines containing "echo" to find the command's actual output.
+            let found = result.output.components(separatedBy: .newlines).contains {
+                $0.contains(uniqMessage) && !$0.contains("echo")
+            }
+            #expect(found, "did not find expected stdout line, stdout: \(result.output)")
+        }
+    }
+}

--- a/Tests/IntegrationTests/System/TestCLISystemLogs.swift
+++ b/Tests/IntegrationTests/System/TestCLISystemLogs.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+/// Tests for `container system logs` argument validation.
+@Suite
+struct TestCLISystemLogs {
+    @Test func testLogsRejectsInvalidLastUnit() async throws {
+        try await ContainerFixture.with { f in
+            let result = try f.run(["system", "logs", "--last", "1x"])
+            #expect(result.status != 0, "Expected non-zero exit for invalid --last unit")
+            #expect(result.error.contains("invalid --last value"))
+        }
+    }
+
+    @Test func testLogsRejectsNonNumericLast() async throws {
+        try await ContainerFixture.with { f in
+            let result = try f.run(["system", "logs", "--last", "abc"])
+            #expect(result.status != 0, "Expected non-zero exit for non-numeric --last")
+            #expect(result.error.contains("invalid --last value"))
+        }
+    }
+
+    @Test func testLogsRejectsZeroLast() async throws {
+        try await ContainerFixture.with { f in
+            let result = try f.run(["system", "logs", "--last", "0m"])
+            #expect(result.status != 0, "Expected non-zero exit for zero --last value")
+            #expect(result.error.contains("invalid --last value"))
+        }
+    }
+}

--- a/Tests/IntegrationTests/Utilities/ContainerFixture.swift
+++ b/Tests/IntegrationTests/Utilities/ContainerFixture.swift
@@ -219,8 +219,11 @@ final class ContainerFixture: Sendable {
             throw CommandError.executionFailed("process launch failed: \(error)")
         }
         if pty {
-            // Master stays open so the slave doesn't receive SIGHUP prematurely.
-            // Close it after the process exits.
+            // Write through the master side; the kernel tty buffers input until the
+            // child reads it, so this works even before the child is ready (e.g. a
+            // shell that hasn't started reading stdin yet). Master stays open until
+            // after the process exits so the slave doesn't receive SIGHUP prematurely.
+            if let data = stdin { FileHandle(fileDescriptor: masterFd, closeOnDealloc: false).write(data) }
         } else {
             if let data = stdin { inputPipe.fileHandleForWriting.write(data) }
             inputPipe.fileHandleForWriting.closeFile()


### PR DESCRIPTION
This PR adds two test suites that were missing from the new integration test suite 

## Testing
- [x] Tested locally
