### PR TITLE
fix(network-vmnet): install explicit subnet route, not just interface-scoped default

### DIFF
--- a/Sources/Services/NetworkVmnet/Server/ReservedVmnetNetwork.swift
+++ b/Sources/Services/NetworkVmnet/Server/ReservedVmnetNetwork.swift
@@ -170,6 +170,18 @@ public final class ReservedVmnetNetwork: ContainerNetworkServer.Network {
         let runningSubnet = try CIDRv4(lower: lower, upper: upper)
         let runningGateway = IPv4Address(runningSubnet.lower.value + 1)
 
+        // `vmnet_network_create` only installs an interface-scoped default route
+        // for this subnet, not an explicit non-scoped one — so routing to
+        // containers is entirely dependent on which *global* default route
+        // currently wins on the host. Any other tool that installs its own
+        // default route (a VPN client, a Tailscale exit node, etc.) can shadow
+        // it and break container connectivity even though this subnet's own
+        // route would normally win under standard longest-prefix-match rules.
+        // Install an explicit route ourselves so container traffic doesn't
+        // depend on default-route ordering at all. Best-effort: failure here
+        // shouldn't prevent the network from otherwise starting successfully.
+        Self.installExplicitSubnetRoute(subnet: lower, mask: IPv4Address(maskValue), gateway: runningGateway, log: log)
+
         var prefixAddr = in6_addr()
         var prefixLength = UInt8(0)
         vmnet_network_get_ipv6_prefix(network, &prefixAddr, &prefixLength)
@@ -198,5 +210,49 @@ public final class ReservedVmnetNetwork: ContainerNetworkServer.Network {
             ipv4Gateway: runningGateway,
             ipv6Subnet: runningV6Subnet,
         )
+    }
+
+    /// Installs an explicit, non-scoped route for `subnet` via `gateway`, so
+    /// routing to this network's containers doesn't depend on which default
+    /// route currently wins on the host (see the call site for why). This is
+    /// a defense-in-depth measure, not a hard requirement — some other tool
+    /// can still remove or shadow the route later (see apple/container#1881
+    /// and tailscale/tailscale#18653 for one such case), so failures here are
+    /// logged rather than thrown; they shouldn't prevent the network from
+    /// otherwise starting successfully.
+    private static func installExplicitSubnetRoute(subnet: IPv4Address, mask: IPv4Address, gateway: IPv4Address, log: Logger) {
+        let process = Foundation.Process()
+        process.executableURL = URL(fileURLWithPath: "/sbin/route")
+        process.arguments = [
+            "add", "-net", subnet.description,
+            "-netmask", mask.description,
+            "-interface", gateway.description,
+        ]
+        let stderr = Pipe()
+        process.standardOutput = Pipe()
+        process.standardError = stderr
+
+        do {
+            try process.run()
+        } catch {
+            log.warning(
+                "failed to launch route(8) to install explicit subnet route",
+                metadata: ["subnet": "\(subnet)", "mask": "\(mask)", "gateway": "\(gateway)", "error": "\(error)"]
+            )
+            return
+        }
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            let message = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            log.warning(
+                "route(8) failed to install explicit subnet route",
+                metadata: [
+                    "subnet": "\(subnet)", "mask": "\(mask)", "gateway": "\(gateway)",
+                    "status": "\(process.terminationStatus)", "message": "\(message)",
+                ]
+            )
+            return
+        }
     }
 }


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

`vmnet_network_create()` only results in an interface-scoped **default** route for the container subnet (e.g. `bridge100`), never an explicit non-scoped route for the subnet itself (e.g. `192.168.64.0/24`). Because of that, routing to containers is entirely dependent on which *global* default route currently wins on the host. Any other tool that installs or changes the system's default route (a VPN client, a Tailscale exit node, etc.) can shadow it and silently break all container connectivity — even though a specific `/24` route for this subnet should normally win over any `/0` default route under standard longest-prefix-match rules, since no such specific route exists to begin with.

Repro (full details in #1881):
1. Run a container, confirm it's reachable (`nc -zv <container-ip> <port>` succeeds).
2. Enable a Tailscale exit node (or introduce any other competing default route).
3. `route -n get <container-ip>` now resolves via the wrong interface; connectivity breaks.
4. Disabling the exit node, or even a full `container system stop && container system start`, does **not** restore connectivity — there was never a specific subnet route to fall back to, only the interface-scoped default.
5. Manually installing an explicit subnet route (`route add -net <subnet> -netmask <mask> -interface <gateway-ip>`) does restore it immediately.

This PR installs that explicit route automatically when a network starts, using `route(8)` via `Process` — the same pattern this codebase already uses for `pfctl` in `PacketFilter.swift`.

Two things this does **not** claim to fix, so I want to be upfront about scope:
- It's best-effort: failures to install the route are logged, not thrown, and don't prevent the network from otherwise starting.
- It doesn't fully eliminate exposure to a tool that *actively removes* a route it doesn't own, rather than just adding a competing one. Testing this against Tailscale specifically, an exit node toggle removes this route outright (not just outranks it), and that looks like a Tailscale-side behavior — tracked at tailscale/tailscale#18653, which already calls out `apple/container`'s `bridge100` interface by name. This change closes the more common case (a competing default route added without deleting others) and gives `container` a correct baseline instead of none, but a tool like Tailscale can still remove it afterward.

## Testing

- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

- `swift build --target ContainerNetworkVmnetServer` compiles cleanly.
- I manually validated the underlying `route(8)` invocation this PR automates, against the exact broken scenario from #1881: with a container running and connectivity broken (exit node enabled, or freshly after `container system` restart with no subnet route present), running
  ```
  route add -net <subnet> -netmask <mask> -interface <gateway-ip>
  ```
  immediately restores `route -n get <container-ip>` to resolve via the correct bridge interface, and connectivity to the container succeeds.
- I was **not** able to do a full signed end-to-end run of the patched `container-network-vmnet` plugin itself — I don't have a code-signing/entitlements setup for local testing of this daemon, the same constraint noted in #1813's testing notes. I'd appreciate it if a maintainer with that setup could confirm the automated call site behaves the same as the manual `route(8)` invocation I validated.

## Related

- Fixes #1881
- Related to #856 (different bug — that one's about binding a DNS listener, not routing to already-running containers; confirmed they're independent by testing binding while this routing bug was active)
- Related to tailscale/tailscale#18653 for the case this doesn't fully cover
