### PR TITLE
[Actions] Pin actions/deploy-pages to a commit SHA.

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -43,4 +43,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5


### PR DESCRIPTION

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Every third-party GitHub Action in `.github/workflows/` is pinned to a full
40-character commit SHA with a readable version comment, except one:
`actions/deploy-pages` in `.github/workflows/docs-release.yml` was still
referenced by the mutable major-version tag `@v5`.

Pinning to a SHA was already established for the imported actions in #1649
("[Actions] Use commit sha for imported gh actions"). `deploy-pages` was
introduced later and only ever bumped by Dependabot, so it was missed. This
change closes that gap so the convention is applied consistently.

The mutable tag matters here because the `deployDocs` job runs with
`pages: write` and `id-token: write`; pinning the SHA removes the risk that a
retagged or compromised `@v5` runs in that privileged job, and it makes the
action version reproducible.

`.github/dependabot.yml` already tracks `github-actions`, and Dependabot updates
SHA-pinned refs, so this adds no maintenance burden.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

Verification performed:
- The pinned SHA `cd2ce8fcbc39b97be8ca5fce6e763baed58fa128` is exactly what the
  `deploy-pages` `v5` tag currently resolves to (a lightweight tag pointing
  directly at the commit; `v5.0.0` resolves to the same commit), so the pin is
  behavior-preserving.
- After the change, `.github/workflows/` has no third-party `uses:` on a mutable
  `@vN`/`@main`/`@master` ref (`rg -n 'uses: [^.].*@(v[0-9]|main|master)'` returns
  nothing; before, it returned only this line).
- The new pin matches the sibling `actions/upload-pages-artifact@... # v5` in
  `common.yml`.
- The `docs-release.yml` deploy workflow is `workflow_dispatch`-only; behavior is
  unchanged, so the Pages deploy job continues to succeed.

### Diff (1 line)
```diff
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -43,4 +43,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
```
