### PR TITLE
Add LRUCache test for get() recency promotion.

### DIFF
--- a/Tests/SocketForwarderTests/LRUCacheTest.swift
+++ b/Tests/SocketForwarderTests/LRUCacheTest.swift
@@ -51,4 +51,21 @@ struct LRUCacheTest {
         #expect(cache.get("qux") == "5")
         #expect(cache.get("quux") == "6")
     }
+
+    @Test
+    func testGetPromotesToMostRecentlyUsed() throws {
+        let cache = LRUCache<String, String>(size: 3)
+        #expect(cache.put(key: "foo", value: "1") == nil)
+        #expect(cache.put(key: "bar", value: "2") == nil)
+        #expect(cache.put(key: "baz", value: "3") == nil)
+
+        // Reading "foo" must promote it to most-recently-used, so the oldest
+        // remaining entry ("bar") is evicted next, not "foo".
+        #expect(cache.get("foo") == "1")
+
+        let evicted = try #require(cache.put(key: "qux", value: "4"))
+        #expect(evicted == ("bar", "2"))
+        #expect(cache.get("foo") == "1")
+        #expect(cache.get("bar") == nil)
+    }
 }


### PR DESCRIPTION

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Test coverage

## Motivation and Context
`LRUCache.get(_:)` is a real LRU read: on a hit it refreshes recency by moving
the node to most-recently-used before returning
(`Sources/SocketForwarder/LRUCache.swift`, the `listRemove` + `listInsert(after: tail)`
pair in `get`). The existing `LRUCacheTest.testLRUCache` never observes that
promotion, though: every `get` call sits at the end of the test purely to read
final values after all `put`-driven evictions are done. No test reads an existing
key and then forces an eviction to check that the just-read key survived.

Because of that, the recency update in `get` is a mutation survivor: removing it
(making `get` a plain lookup that no longer counts as use) keeps every current
assertion green, since `put` already promotes on insert/replace and the test only
relies on `put`-driven ordering. A regression that stopped treating reads as use
would ship undetected.

This is a test-only change: it adds one focused test and leaves production code
untouched.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

`testGetPromotesToMostRecentlyUsed` fills a size-3 cache with `foo, bar, baz`,
reads `foo` (promoting it to most-recently-used), then inserts `qux` and asserts
the evicted entry is `("bar", "2")` rather than `("foo", "1")`, that `foo`
survived, and that `bar` is gone. It fails if the promotion in `get` is removed
and passes with it.

Run:

```
swift test --filter LRUCacheTest
```

Both `testLRUCache` and the new test pass. To confirm it closes the gap, removing
the two promotion lines in `get(_:)` leaves `testLRUCache` green but makes the new
test fail, then reverting restores both to green.
