### PR TITLE
Use log instead of print for system start status messages

### DIFF
--- a/Sources/ContainerCommands/System/SystemStart.swift
+++ b/Sources/ContainerCommands/System/SystemStart.swift
@@ -141,7 +141,7 @@ extension Application {
             }
 
             do {
-                print("Verifying machine API server is running...")
+                log.info("Verifying machine API server is running...")
                 _ = try await MachineClient().list()
             } catch {
                 throw ContainerizationError(
@@ -174,7 +174,7 @@ extension Application {
         private func installDefaultKernel(kernelURL: URL, kernelBinaryPath: String) async throws {
             var shouldInstallKernel = false
             if kernelInstall == nil {
-                print("No default kernel configured.")
+                log.warning("No default kernel configured.")
                 print("Install the recommended default kernel from [\(kernelURL)]? [Y/n]: ", terminator: "")
                 guard let read = readLine(strippingNewline: true) else {
                     throw ContainerizationError(.internalError, message: "failed to read user input")


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

Fixes #1888

## Motivation and Context
Two status messages in `container system start` were using `print()` (stdout) instead of the `log` object (stderr via `StderrLogHandler`). Per project convention, informational and warning messages should use the Logger.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs