### PR TITLE
Container test fixture package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,7 @@ let package = Package(
         .library(name: "ContainerNetworkServer", targets: ["ContainerNetworkServer"]),
         .library(name: "ContainerNetworkVmnetServer", targets: ["ContainerNetworkVmnetServer"]),
         .library(name: "ContainerResource", targets: ["ContainerResource"]),
+        .library(name: "ContainerTestSupport", targets: ["ContainerTestSupport"]),
         .library(name: "ContainerLog", targets: ["ContainerLog"]),
         .library(name: "ContainerPersistence", targets: ["ContainerPersistence"]),
         .library(name: "ContainerPlugin", targets: ["ContainerPlugin"]),
@@ -100,6 +101,7 @@ let package = Package(
                 "ContainerPersistence",
                 "ContainerPlugin",
                 "ContainerResource",
+                "ContainerTestSupport",
                 "MachineAPIClient",
                 "Yams",
             ],
@@ -571,7 +573,14 @@ let package = Package(
         .target(
             name: "ContainerTestSupport",
             dependencies: [
-                .product(name: "SystemPackage", package: "swift-system")
+                .product(name: "AsyncHTTPClient", package: "async-http-client"),
+                .product(name: "ContainerizationExtras", package: "containerization"),
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "SystemPackage", package: "swift-system"),
+                .product(name: "TOML", package: "swift-toml"),
+                "ContainerLog",
+                "ContainerPersistence",
+                "ContainerResource",
             ]
         ),
         .target(

--- a/Sources/ContainerTestSupport/BuildFixture.swift
+++ b/Sources/ContainerTestSupport/BuildFixture.swift
@@ -24,7 +24,7 @@ import Testing
 
 extension ContainerFixture {
     /// A file-system entry to materialize inside a build context directory.
-    enum FileSystemEntry {
+    public enum FileSystemEntry {
         case file(
             _ path: String,
             content: FileEntryContent,
@@ -41,22 +41,23 @@ extension ContainerFixture {
         case symbolicLink(_ path: String, target: String, uid: uid_t = 0, gid: gid_t = 0)
     }
 
-    enum FileEntryContent {
+    public enum FileEntryContent {
         case zeroFilled(size: Int64)
         case data(Data)
     }
 
-    struct FilePermissions: OptionSet {
-        let rawValue: UInt16
-        static let r = FilePermissions(rawValue: 0o400)
-        static let w = FilePermissions(rawValue: 0o200)
-        static let x = FilePermissions(rawValue: 0o100)
-        static let gr = FilePermissions(rawValue: 0o040)
-        static let gw = FilePermissions(rawValue: 0o020)
-        static let gx = FilePermissions(rawValue: 0o010)
-        static let or = FilePermissions(rawValue: 0o004)
-        static let ow = FilePermissions(rawValue: 0o002)
-        static let ox = FilePermissions(rawValue: 0o001)
+    public struct FilePermissions: OptionSet, Sendable {
+        public let rawValue: UInt16
+        public init(rawValue: UInt16) { self.rawValue = rawValue }
+        public static let r = FilePermissions(rawValue: 0o400)
+        public static let w = FilePermissions(rawValue: 0o200)
+        public static let x = FilePermissions(rawValue: 0o100)
+        public static let gr = FilePermissions(rawValue: 0o040)
+        public static let gw = FilePermissions(rawValue: 0o020)
+        public static let gx = FilePermissions(rawValue: 0o010)
+        public static let or = FilePermissions(rawValue: 0o004)
+        public static let ow = FilePermissions(rawValue: 0o002)
+        public static let ox = FilePermissions(rawValue: 0o001)
     }
 }
 
@@ -65,24 +66,24 @@ extension ContainerFixture {
 extension ContainerFixture {
 
     /// Starts the buildkit builder container.
-    func builderStart(cpus: Int64 = 2, memoryInGBs: Int64 = 2) throws {
+    public func builderStart(cpus: Int64 = 2, memoryInGBs: Int64 = 2) throws {
         try run(["builder", "start", "-c", "\(cpus)", "-m", "\(memoryInGBs)GB"]).check()
     }
 
     /// Stops the buildkit builder container.
-    func builderStop() throws {
+    public func builderStop() throws {
         try run(["builder", "stop"]).check()
     }
 
     /// Deletes the buildkit builder container.
-    func builderDelete(force: Bool = false) throws {
+    public func builderDelete(force: Bool = false) throws {
         var args = ["builder", "delete"]
         if force { args.append("--force") }
         try run(args).check()
     }
 
     /// Polls until the buildkit container is running and the builder shim is ready.
-    func waitForBuilderRunning() async throws {
+    public func waitForBuilderRunning() async throws {
         try await waitForContainerRunning("buildkit", attempts: 10)
         for _ in 0..<3 {
             let response = try? doExec("buildkit", cmd: ["pidof", "-s", "container-builder-shim"])
@@ -99,7 +100,7 @@ extension ContainerFixture {
     /// Each build test gets an isolated builder to avoid inter-test contamination.
     /// Acquires a process-wide lock so only one test holds the buildkit singleton at a time,
     /// regardless of how many suites run concurrently in the global pass.
-    func withBuilder(
+    public func withBuilder(
         cpus: Int64 = 2,
         memoryInGBs: Int64 = 2,
         _ body: @Sendable (ContainerFixture) async throws -> Void
@@ -120,7 +121,7 @@ extension ContainerFixture {
     /// Use this in tests that manually manage the builder lifecycle (e.g. lifecycle
     /// tests that call ``builderStart()``/``builderStop()`` directly) so they
     /// serialise correctly with tests that use ``withBuilder(_:)``.
-    func withBuilderLock<T: Sendable>(_ body: @Sendable () async throws -> T) async throws -> T {
+    public func withBuilderLock<T: Sendable>(_ body: @Sendable () async throws -> T) async throws -> T {
         try await withoutActuallyEscaping(body) { escapingBody in
             try await Self.builderLock.withLock { _ in
                 try await escapingBody()
@@ -138,7 +139,7 @@ extension ContainerFixture {
     /// Creates a new scratch directory under ``testDir`` and returns its path.
     ///
     /// The directory is removed automatically when the fixture scope exits.
-    func createTempDir() throws -> FilePath {
+    public func createTempDir() throws -> FilePath {
         let dir = testDir.appending(UUID().uuidString)
         try FileManager.default.createDirectory(
             atPath: dir.string, withIntermediateDirectories: true, attributes: nil)
@@ -146,7 +147,7 @@ extension ContainerFixture {
     }
 
     /// Writes `contents` to a new file under ``testDir`` with the given suffix.
-    func createTempFile(suffix: String, contents: Data) throws -> FilePath {
+    public func createTempFile(suffix: String, contents: Data) throws -> FilePath {
         let file = testDir.appending(UUID().uuidString + suffix)
         try contents.write(to: URL(filePath: file.string), options: .atomic)
         return file
@@ -156,7 +157,7 @@ extension ContainerFixture {
     ///
     /// Creates `dir/Dockerfile` (if `dockerfile` is non-empty) and
     /// `dir/context/` populated with `context` entries.
-    func createContext(dir: FilePath, dockerfile: String, context: [FileSystemEntry]? = nil) throws {
+    public func createContext(dir: FilePath, dockerfile: String, context: [FileSystemEntry]? = nil) throws {
         if !dockerfile.isEmpty {
             try Data(dockerfile.utf8).write(to: URL(filePath: dir.appending("Dockerfile").string), options: .atomic)
         }
@@ -169,7 +170,7 @@ extension ContainerFixture {
     }
 
     /// Materializes a ``FileSystemEntry`` inside `contextDir`.
-    func createEntry(_ entry: FileSystemEntry, contextDir: FilePath) throws {
+    public func createEntry(_ entry: FileSystemEntry, contextDir: FilePath) throws {
         switch entry {
         case .file(let path, let content, let permissions, let uid, let gid):
             let fullPath = appendingRelative(contextDir, path)
@@ -242,7 +243,7 @@ extension ContainerFixture {
 
     /// Builds an image from `contextDir/Dockerfile` with context `contextDir/context/`.
     @discardableResult
-    func build(
+    public func build(
         tag: String,
         contextDir: FilePath = FilePath("."),
         buildArgs: [String] = [],
@@ -260,7 +261,7 @@ extension ContainerFixture {
     /// - `contextDir` defaults to the current directory (`.`)
     /// - `dockerfilePath` defaults to `nil`, resolved to `contextDir/Dockerfile` at call time
     @discardableResult
-    func buildWithPaths(
+    public func buildWithPaths(
         tags: [String] = [],
         contextDir: FilePath = FilePath("."),
         dockerfilePath: FilePath? = nil,
@@ -284,7 +285,7 @@ extension ContainerFixture {
 
     /// Builds with a Dockerfile read from stdin.
     @discardableResult
-    func buildWithStdin(
+    public func buildWithStdin(
         tags: [String],
         contextDir: FilePath,
         dockerfileContents: String,
@@ -307,7 +308,7 @@ extension ContainerFixture {
 
     /// Builds with `--output type=local,dest=<outputDir>`.
     @discardableResult
-    func buildWithPathsAndLocalOutput(
+    public func buildWithPathsAndLocalOutput(
         tag: String,
         contextDir: FilePath = FilePath("."),
         dockerfilePath: FilePath? = nil,
@@ -337,18 +338,18 @@ extension ContainerFixture {
 
 extension ContainerFixture {
     /// Returns true if `path` exists as a regular file inside `container`.
-    func containerHasFile(_ container: String, at path: String) throws -> Bool {
+    public func containerHasFile(_ container: String, at path: String) throws -> Bool {
         try run(["exec", container, "test", "-f", path]).status == 0
     }
 
     /// Asserts that `path` exists as a regular file inside `container`.
-    func assertContainerHasFile(_ container: String, at path: String, _ comment: String? = nil) throws {
+    public func assertContainerHasFile(_ container: String, at path: String, _ comment: String? = nil) throws {
         let exists = try containerHasFile(container, at: path)
         #expect(exists, "\(comment ?? path) should exist in container")
     }
 
     /// Asserts that `path` does NOT exist inside `container`.
-    func assertContainerMissingFile(_ container: String, at path: String, _ comment: String? = nil) throws {
+    public func assertContainerMissingFile(_ container: String, at path: String, _ comment: String? = nil) throws {
         let exists = try containerHasFile(container, at: path)
         #expect(!exists, "\(comment ?? path) should NOT exist in container")
     }

--- a/Sources/ContainerTestSupport/CommandResult.swift
+++ b/Sources/ContainerTestSupport/CommandResult.swift
@@ -16,21 +16,21 @@
 
 import Foundation
 
-struct CommandResult: Sendable {
-    let outputData: Data
-    let errorData: Data
-    let status: Int32
+public struct CommandResult: Sendable {
+    public let outputData: Data
+    public let errorData: Data
+    public let status: Int32
 
-    var output: String {
+    public var output: String {
         String(data: outputData, encoding: .utf8) ?? ""
     }
 
-    var error: String {
+    public var error: String {
         String(data: errorData, encoding: .utf8) ?? ""
     }
 
     @discardableResult
-    func check(_ message: String? = nil) throws -> CommandResult {
+    public func check(_ message: String? = nil) throws -> CommandResult {
         guard status == 0 else {
             let detail = message ?? error.trimmingCharacters(in: .whitespacesAndNewlines)
             throw CommandError.nonZeroExit(status, detail)
@@ -39,7 +39,7 @@ struct CommandResult: Sendable {
     }
 }
 
-enum CommandError: Error {
+public enum CommandError: Error {
     case binaryNotFound
     case executionFailed(String)
     case nonZeroExit(Int32, String)

--- a/Sources/ContainerTestSupport/ContainerFixture+ContainerHelpers.swift
+++ b/Sources/ContainerTestSupport/ContainerFixture+ContainerHelpers.swift
@@ -22,14 +22,14 @@ import SystemPackage
 
 extension ContainerFixture {
     /// Decoded output of `container inspect <name>`.
-    struct InspectOutput: Codable {
-        struct Status: Codable {
-            let state: String
-            let networks: [ContainerResource.Attachment]
+    public struct InspectOutput: Codable {
+        public struct Status: Codable {
+            public let state: String
+            public let networks: [ContainerResource.Attachment]
         }
-        let configuration: ContainerConfiguration
-        let status: Status
-        var networks: [ContainerResource.Attachment] { status.networks }
+        public let configuration: ContainerConfiguration
+        public let status: Status
+        public var networks: [ContainerResource.Attachment] { status.networks }
     }
 }
 
@@ -38,7 +38,7 @@ extension ContainerFixture {
 extension ContainerFixture {
 
     /// `-e` flags forwarding proxy env vars into container commands.
-    var proxyEnvironmentArgs: [String] {
+    public var proxyEnvironmentArgs: [String] {
         let vars = Set(["HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "NO_PROXY", "no_proxy"])
         return ProcessInfo.processInfo.environment
             .filter { vars.contains($0.key) }
@@ -49,7 +49,7 @@ extension ContainerFixture {
     ///
     /// `containerEnv` injects environment variables into the container via `-e` flags.
     /// To set the CLI subprocess environment (e.g. for `--ssh`), use ``run(_:env:)`` directly.
-    func doLongRun(
+    public func doLongRun(
         name: String,
         image: String? = nil,
         args: [String] = [],
@@ -70,7 +70,7 @@ extension ContainerFixture {
     }
 
     /// Creates a stopped container (`container create`).
-    func doCreate(
+    public func doCreate(
         name: String,
         image: String? = nil,
         args: [String] = ["sleep", "infinity"],
@@ -90,12 +90,12 @@ extension ContainerFixture {
     }
 
     /// Starts a stopped container.
-    func doStart(_ name: String) throws {
+    public func doStart(_ name: String) throws {
         try run(["start", name]).check()
     }
 
     /// Stops a container. Pass `signal: nil` to use the server's default.
-    func doStop(_ name: String, signal: String? = "SIGKILL") throws {
+    public func doStop(_ name: String, signal: String? = "SIGKILL") throws {
         var args = ["stop"]
         if let signal { args += ["-s", signal] }
         args.append(name)
@@ -103,7 +103,7 @@ extension ContainerFixture {
     }
 
     /// Deletes a container.
-    func doRemove(_ name: String, force: Bool = false) throws {
+    public func doRemove(_ name: String, force: Bool = false) throws {
         var args = ["delete"]
         if force { args.append("--force") }
         args.append(name)
@@ -116,7 +116,7 @@ extension ContainerFixture {
     /// this when the container is expected to exist and removal must succeed.
     /// Set `ignoreFailure: true` in cleanup contexts where best-effort removal
     /// is acceptable (e.g. the container may have already been removed).
-    func doRemoveIfExists(_ name: String, force: Bool = false, ignoreFailure: Bool = false) throws {
+    public func doRemoveIfExists(_ name: String, force: Bool = false, ignoreFailure: Bool = false) throws {
         do {
             try doRemove(name, force: force)
         } catch {
@@ -126,7 +126,7 @@ extension ContainerFixture {
 
     /// Runs a command inside a container, returns stdout. Throws on non-zero exit.
     @discardableResult
-    func doExec(
+    public func doExec(
         _ name: String,
         cmd: [String],
         detach: Bool = false,
@@ -142,7 +142,7 @@ extension ContainerFixture {
     }
 
     /// Exports a container filesystem to a tar archive at `path`.
-    func doExport(_ name: String, to path: FilePath) throws {
+    public func doExport(_ name: String, to path: FilePath) throws {
         try run(["export", name, "-o", path.string]).check()
     }
 }
@@ -152,7 +152,7 @@ extension ContainerFixture {
 extension ContainerFixture {
 
     /// Returns the parsed inspect output for a container.
-    func inspectContainer(_ name: String) throws -> InspectOutput {
+    public func inspectContainer(_ name: String) throws -> InspectOutput {
         let result = try run(["inspect", name]).check()
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
@@ -164,12 +164,12 @@ extension ContainerFixture {
     }
 
     /// Returns the `status.state` string for a container (e.g. `"running"`, `"stopped"`).
-    func getContainerStatus(_ name: String) throws -> String {
+    public func getContainerStatus(_ name: String) throws -> String {
         try inspectContainer(name).status.state
     }
 
     /// Returns the `configuration.id` for a container.
-    func getContainerId(_ name: String) throws -> String {
+    public func getContainerId(_ name: String) throws -> String {
         try inspectContainer(name).configuration.id
     }
 }

--- a/Sources/ContainerTestSupport/ContainerFixture+ImageHelpers.swift
+++ b/Sources/ContainerTestSupport/ContainerFixture+ImageHelpers.swift
@@ -21,17 +21,17 @@ import Testing
 
 extension ContainerFixture {
     /// Decoded output of `container image inspect` or `container image list --format json`.
-    struct ImageInspectOutput: Codable {
-        struct Configuration: Codable { let name: String }
-        struct Variant: Codable {
-            struct Platform: Codable {
-                let os: String
-                let architecture: String
+    public struct ImageInspectOutput: Codable {
+        public struct Configuration: Codable { public let name: String }
+        public struct Variant: Codable {
+            public struct Platform: Codable {
+                public let os: String
+                public let architecture: String
             }
-            let platform: Platform
+            public let platform: Platform
         }
-        let configuration: Configuration
-        let variants: [Variant]
+        public let configuration: Configuration
+        public let variants: [Variant]
     }
 }
 
@@ -40,43 +40,43 @@ extension ContainerFixture {
 extension ContainerFixture {
 
     /// Pulls an image. Passes optional extra args (e.g. `["--platform", "linux/amd64"]`).
-    func doPull(_ imageName: String, args: [String] = []) throws {
+    public func doPull(_ imageName: String, args: [String] = []) throws {
         var pullArgs = ["image", "pull"] + args
         pullArgs.append(imageName)
         try run(pullArgs).check()
     }
 
     /// Returns all images currently in the local store.
-    func doListImages() throws -> [ImageInspectOutput] {
+    public func doListImages() throws -> [ImageInspectOutput] {
         let result = try run(["image", "list", "--format", "json"]).check()
         return try JSONDecoder().decode([ImageInspectOutput].self, from: result.outputData)
     }
 
     /// Returns true if an image with the given exact reference is present.
-    func isImagePresent(_ targetImage: String) throws -> Bool {
+    public func isImagePresent(_ targetImage: String) throws -> Bool {
         try doListImages().contains { $0.configuration.name == targetImage }
     }
 
     /// Tags `image` with `newName`.
-    func doImageTag(_ image: String, newName: String) throws {
+    public func doImageTag(_ image: String, newName: String) throws {
         try run(["image", "tag", image, newName]).check()
     }
 
     /// Removes the given images, or all images when `images` is `nil`.
-    func doRemoveImages(_ images: [String]? = nil) throws {
+    public func doRemoveImages(_ images: [String]? = nil) throws {
         var args = ["image", "rm"]
         if let images { args.append(contentsOf: images) } else { args.append("--all") }
         try run(args).check()
     }
 
     /// Returns the full inspect output for an image, including variant information.
-    func doInspectImages(_ name: String) throws -> [ImageInspectOutput] {
+    public func doInspectImages(_ name: String) throws -> [ImageInspectOutput] {
         let result = try run(["image", "inspect", name]).check()
         return try JSONDecoder().decode([ImageInspectOutput].self, from: result.outputData)
     }
 
     /// Returns the `configuration.name` of an image.
-    func inspectImage(_ name: String) throws -> String {
+    public func inspectImage(_ name: String) throws -> String {
         let outputs = try doInspectImages(name)
         guard let first = outputs.first else {
             throw CommandError.executionFailed("image '\(name)' not found in inspect output")
@@ -85,7 +85,7 @@ extension ContainerFixture {
     }
 
     /// Asserts that the image was successfully built and is present in the image store.
-    func assertImageBuilt(_ image: String) throws {
+    public func assertImageBuilt(_ image: String) throws {
         let name = try inspectImage(image)
         #expect(name == image, "expected image \(image) to be present")
     }

--- a/Sources/ContainerTestSupport/ContainerFixture+MachineHelpers.swift
+++ b/Sources/ContainerTestSupport/ContainerFixture+MachineHelpers.swift
@@ -19,38 +19,38 @@ import Testing
 
 // MARK: - Machine output types
 
-struct MachineListItem: Codable {
-    let id: String
-    let status: String
-    let `default`: Bool
-    let ipAddress: String?
-    let cpus: Int
-    let memory: UInt64
-    let diskSize: UInt64?
-    let createdDate: Date?
+public struct MachineListItem: Codable {
+    public let id: String
+    public let status: String
+    public let `default`: Bool
+    public let ipAddress: String?
+    public let cpus: Int
+    public let memory: UInt64
+    public let diskSize: UInt64?
+    public let createdDate: Date?
 }
 
-struct MachineInspectOutput: Codable {
-    let id: String
-    let image: ImageDescription
-    let platform: Platform
-    let status: String
-    let startedDate: Date?
-    let createdDate: Date?
-    let containerId: String?
-    let cpus: Int
-    let memory: UInt64
-    let homeMount: String?
-    let diskSize: UInt64?
-    let ipAddress: String?
+public struct MachineInspectOutput: Codable {
+    public let id: String
+    public let image: ImageDescription
+    public let platform: Platform
+    public let status: String
+    public let startedDate: Date?
+    public let createdDate: Date?
+    public let containerId: String?
+    public let cpus: Int
+    public let memory: UInt64
+    public let homeMount: String?
+    public let diskSize: UInt64?
+    public let ipAddress: String?
 
-    struct ImageDescription: Codable {
-        let reference: String
+    public struct ImageDescription: Codable {
+        public let reference: String
     }
 
-    struct Platform: Codable {
-        let os: String
-        let architecture: String
+    public struct Platform: Codable {
+        public let os: String
+        public let architecture: String
     }
 }
 
@@ -59,12 +59,12 @@ struct MachineInspectOutput: Codable {
 extension ContainerFixture {
 
     /// Runs `container machine <arguments>` and returns the result.
-    func runMachine(_ arguments: [String], env: [String: String] = [:]) throws -> CommandResult {
+    public func runMachine(_ arguments: [String], env: [String: String] = [:]) throws -> CommandResult {
         try run(["machine"] + arguments, env: env, pty: true)
     }
 
     /// Creates a machine without booting it.
-    func doMachineCreate(name: String, image: String, extraArgs: [String] = []) throws {
+    public func doMachineCreate(name: String, image: String, extraArgs: [String] = []) throws {
         var args = ["create", "--no-boot", "--name", name]
         args += extraArgs
         args.append(image)
@@ -72,30 +72,30 @@ extension ContainerFixture {
     }
 
     /// Boots a machine by running a trivial command (which auto-boots).
-    func doMachineBoot(name: String) throws {
+    public func doMachineBoot(name: String) throws {
         try runMachine(["run", "--root", "-n", name, "true"]).check()
     }
 
     /// Stops a machine and returns the output (the machine name).
     @discardableResult
-    func doMachineStop(name: String) throws -> String {
+    public func doMachineStop(name: String) throws -> String {
         let result = try runMachine(["stop", name]).check()
         return result.output.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     /// Removes a machine.
-    func doMachineRemove(name: String) throws {
+    public func doMachineRemove(name: String) throws {
         try runMachine(["rm", name]).check()
     }
 
     /// Silently stops and removes a machine, ignoring errors.
-    func cleanupMachine(_ name: String) {
+    public func cleanupMachine(_ name: String) {
         _ = try? runMachine(["stop", name])
         _ = try? runMachine(["rm", name])
     }
 
     /// Inspects a machine and decodes the JSON output.
-    func doMachineInspect(name: String? = nil) throws -> MachineInspectOutput {
+    public func doMachineInspect(name: String? = nil) throws -> MachineInspectOutput {
         var args = ["inspect"]
         if let name { args.append(name) }
         let result = try runMachine(args).check()
@@ -110,7 +110,7 @@ extension ContainerFixture {
 
     /// Runs a command inside a machine and returns its stdout.
     @discardableResult
-    func doMachineRun(
+    public func doMachineRun(
         name: String,
         root: Bool = false,
         env: [String] = [],
@@ -127,7 +127,7 @@ extension ContainerFixture {
     }
 
     /// Polls machine inspect until the status matches or the attempt limit is reached.
-    func waitForMachineStatus(_ name: String, status: String, maxAttempts: Int = 30) async throws {
+    public func waitForMachineStatus(_ name: String, status: String, maxAttempts: Int = 30) async throws {
         for _ in 0..<maxAttempts {
             let snapshot = try doMachineInspect(name: name)
             if snapshot.status == status { return }

--- a/Sources/ContainerTestSupport/ContainerFixture+NetworkHelpers.swift
+++ b/Sources/ContainerTestSupport/ContainerFixture+NetworkHelpers.swift
@@ -20,15 +20,15 @@ import Foundation
 
 // MARK: - Network inspect output
 
-struct NetworkInspectOutput: Codable {
-    struct Status: Codable {
-        let ipv4Subnet: String?
-        let ipv4Gateway: String?
-        let ipv6Subnet: String?
+public struct NetworkInspectOutput: Codable {
+    public struct Status: Codable {
+        public let ipv4Subnet: String?
+        public let ipv4Gateway: String?
+        public let ipv6Subnet: String?
     }
-    let id: String
-    let configuration: NetworkConfiguration
-    let status: Status
+    public let id: String
+    public let configuration: NetworkConfiguration
+    public let status: Status
 }
 
 // MARK: - Network lifecycle helpers
@@ -36,7 +36,7 @@ struct NetworkInspectOutput: Codable {
 extension ContainerFixture {
 
     /// Creates a named network, throwing on failure.
-    func doNetworkCreate(_ name: String, args: [String] = []) throws {
+    public func doNetworkCreate(_ name: String, args: [String] = []) throws {
         var arguments = ["network", "create"]
         arguments += args
         arguments.append(name)
@@ -44,17 +44,17 @@ extension ContainerFixture {
     }
 
     /// Deletes a named network, throwing on failure.
-    func doNetworkDelete(_ name: String) throws {
+    public func doNetworkDelete(_ name: String) throws {
         try run(["network", "delete", name]).check()
     }
 
     /// Deletes a named network, silently ignoring errors.
-    func doNetworkDeleteIfExists(_ name: String) {
+    public func doNetworkDeleteIfExists(_ name: String) {
         _ = try? run(["network", "delete", name])
     }
 
     /// Inspects a network and returns decoded output.
-    func inspectNetwork(_ name: String) throws -> NetworkInspectOutput {
+    public func inspectNetwork(_ name: String) throws -> NetworkInspectOutput {
         let result = try run(["network", "inspect", name]).check()
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
@@ -66,7 +66,7 @@ extension ContainerFixture {
     }
 
     /// Returns an `HTTPClient` for use in network connectivity tests.
-    func makeHTTPClient() -> HTTPClient {
+    public func makeHTTPClient() -> HTTPClient {
         HTTPClient(eventLoopGroupProvider: .singleton)
     }
 }

--- a/Sources/ContainerTestSupport/ContainerFixture+SSHTestHelpers.swift
+++ b/Sources/ContainerTestSupport/ContainerFixture+SSHTestHelpers.swift
@@ -35,7 +35,7 @@ extension ContainerFixture {
     /// closing the listening fd is what causes the accept loop to exit.
     ///
     /// Returns the socket path. Pass it as `SSH_AUTH_SOCK` in the CLI process env.
-    func makeFakeSSHAgentSocket() throws -> String {
+    public func makeFakeSSHAgentSocket() throws -> String {
         let socketDir = "/tmp/\(testID)-ssh"
         try FileManager.default.createDirectory(
             atPath: socketDir, withIntermediateDirectories: true, attributes: nil)

--- a/Sources/ContainerTestSupport/ContainerFixture+SystemHelpers.swift
+++ b/Sources/ContainerTestSupport/ContainerFixture+SystemHelpers.swift
@@ -24,14 +24,14 @@ import TOML
 extension ContainerFixture {
 
     /// Returns the decoded system configuration from `container system property list`.
-    func getSystemConfig() throws -> ContainerSystemConfig {
+    public func getSystemConfig() throws -> ContainerSystemConfig {
         let result = try run(["system", "property", "list", "--format", "toml"]).check()
         return try TOMLDecoder().decode(ContainerSystemConfig.self, from: Data(result.output.utf8))
     }
 
     /// Creates a temporary directory, calls `body` with its URL, then removes it
     /// regardless of whether `body` throws.
-    func withTempDir<T>(_ body: (URL) async throws -> T) async throws -> T {
+    public func withTempDir<T>(_ body: (URL) async throws -> T) async throws -> T {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)

--- a/Sources/ContainerTestSupport/ContainerFixture+VolumeHelpers.swift
+++ b/Sources/ContainerTestSupport/ContainerFixture+VolumeHelpers.swift
@@ -21,7 +21,7 @@ import Foundation
 extension ContainerFixture {
 
     /// Creates a named volume, optionally with extra `--opt` arguments.
-    func doVolumeCreate(_ name: String, opts: [String] = []) throws {
+    public func doVolumeCreate(_ name: String, opts: [String] = []) throws {
         var args = ["volume", "create"]
         for opt in opts { args += ["--opt", opt] }
         args.append(name)
@@ -29,23 +29,23 @@ extension ContainerFixture {
     }
 
     /// Deletes a volume, throwing on failure.
-    func doVolumeDelete(_ name: String) throws {
+    public func doVolumeDelete(_ name: String) throws {
         try run(["volume", "rm", name]).check()
     }
 
     /// Deletes a volume, silently ignoring errors.
-    func doVolumeDeleteIfExists(_ name: String) {
+    public func doVolumeDeleteIfExists(_ name: String) {
         _ = try? run(["volume", "rm", name])
     }
 
     /// Returns `true` if `volume rm` exits non-zero (i.e. the delete was blocked).
-    func doesVolumeDeleteFail(_ name: String) throws -> Bool {
+    public func doesVolumeDeleteFail(_ name: String) throws -> Bool {
         try run(["volume", "rm", name]).status != 0
     }
 
     /// Returns the names of all volume attachments on a container
     /// (the UUID name for anonymous volumes, the explicit name for named volumes).
-    func getContainerMountedVolumeNames(_ containerName: String) throws -> [String] {
+    public func getContainerMountedVolumeNames(_ containerName: String) throws -> [String] {
         let inspect = try inspectContainer(containerName)
         return inspect.configuration.mounts.compactMap { mount in
             if case .volume(let name, _, _, _) = mount.type { return name }
@@ -54,7 +54,7 @@ extension ContainerFixture {
     }
 
     /// Returns the names of all anonymous volumes (UUID-format names) in the local store.
-    func getAnonymousVolumeNames() throws -> [String] {
+    public func getAnonymousVolumeNames() throws -> [String] {
         let result = try run(["volume", "list", "--quiet"]).check()
         return result.output
             .components(separatedBy: .newlines)
@@ -63,14 +63,14 @@ extension ContainerFixture {
     }
 
     /// Deletes all currently known anonymous volumes. Useful before count-based assertions.
-    func doCleanupAnonymousVolumes() {
+    public func doCleanupAnonymousVolumes() {
         for vol in (try? getAnonymousVolumeNames()) ?? [] {
             doVolumeDeleteIfExists(vol)
         }
     }
 
     /// Returns `true` if a volume with the given name appears in `volume list`.
-    func volumeExists(_ name: String) throws -> Bool {
+    public func volumeExists(_ name: String) throws -> Bool {
         let result = try run(["volume", "list", "--quiet"]).check()
         return result.output
             .components(separatedBy: .newlines)

--- a/Sources/ContainerTestSupport/ContainerFixture.swift
+++ b/Sources/ContainerTestSupport/ContainerFixture.swift
@@ -57,13 +57,13 @@ import Testing
 /// prevents leaks. Drop to Tier 1 when a test exercises a specific
 /// create/start/stop sequence, needs low-level control, or uses a resource
 /// pattern the structured helpers don't cover.
-final class ContainerFixture: Sendable {
+public final class ContainerFixture: Sendable {
 
     // MARK: - Configuration
 
     /// Images preloaded by the ``ImageWarmup`` suite before concurrent tests run.
     /// Add new commonly-used images here; the warmup pass pulls them in parallel.
-    static let warmupImages: [String] = [
+    public static let warmupImages: [String] = [
         "ghcr.io/linuxcontainers/alpine:3.20",
         "ghcr.io/linuxcontainers/alpine:3.18",
         "ghcr.io/containerd/busybox:1.36",
@@ -72,14 +72,14 @@ final class ContainerFixture: Sendable {
     // MARK: - State
 
     /// Short random identifier prefixed to every resource this test creates.
-    let testID: String
+    public let testID: String
 
     /// Scratch directory for build inputs, test data, and command output.
     /// Created at fixture init; removed on cleanup unless `CLITEST_PRESERVE_SCRATCH=true`.
-    let testDir: FilePath
+    public let testDir: FilePath
 
     /// Logger for this fixture scope. Tests may emit diagnostic messages via this logger.
-    let log: Logger
+    public let log: Logger
 
     // MARK: - Unstructured API
 
@@ -87,7 +87,7 @@ final class ContainerFixture: Sendable {
     ///
     /// Cleanup runs in LIFO order regardless of whether `body` throws.
     @discardableResult
-    static func with<T>(_ body: (ContainerFixture) async throws -> T) async throws -> T {
+    public static func with<T>(_ body: (ContainerFixture) async throws -> T) async throws -> T {
         let testID = String(UUID().uuidString.prefix(8)).lowercased()
 
         let scratchRoot =
@@ -143,7 +143,7 @@ final class ContainerFixture: Sendable {
 
     /// Registers a cleanup closure to run when the fixture scope exits.
     /// Closures execute in LIFO order.
-    func addCleanup(_ task: @escaping @Sendable () async throws -> Void) {
+    public func addCleanup(_ task: @escaping @Sendable () async throws -> Void) {
         cleanupTasks.withLock { $0.append(task) }
     }
 
@@ -153,7 +153,7 @@ final class ContainerFixture: Sendable {
     /// process launch error). A non-zero exit status is represented in
     /// ``CommandResult/status`` — call ``CommandResult/check(_:)`` to turn it
     /// into a thrown error.
-    func run(
+    public func run(
         _ arguments: [String],
         stdin: Data? = nil,
         currentDirectory: FilePath? = nil,
@@ -249,7 +249,7 @@ final class ContainerFixture: Sendable {
     /// The returned name is `{testID}-{imageName}:{tag}`, e.g.
     /// `a3f7c2b1-alpine:3.20`. Tests operate freely on this reference;
     /// the canonical warmup image is never touched.
-    func copyWarmupImage(_ canonical: String) throws -> String {
+    public func copyWarmupImage(_ canonical: String) throws -> String {
         let lastComponent = canonical.split(separator: "/").last.map(String.init) ?? canonical
         let parts = lastComponent.split(separator: ":", maxSplits: 1)
         let name = String(parts[0])
@@ -268,7 +268,7 @@ final class ContainerFixture: Sendable {
     /// Call this directly only when using ``doCreate(_:image:args:volumes:networks:ports:)``
     /// and ``doStart(_:)`` — ``withContainer(image:tag:runArgs:containerArgs:autoRemove:_:)``
     /// waits automatically.
-    func waitForContainerRunning(_ name: String, attempts: Int = 30) async throws {
+    public func waitForContainerRunning(_ name: String, attempts: Int = 30) async throws {
         for _ in 0..<attempts {
             if let result = try? run(["inspect", name]),
                 result.status == 0,
@@ -293,7 +293,7 @@ final class ContainerFixture: Sendable {
     /// removes the container on stop. Set `autoRemove: false` when the test
     /// needs to inspect the container's stopped state — cleanup will then stop
     /// *and* delete it.
-    func withContainer(
+    public func withContainer(
         image: String,
         tag: String = "c",
         runArgs: [String] = [],
@@ -364,7 +364,7 @@ extension ContainerFixture {
     /// - Propagates immediately (aborting the loop) when `body` throws.
     ///
     /// Throws `CommandError.executionFailed` if all attempts return `false`.
-    func retry(attempts: Int, delay: Duration = .seconds(1), _ body: () async throws -> Bool) async throws {
+    public func retry(attempts: Int, delay: Duration = .seconds(1), _ body: () async throws -> Bool) async throws {
         for attempt in 1...attempts {
             if try await body() { return }
             print("retry: attempt \(attempt)/\(attempts) not yet ready")

--- a/Sources/ContainerTestSupport/KernelFixture.swift
+++ b/Sources/ContainerTestSupport/KernelFixture.swift
@@ -30,7 +30,8 @@ import Foundation
 /// tar with the same internal layout (a real binary plus the `vmlinux.container`
 /// symlink member kata's release tarballs ship) so the real install/extract/
 /// digest-verify code paths still get exercised, without any network access.
-struct KernelFixture {
+public struct KernelFixture {
+    public init() {}
     private let kernelsDirectory = URL(fileURLWithPath: ApplicationRoot.pathname).appendingPathComponent("kernels")
 
     private var defaultKernelSymlink: URL {
@@ -38,7 +39,7 @@ struct KernelFixture {
     }
 
     /// Copies the bytes of the currently-installed default kernel to `destination`.
-    func captureInstalledBinary(to destination: URL) throws {
+    public func captureInstalledBinary(to destination: URL) throws {
         let resolved = defaultKernelSymlink.resolvingSymlinksInPath()
         guard FileManager.default.fileExists(atPath: resolved.path) else {
             throw CommandError.executionFailed("no default kernel installed at \(resolved.path)")
@@ -55,7 +56,7 @@ struct KernelFixture {
     /// kernel set --digest` verifies the archive's digest, not the extracted
     /// binary's.
     @discardableResult
-    func writeTar(binary: URL, binaryArchivePath: String, to tarPath: URL) throws -> String {
+    public func writeTar(binary: URL, binaryArchivePath: String, to tarPath: URL) throws -> String {
         let binaryData = try Data(contentsOf: binary)
 
         let writer = try ArchiveWriter(format: .ustar, filter: .none, file: tarPath)

--- a/Sources/ContainerTestSupport/LoopbackFileServer.swift
+++ b/Sources/ContainerTestSupport/LoopbackFileServer.swift
@@ -23,14 +23,14 @@ import NIOPosix
 /// payload for any GET request. Used by integration tests that need to
 /// exercise a "fetch this over a URL" code path without depending on a real
 /// network peer.
-final class LoopbackFileServer: Sendable {
+public final class LoopbackFileServer: Sendable {
     /// URL clients should fetch to receive the served payload.
-    let url: URL
+    public let url: URL
 
     private let group: MultiThreadedEventLoopGroup
     private let channel: any Channel
 
-    init(serving data: Data) throws {
+    public init(serving data: Data) throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let bootstrap = ServerBootstrap(group: group)
             .childChannelInitializer { channel in
@@ -58,7 +58,7 @@ final class LoopbackFileServer: Sendable {
     }
 
     /// Stops accepting connections and shuts down the server's event loop.
-    func shutdown() {
+    public func shutdown() {
         try? channel.close().wait()
         try? group.syncShutdownGracefully()
     }

--- a/Tests/IntegrationTests/Build/TestCLIBuilderEnvOnlySerial.swift
+++ b/Tests/IntegrationTests/Build/TestCLIBuilderEnvOnlySerial.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/Build/TestCLIBuilderLifecycleSerial.swift
+++ b/Tests/IntegrationTests/Build/TestCLIBuilderLifecycleSerial.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Darwin
 import Foundation
 import Testing

--- a/Tests/IntegrationTests/Build/TestCLIBuilderLocalOutputSerial.swift
+++ b/Tests/IntegrationTests/Build/TestCLIBuilderLocalOutputSerial.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/Build/TestCLIBuilderSerial.swift
+++ b/Tests/IntegrationTests/Build/TestCLIBuilderSerial.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Darwin
 import Foundation
 import Testing

--- a/Tests/IntegrationTests/Build/TestCLIBuilderTarExportSerial.swift
+++ b/Tests/IntegrationTests/Build/TestCLIBuilderTarExportSerial.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/Containers/TestCLICopyCommand.swift
+++ b/Tests/IntegrationTests/Containers/TestCLICopyCommand.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/Containers/TestCLICreateCommand.swift
+++ b/Tests/IntegrationTests/Containers/TestCLICreateCommand.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import ContainerizationExtras
 import Foundation
 import Testing

--- a/Tests/IntegrationTests/Containers/TestCLIExecCommand.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIExecCommand.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Testing
 
 @Suite

--- a/Tests/IntegrationTests/Containers/TestCLIExportCommand.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIExportCommand.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import ContainerizationArchive
 import Foundation
 import Testing

--- a/Tests/IntegrationTests/Containers/TestCLINotFound.swift
+++ b/Tests/IntegrationTests/Containers/TestCLINotFound.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/Containers/TestCLIPruneCommandSerial.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIPruneCommandSerial.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/Containers/TestCLIRemove.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIRemove.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/Containers/TestCLIRemoveSerial.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIRemoveSerial.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/Containers/TestCLIRmRaceCondition.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIRmRaceCondition.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Testing
 
 @Suite

--- a/Tests/IntegrationTests/Containers/TestCLIStatsCommand.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIStatsCommand.swift
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import ContainerResource
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/Containers/TestCLIStop.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIStop.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Testing
 
 @Suite

--- a/Tests/IntegrationTests/Images/TestCLIImagePruneSerial.swift
+++ b/Tests/IntegrationTests/Images/TestCLIImagePruneSerial.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Testing
 
 private let alpine = ContainerFixture.warmupImages[0]

--- a/Tests/IntegrationTests/Images/TestCLIImagesCommand.swift
+++ b/Tests/IntegrationTests/Images/TestCLIImagesCommand.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import ContainerizationArchive
 import ContainerizationOCI
 import Foundation

--- a/Tests/IntegrationTests/Images/TestCLIProgressAuto.swift
+++ b/Tests/IntegrationTests/Images/TestCLIProgressAuto.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Testing
 
 @Suite

--- a/Tests/IntegrationTests/Machine/TestCLIMachineCommand.swift
+++ b/Tests/IntegrationTests/Machine/TestCLIMachineCommand.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Containerization
 import Foundation
 import MachineAPIClient

--- a/Tests/IntegrationTests/Machine/TestCLIMachineRuntimeSerial.swift
+++ b/Tests/IntegrationTests/Machine/TestCLIMachineRuntimeSerial.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/Network/TestCLINetwork.swift
+++ b/Tests/IntegrationTests/Network/TestCLINetwork.swift
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncHTTPClient
+import ContainerTestSupport
 import ContainerizationExtras
 import Foundation
 import Testing

--- a/Tests/IntegrationTests/Network/TestCLINetworkPruneSerial.swift
+++ b/Tests/IntegrationTests/Network/TestCLINetworkPruneSerial.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Testing
 
 /// Serial tests for `network prune` — pruning affects all unused networks regardless of name.

--- a/Tests/IntegrationTests/Registry/TestCLIRegistry.swift
+++ b/Tests/IntegrationTests/Registry/TestCLIRegistry.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/Run/TestCLIRunCapabilities.swift
+++ b/Tests/IntegrationTests/Run/TestCLIRunCapabilities.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/Run/TestCLIRunCommand.swift
+++ b/Tests/IntegrationTests/Run/TestCLIRunCommand.swift
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncHTTPClient
+import ContainerTestSupport
 import ContainerizationExtras
 import ContainerizationOS
 import Foundation

--- a/Tests/IntegrationTests/Run/TestCLIRunInitImage.swift
+++ b/Tests/IntegrationTests/Run/TestCLIRunInitImage.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/Run/TestCLIRunLifecycle.swift
+++ b/Tests/IntegrationTests/Run/TestCLIRunLifecycle.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/Run/TestCLIRunLifecycleSerial.swift
+++ b/Tests/IntegrationTests/Run/TestCLIRunLifecycleSerial.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/Run/TestCLITermIO.swift
+++ b/Tests/IntegrationTests/Run/TestCLITermIO.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/System/TestCLIHelp.swift
+++ b/Tests/IntegrationTests/System/TestCLIHelp.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Testing
 
 @Suite

--- a/Tests/IntegrationTests/System/TestCLIKernelSetSerial.swift
+++ b/Tests/IntegrationTests/System/TestCLIKernelSetSerial.swift
@@ -15,6 +15,8 @@
 //===----------------------------------------------------------------------===//
 
 import ContainerPersistence
+import ContainerTestSupport
+import ContainerizationArchive
 import Foundation
 import Testing
 
@@ -141,7 +143,7 @@ struct TestCLIKernelSetSerial {
     private func prepareFixture(_ f: ContainerFixture) throws -> URL {
         let capturedBinary = URL(filePath: f.testDir.string).appending(path: "captured-kernel")
         try fixture.captureInstalledBinary(to: capturedBinary)
-        f.addCleanup { restoreCapturedKernel(f, from: capturedBinary) }
+        f.addCleanup { Self.restoreCapturedKernel(f, from: capturedBinary) }
         return capturedBinary
     }
 
@@ -150,7 +152,7 @@ struct TestCLIKernelSetSerial {
     /// the suite is serialised and the kernel is global state. The fixture's
     /// cleanup runner swallows throws with `try?`, so we record an issue against
     /// the current test rather than rely on error propagation.
-    private func restoreCapturedKernel(_ f: ContainerFixture, from capturedBinary: URL) {
+    private static func restoreCapturedKernel(_ f: ContainerFixture, from capturedBinary: URL) {
         do {
             let result = try f.run(["system", "kernel", "set", "--force", "--binary", capturedBinary.path])
             if result.status != 0 {

--- a/Tests/IntegrationTests/System/TestCLIPluginErrors.swift
+++ b/Tests/IntegrationTests/System/TestCLIPluginErrors.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Testing
 
 @Suite

--- a/Tests/IntegrationTests/System/TestCLIStatus.swift
+++ b/Tests/IntegrationTests/System/TestCLIStatus.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/System/TestCLISystemDFSerial.swift
+++ b/Tests/IntegrationTests/System/TestCLISystemDFSerial.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/System/TestCLISystemLogs.swift
+++ b/Tests/IntegrationTests/System/TestCLISystemLogs.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/System/TestCLIVersion.swift
+++ b/Tests/IntegrationTests/System/TestCLIVersion.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 import Yams

--- a/Tests/IntegrationTests/Volumes/TestCLIAnonymousVolumes.swift
+++ b/Tests/IntegrationTests/Volumes/TestCLIAnonymousVolumes.swift
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import ContainerResource
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/Volumes/TestCLIVolumes.swift
+++ b/Tests/IntegrationTests/Volumes/TestCLIVolumes.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/Volumes/TestCLIVolumesSerial.swift
+++ b/Tests/IntegrationTests/Volumes/TestCLIVolumesSerial.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 

--- a/Tests/IntegrationTests/Warmup/ImageWarmup.swift
+++ b/Tests/IntegrationTests/Warmup/ImageWarmup.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Testing
 
 /// Pulls each image in ``ContainerFixture/warmupImages`` in parallel before


### PR DESCRIPTION
## Type of Change
- [x] New feature  

## Motivation and Context
This PR moves helpful testing support code to a new package ContainerTestSupport that can be imported in other projects and packages. This includes the new [ContainerFixture](https://github.com/apple/container/blob/76f387e3be2855b84ba411c72ef14c9439a413aa/Tests/IntegrationTests/Utilities/ContainerFixture.swift#L60) class for easier tracking and management of testing resources. This package is only intended to be used in test targets. 

## Testing
- [x] Tested locally
