### PR TITLE
Fix installRoot config path in ConfigurationLoader load() docstring.

### DIFF
--- a/Sources/ContainerPersistence/ConfigurationLoader.swift
+++ b/Sources/ContainerPersistence/ConfigurationLoader.swift
@@ -84,7 +84,7 @@ public enum ConfigurationLoader {
     ///
     /// Providers are consulted in the order given — values from earlier files override
     /// later ones. The default order is user config (`<appRoot>/config/config.toml`)
-    /// > system config (`<installRoot>/etc/container/config/config.toml`).
+    /// > system config (`<installRoot>/etc/container/config.toml`).
     ///
     /// An empty `configurationFiles` array falls back to `defaultConfigFiles()`.
     ///


### PR DESCRIPTION

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context
The `load()` docstring in `Sources/ContainerPersistence/ConfigurationLoader.swift`
described the default system config layer as
`<installRoot>/etc/container/config/config.toml`, but the code produces
`<installRoot>/etc/container/config.toml`.

The path builder `configurationFile(in:of:)` only inserts the `config` directory
for the `.appRoot` case; the `.installRoot` case appends `etc/container` and the
config filename directly:

```swift
case .appRoot: base.appending(configDirectory).appending(configFilename)   // <base>/config/config.toml
case .installRoot: base.appending("etc/container").appending(configFilename) // <base>/etc/container/config.toml
```

The extra `/config/` segment was also self-contradictory: the sibling
`configurationFile(in:of:)` docstring in the same file already documents
`.installRoot` as `<base>/etc/container/config.toml` (with the example
`/usr/local/etc/container/config.toml`).

This drops the spurious `/config/` segment so the `load()` docstring matches both
the code and the sibling docstring. The `<appRoot>/config/config.toml` half of the
same line is correct and is left unchanged.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [x] Added/updated docs

Docstring-only change, so no unit test applies. Verified with:
- `swift format lint --strict` on the file: clean.
- `swift build --target ContainerPersistence`: builds.

Diff (+1/-1):

```diff
     /// Providers are consulted in the order given — values from earlier files override
     /// later ones. The default order is user config (`<appRoot>/config/config.toml`)
-    /// > system config (`<installRoot>/etc/container/config/config.toml`).
+    /// > system config (`<installRoot>/etc/container/config.toml`).
```
