### PR TITLE
Make Arch.hostArchitecture() fail fast on unsupported architectures.

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/Arch.swift
+++ b/Sources/Services/ContainerAPIService/Client/Arch.swift
@@ -33,6 +33,8 @@ public enum Arch: String {
         return .arm64
         #elseif arch(x86_64)
         return .amd64
+        #else
+        #error("unsupported host architecture")
         #endif
     }
 }


### PR DESCRIPTION

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
`Arch.hostArchitecture()` in `Sources/Services/ContainerAPIService/Client/Arch.swift`
resolves the host architecture with a compile-time switch:

```swift
public static func hostArchitecture() -> Arch {
    #if arch(arm64)
    return .arm64
    #elseif arch(x86_64)
    return .amd64
    #endif
}
```

The `#if`/`#elseif` has no `#else` arm. On `arch(arm64)` and `arch(x86_64)` this
compiles and returns the right value, but on any other architecture the function
declares a non-optional `Arch` return type yet has no `return` statement, so the
compiler emits a confusing "missing return in a function expected to return 'Arch'"
diagnostic rather than a clear reason.

This adds an `#else` arm that fails the build with an explicit message:

```swift
#else
#error("unsupported host architecture")
#endif
```

This makes the conditional exhaustive and turns a vague missing-return error into a
precise one, mirroring how `ClientKernel.swift` already handles the runtime analogue
of this switch with `fatalError("unknown architecture")`. It is behavior-preserving
on the two supported architectures: the `#else` arm is inert there, so there is no
change to generated code or runtime behavior on Apple silicon or Intel.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

Built `swift build --target ContainerAPIClient` before and after the change; both
succeed on arm64, and only `Arch.swift` recompiles, confirming the `#else` arm is
inert on a supported architecture. `swift format lint --strict` reports no issues
and the formatter is a no-op on the file. The existing `ArchTests` suite passes.

No test was added: `hostArchitecture()` is resolved entirely at compile time, so the
`#else`/`#error` arm is stripped by the compiler and has no runtime code path to
exercise. `ArchTests` covers the runtime `Arch(rawValue:)` initializer, which is
unchanged.
