### PR TITLE
Fix StandardQueryValidator initializer doc parameter name.

### DIFF
--- a/Sources/DNSServer/Handlers/StandardQueryValidator.swift
+++ b/Sources/DNSServer/Handlers/StandardQueryValidator.swift
@@ -19,7 +19,7 @@ public struct StandardQueryValidator: DNSHandler {
     private let handler: DNSHandler
 
     /// Create the handler.
-    /// - Parameter delegate: the handler that receives valid queries
+    /// - Parameter handler: the handler that receives valid queries
     public init(handler: DNSHandler) {
         self.handler = handler
     }


### PR DESCRIPTION

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context
The doc comment on `StandardQueryValidator.init` documents a `- Parameter delegate:`,
but the initializer's only parameter is `handler`:

```swift
/// Create the handler.
/// - Parameter delegate: the handler that receives valid queries
public init(handler: DNSHandler) {
    self.handler = handler
}
```

There is no `delegate` parameter (the stored property is also `handler`). A
`- Parameter <name>` that names no real parameter is a documentation defect: DocC
warns on it, and the rendered API docs would show a parameter that does not exist.
This updates the parameter name in the doc comment to match the actual `handler`
parameter.

The surrounding prose (the type summary "Pass standard queries to a delegate
handler." and the `answer(query:)` comments referring to "the delegate") is left
untouched: those describe the delegation role in words and are not DocC
`- Parameter` directives, so they are correct as written.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

- `swift build --target DNSServer` succeeds; `StandardQueryValidator.swift` compiles
  with no diagnostics.
- `swift format lint --strict` reports no issues on the file, and `make fmt`
  (`swift format`) is a no-op (no formatting change).
- No test change: this is a documentation-comment-only edit with no behavioral
  effect. The `- Parameter` name now matches the `init(handler:)` signature.

---

## Diff (for reference)

```diff
diff --git a/Sources/DNSServer/Handlers/StandardQueryValidator.swift b/Sources/DNSServer/Handlers/StandardQueryValidator.swift
--- a/Sources/DNSServer/Handlers/StandardQueryValidator.swift
+++ b/Sources/DNSServer/Handlers/StandardQueryValidator.swift
@@ -19,7 +19,7 @@ public struct StandardQueryValidator: DNSHandler {
     private let handler: DNSHandler
 
     /// Create the handler.
-    /// - Parameter delegate: the handler that receives valid queries
+    /// - Parameter handler: the handler that receives valid queries
     public init(handler: DNSHandler) {
         self.handler = handler
     }
```

`1 file changed, 1 insertion(+), 1 deletion(-)`.
