### PR TITLE
Fix container machine setup script being dropped from artifact.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -583,6 +583,12 @@ let package = Package(
             ],
             path: "Sources/Services/MachineAPIService/Client"
         ),
+        .testTarget(
+            name: "MachineAPIClientTests",
+            dependencies: [
+                "MachineAPIClient"
+            ]
+        ),
         .target(
             name: "MachineAPIService",
             dependencies: [

--- a/Sources/Services/MachineAPIService/Client/MachineClient.swift
+++ b/Sources/Services/MachineAPIService/Client/MachineClient.swift
@@ -390,10 +390,18 @@ extension MachineClient {
             }
         }
 
-        if var resources, let setupScript {
-            resources.setupScript = setupScript
-        }
+        return merge(resources: resources, setupScript: setupScript)
+    }
 
+    /// Merge a separately-fetched setup script into the decoded machine resources.
+    ///
+    /// `MachineResources` is a value type, so mutating a copy bound via `if var`
+    /// would not affect the returned value. Assign through the optional instead.
+    static func merge(resources: MachineResources?, setupScript: String?) -> MachineResources? {
+        var resources = resources
+        if let setupScript {
+            resources?.setupScript = setupScript
+        }
         return resources
     }
 }

--- a/Tests/MachineAPIClientTests/MachineClientMergeTests.swift
+++ b/Tests/MachineAPIClientTests/MachineClientMergeTests.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import MachineAPIClient
+
+struct MachineClientMergeTests {
+    @Test func mergeAppliesSetupScriptToResources() throws {
+        let resources = MachineResources(schemaVersion: 1, shell: "/bin/sh")
+        let merged = MachineClient.merge(resources: resources, setupScript: "echo hello")
+        #expect(merged?.setupScript == "echo hello")
+        #expect(merged?.shell == "/bin/sh")
+    }
+
+    @Test func mergeLeavesResourcesUnchangedWhenNoSetupScript() throws {
+        let resources = MachineResources(schemaVersion: 1, setupScript: "existing")
+        let merged = MachineClient.merge(resources: resources, setupScript: nil)
+        #expect(merged?.setupScript == "existing")
+    }
+
+    @Test func mergeReturnsNilWhenNoResources() throws {
+        let merged = MachineClient.merge(resources: nil, setupScript: "echo hello")
+        #expect(merged == nil)
+    }
+}


### PR DESCRIPTION

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
When a container machine image ships a custom setup script as an OCI artifact,
that script was silently dropped and the default `create-user.sh` was used
instead.

In `MachineClient.fetchMachineArtifact`, the config layer is decoded into
`resources: MachineResources?` and the separate setup-script layer into
`setupScript: String?`. The two were merged with:

    if var resources, let setupScript {
        resources.setupScript = setupScript
    }

`MachineResources` is a value type (a `struct`), so `if var resources` binds a
mutable copy. Assigning `setupScript` mutates that throwaway copy, which is
discarded at the end of the block. The function then returns the outer
`resources`, whose `setupScript` is still `nil`. Downstream,
`MachineBundle.create` sees `resources?.setupScript == nil` and falls back to
copying the default `userSetupFile`, so the per-image script fetched from the
registry is never applied.

The fix merges through the optional (`resources?.setupScript = setupScript`) so
the value survives on the returned `MachineResources`. The merge is extracted
into a small `merge(resources:setupScript:)` helper, both to make the value
semantics explicit and to give the logic a unit-testable seam
(`fetchMachineArtifact` itself needs a live registry client).

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

Added a `MachineAPIClientTests` target with three tests for the merge:
- a non-nil setup script is applied to the returned resources,
- a nil setup script leaves an existing script untouched,
- a nil `resources` stays nil.

`swift test --filter MachineAPIClientTests` passes (3/3). Reverting the helper to
the original `if var resources` body makes the first test fail
(`merged?.setupScript` is `nil`), confirming the test covers this bug. The full
tree builds with `swift build --build-tests`, and `swift format lint --strict`
is clean on the changed files.

---

## Files changed (3 files, +56 -3)

- `Sources/Services/MachineAPIService/Client/MachineClient.swift`
  Replace the inline `if var resources, let setupScript { ... }` merge with a call
  to a new `static func merge(resources:setupScript:) -> MachineResources?` that
  assigns through the optional. Doc comment notes the value-type pitfall.
- `Package.swift`
  Add a `MachineAPIClientTests` test target depending on `MachineAPIClient`
  (this target had no unit tests before, only VM-dependent integration tests).
- `Tests/MachineAPIClientTests/MachineClientMergeTests.swift` (new)
  Three Swift Testing (`import Testing`) regression tests. Carries the repo's
  canonical Apache-2.0 license header (byte-identical to existing tracked files).
