### PR TITLE
Use loadUnaligned/storeBytes for the DNS wire codec

### DIFF
--- a/Sources/DNSServer/Records/UInt8+Binding.swift
+++ b/Sources/DNSServer/Records/UInt8+Binding.swift
@@ -24,29 +24,26 @@ import Foundation
 extension [UInt8] {
     /// Copy a value into the buffer at the given offset.
     /// - Returns: The new offset after writing, or nil if the buffer is too small.
-    package mutating func copyIn<T>(as type: T.Type, value: T, offset: Int = 0) -> Int? {
+    package mutating func copyIn<T: BitwiseCopyable>(as type: T.Type, value: T, offset: Int = 0) -> Int? {
         let size = MemoryLayout<T>.size
         guard self.count >= size + offset else {
             return nil
         }
         return self.withUnsafeMutableBytes {
-            $0.baseAddress?.advanced(by: offset).assumingMemoryBound(to: T.self).pointee = value
+            $0.storeBytes(of: value, toByteOffset: offset, as: T.self)
             return offset + size
         }
     }
 
     /// Copy a value out of the buffer at the given offset.
     /// - Returns: A tuple of (new offset, value), or nil if the buffer is too small.
-    package func copyOut<T>(as type: T.Type, offset: Int = 0) -> (Int, T)? {
+    package func copyOut<T: BitwiseCopyable>(as type: T.Type, offset: Int = 0) -> (Int, T)? {
         let size = MemoryLayout<T>.size
         guard self.count >= size + offset else {
             return nil
         }
         return self.withUnsafeBytes {
-            guard let value = $0.baseAddress?.advanced(by: offset).assumingMemoryBound(to: T.self).pointee else {
-                return nil
-            }
-            return (offset + size, value)
+            (offset + size, $0.loadUnaligned(fromByteOffset: offset, as: T.self))
         }
     }
 

--- a/Tests/DNSServerTests/RecordsTests.swift
+++ b/Tests/DNSServerTests/RecordsTests.swift
@@ -23,6 +23,97 @@ import Testing
 @Suite("DNS Records Tests")
 struct RecordsTests {
 
+    // MARK: - Binding Tests
+
+    /// The DNS wire codec writes multi-byte integers (`UInt16` type/class,
+    /// `UInt32` ttl) at variable offsets that follow a variable-length name, so
+    /// they routinely land on unaligned addresses. These tests exercise
+    /// `copyIn`/`copyOut` at every offset in a machine word to ensure the codec
+    /// reads and writes correct big-endian bytes regardless of alignment.
+    @Suite("Binding")
+    struct BindingTests {
+        @Test("UInt16 round-trips at every offset")
+        func uint16RoundTripEveryOffset() throws {
+            let value: UInt16 = 0x1234
+            for offset in 0..<8 {
+                var buffer = [UInt8](repeating: 0, count: offset + MemoryLayout<UInt16>.size)
+
+                let writeEnd = buffer.copyIn(as: UInt16.self, value: value.bigEndian, offset: offset)
+                #expect(writeEnd == offset + 2)
+                // Stored as big-endian bytes at the requested offset.
+                #expect(buffer[offset] == 0x12)
+                #expect(buffer[offset + 1] == 0x34)
+
+                let (readEnd, raw) = try #require(buffer.copyOut(as: UInt16.self, offset: offset))
+                #expect(readEnd == offset + 2)
+                #expect(UInt16(bigEndian: raw) == value)
+            }
+        }
+
+        @Test("UInt32 round-trips at every offset")
+        func uint32RoundTripEveryOffset() throws {
+            let value: UInt32 = 0x1234_5678
+            for offset in 0..<8 {
+                var buffer = [UInt8](repeating: 0, count: offset + MemoryLayout<UInt32>.size)
+
+                let writeEnd = buffer.copyIn(as: UInt32.self, value: value.bigEndian, offset: offset)
+                #expect(writeEnd == offset + 4)
+                // Stored as big-endian bytes at the requested offset.
+                #expect(buffer[offset] == 0x12)
+                #expect(buffer[offset + 1] == 0x34)
+                #expect(buffer[offset + 2] == 0x56)
+                #expect(buffer[offset + 3] == 0x78)
+
+                let (readEnd, raw) = try #require(buffer.copyOut(as: UInt32.self, offset: offset))
+                #expect(readEnd == offset + 4)
+                #expect(UInt32(bigEndian: raw) == value)
+            }
+        }
+
+        @Test("copyIn returns nil when the buffer is too small")
+        func copyInBufferTooSmall() {
+            var buffer = [UInt8](repeating: 0, count: 1)
+            #expect(buffer.copyIn(as: UInt16.self, value: 0, offset: 0) == nil)
+            #expect(buffer.copyIn(as: UInt16.self, value: 0, offset: 1) == nil)
+        }
+
+        @Test("copyOut returns nil when the buffer is too small")
+        func copyOutBufferTooSmall() {
+            let buffer = [UInt8](repeating: 0, count: 1)
+            #expect(buffer.copyOut(as: UInt16.self, offset: 0) == nil)
+            #expect(buffer.copyOut(as: UInt16.self, offset: 1) == nil)
+        }
+
+        @Test("Message round-trips with fields at unaligned offsets")
+        func messageRoundTripUnaligned() throws {
+            // "example.com." encodes to [7]example[3]com[0] = 13 bytes. With the
+            // 12-byte header, the question's type/class UInt16 fields start at
+            // offset 25 (odd), so serialize and deserialize both hit the
+            // unaligned path.
+            let original = Message(
+                id: 0xABCD,
+                type: .query,
+                recursionDesired: true,
+                questions: [Question(name: "example.com.", type: .host6)]
+            )
+
+            let data = try original.serialize()
+            let bytes = Array(data)
+
+            // type (AAAA = 28) and class (IN = 1) are big-endian at odd offsets.
+            #expect(bytes[25] == 0x00)
+            #expect(bytes[26] == 28)
+            #expect(bytes[27] == 0x00)
+            #expect(bytes[28] == 1)
+
+            let parsed = try Message(deserialize: data)
+            #expect(parsed.id == 0xABCD)
+            #expect(parsed.questions.count == 1)
+            #expect(parsed.questions[0].type == .host6)
+            #expect(parsed.questions[0].recordClass == .internet)
+        }
+    }
+
     // MARK: - DNSName Tests
 
     @Suite("DNSName")


### PR DESCRIPTION

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
The DNS wire codec in `Sources/DNSServer/Records/UInt8+Binding.swift` reads and
writes multi-byte integers (the `UInt16` type/class fields, the `UInt32` TTL) at
offsets that follow a variable-length domain name, so those fields routinely land
on unaligned addresses. For example `ResourceRecord.serialize` writes the `UInt32`
TTL immediately after the name.

`copyIn`/`copyOut` accessed that memory with:

```swift
$0.baseAddress?.advanced(by: offset).assumingMemoryBound(to: T.self).pointee
```

That has two problems under the `UnsafeRawPointer` contract:

- `assumingMemoryBound(to: T.self)` asserts the memory is already bound to `T`, but
  the buffer is a `[UInt8]` bound to `UInt8`. It never rebinds, so it type-puns the
  storage.
- Typed `.pointee` load/store requires the address to be properly aligned for `T`,
  while these accesses happen at variable, frequently odd, offsets.

Both are undefined behavior. arm64 happens to tolerate unaligned scalar loads, so
this works in practice today, but it is not guaranteed by the language and is
exactly the kind of access the raw-pointer API has dedicated, well-defined
alternatives for.

This switches to the alignment- and binding-agnostic raw buffer APIs:

- write path -> `UnsafeMutableRawBufferPointer.storeBytes(of:toByteOffset:as:)`
- read path -> `UnsafeRawBufferPointer.loadUnaligned(fromByteOffset:as:)`

Both operate on untyped raw bytes (no memory binding is assumed or changed) and
`loadUnaligned` has no alignment requirement. The generic parameter is constrained
to `BitwiseCopyable`, which is the constraint those overloads require; it also moves
`storeBytes`'s trivial-type precondition to compile time. The only callers pass
`UInt8`, `UInt16`, and `UInt32`, which all satisfy it. The `[UInt8]` extension is
`package`-scoped, so the tightened signature is not visible outside the module.

The existing size/bounds guards and the `nil`-on-too-small behavior are unchanged
(the removed `guard let ... = baseAddress` branch in `copyOut` was only reachable
for an empty buffer, which the `count >= size + offset` guard already rejects for
every caller, since every value type here is at least one byte).

Note on scope: this fixes latent undefined behavior rather than a currently
observable failure. On arm64 the old code returns the correct bytes, and neither
AddressSanitizer nor `-sanitize=undefined` traps the unaligned access (there is no
C-style alignment check in the Swift sanitizers), so I could not write a test that
is red before the fix and green after on this architecture. The added tests instead
pin the codec's observable contract: correct big-endian layout and lossless
round-trips at unaligned offsets, so the intended wire behavior is locked in and the
fix is exercised on the actual unaligned path.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

Added a `Binding` suite to `Tests/DNSServerTests/RecordsTests.swift`:

- `UInt16` and `UInt32` round-trip through `copyIn`/`copyOut` at every byte offset
  within a machine word (0..7), asserting correct big-endian bytes and value.
- `copyIn`/`copyOut` still return `nil` when the buffer is too small.
- A `Message` serialize/deserialize round-trip whose question (`example.com.`) puts
  the `type`/`class` `UInt16` fields at odd offsets (25/27), asserting both the raw
  big-endian bytes on the wire and the decoded values.

Verification run:
- `swift build --target DNSServer` succeeds.
- `swift test --filter DNSServerTests` passes (70 tests, including the 5 new ones).
- `make fmt` produces no changes to the touched files; strict `swift format` lint
  on both files is clean.
