### PR TITLE
Fix crash parsing a mount directive with an empty key.

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/Parser.swift
+++ b/Sources/Services/ContainerAPIService/Client/Parser.swift
@@ -369,7 +369,10 @@ public struct Parser {
         var directives = defaultDirectives
         for part in parts {
             let keyVal = part.split(separator: "=", maxSplits: 2)
-            var key = String(keyVal[0])
+            guard let rawKey = keyVal.first else {
+                throw ContainerizationError(.invalidArgument, message: "invalid mount directive '\(part)' in \(mount)")
+            }
+            var key = String(rawKey)
             var skipValue = false
             switch key {
             case "type", "size", "mode":

--- a/Tests/ContainerAPIClientTests/ParserTest.swift
+++ b/Tests/ContainerAPIClientTests/ParserTest.swift
@@ -513,6 +513,23 @@ struct ParserTest {
     }
 
     @Test
+    func testMountEmptyDirectiveSegment() throws {
+        // A comma-segment consisting solely of "=" characters splits to an empty
+        // array under Swift's default omittingEmptySubsequences, so reading the
+        // key without a guard would trap. These must surface a validation error.
+        for input in ["=", "==", "type=bind,=,dst=/foo"] {
+            #expect {
+                _ = try Parser.mount(input)
+            } throws: { error in
+                guard let error = error as? ContainerizationError else {
+                    return false
+                }
+                return error.description.contains("invalid mount directive")
+            }
+        }
+    }
+
+    @Test
     func testIsValidDomainNameOk() throws {
         let names = [
             "a",


### PR DESCRIPTION

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
`Parser.mount(_:)` splits each comma-separated part of a mount spec on `=` and then
immediately reads `keyVal[0]`. Swift's `split(separator:)` omits empty subsequences by
default, so a part made up solely of `=` characters produces an **empty** array and the
`keyVal[0]` read traps with a fatal `Index out of range`, crashing the process on user
input.

This is reachable straight from the CLI. For example:

```
container run --mount "=" ...
container run --mount "src=/x,=,type=bind" ...
```

The existing `parts.count == 0` guard only catches an empty or all-comma string; it does
not catch a `=`-only segment.

The fix guards the first element and throws a
`ContainerizationError(.invalidArgument, ...)` so the malformed input is rejected the same
way other bad mount directives already are, instead of aborting the process. The change is
a single guarded read; the error message shape matches the sibling `.invalidArgument`
throws already in `mount(_:)`.

This is the same class of user-input crash fix as #1612 ("Fix potential integer math crash
on `PublishPort`."), which also hardened `Parser.swift` and added a regression test.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

Added `testMountEmptyDirectiveSegment` in `Tests/ContainerAPIClientTests/ParserTest.swift`,
asserting that `"="`, `"=="`, and `"type=bind,=,dst=/foo"` each throw a
`ContainerizationError` whose description contains "invalid mount directive". Reverting only
the guard makes the new test trap with `Fatal error: Index out of range` (proving the crash);
with the guard it passes. `swift format` reports no drift, `swift format lint --strict`
passes, and the full `ContainerAPIClientTests` suite (184 tests) is green.

---

## The diff (for reference; already committed locally on `patch-5`, unsigned)

`Sources/Services/ContainerAPIService/Client/Parser.swift` (+4/-1):

```swift
             let keyVal = part.split(separator: "=", maxSplits: 2)
-            var key = String(keyVal[0])
+            guard let rawKey = keyVal.first else {
+                throw ContainerizationError(.invalidArgument, message: "invalid mount directive '\(part)' in \(mount)")
+            }
+            var key = String(rawKey)
```

`Tests/ContainerAPIClientTests/ParserTest.swift` (+17): new `@Test testMountEmptyDirectiveSegment()`.
