### PR TITLE
Update .spi.yml network documentation targets

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -8,8 +8,9 @@ builder:
         - ContainerRuntimeClient
         - ContainerRuntimeLinuxClient
         - ContainerRuntimeLinuxServer
-        - ContainerNetworkService
-        - ContainerNetworkServiceClient
+        - ContainerNetworkClient
+        - ContainerNetworkServer
+        - ContainerNetworkVmnetServer
         - ContainerImagesService
         - ContainerImagesServiceClient
         - ContainerResource


### PR DESCRIPTION

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context
The network plugin target reorganization in #1615 renamed the network targets to
`ContainerNetworkClient`, `ContainerNetworkServer`, and
`ContainerNetworkVmnetServer`, and updated `scripts/make-docs.sh` to match. The
Swift Package Index manifest `.spi.yml` was missed (its last update was #1577,
before the reorg), so it still listed the old `ContainerNetworkService` and
`ContainerNetworkServiceClient` targets, which no longer exist in `Package.swift`.

Because Swift Package Index builds hosted DocC from `.spi.yml`, the two stale
entries point the build at missing targets, so the network plugin documentation
is not published. This change points `.spi.yml` at the current targets so its
`documentation_targets` list matches `scripts/make-docs.sh` again.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

`swift package dump-package` succeeds and every one of the 15
`documentation_targets` in `.spi.yml` now resolves to a real SwiftPM target (two
did not resolve before this change). The list is identical, in the same order, to
the `--target` list in `scripts/make-docs.sh`, and no references to the old target
names remain anywhere in the tree. `.spi.yml` is a hosting manifest, not compiled
code, and has no test harness, so there is no unit test to add.

<!-- "Added/updated tests" and "Added/updated docs" are intentionally left
     unchecked: this fixes the docs *manifest*; there is no test surface for
     .spi.yml, and it does not add or edit DocC content. -->

---

## The diff (for reference)

```diff
diff --git a/.spi.yml b/.spi.yml
index d7f94f9..d925187 100644
--- a/.spi.yml
+++ b/.spi.yml
@@ -8,8 +8,9 @@ builder:
         - ContainerRuntimeClient
         - ContainerRuntimeLinuxClient
         - ContainerRuntimeLinuxServer
-        - ContainerNetworkService
-        - ContainerNetworkServiceClient
+        - ContainerNetworkClient
+        - ContainerNetworkServer
+        - ContainerNetworkVmnetServer
         - ContainerImagesService
         - ContainerImagesServiceClient
         - ContainerResource
```
