### PR TITLE
Fix network list sample output in how-to docs.

### DIFF
--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -326,9 +326,9 @@ Run `container network list` to see the networks that exist:
 
 ```console
 % container network list
-NETWORK  STATE    SUBNET
-default  running  192.168.64.0/24
-foo      running  192.168.65.0/24
+NETWORK  SUBNET
+default  192.168.64.0/24
+foo      192.168.65.0/24
 %
 ```
 


### PR DESCRIPTION
```markdown
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context
The `container network list` example in `docs/how-to.md` shows a three-column
table with a `STATE` column and a `running` value on every row:

```
NETWORK  STATE    SUBNET
default  running  192.168.64.0/24
foo      running  192.168.65.0/24
```

The command does not print a `STATE` column. `NetworkResource`'s
`ListDisplayable` conformance defines exactly two columns, `NETWORK` and
`SUBNET` (`tableHeader = ["NETWORK", "SUBNET"]`,
`tableRow = [id, status.ipv4Subnet.description]`), and `container network list`
renders that verbatim, so real output has no `STATE` column and no `running`
value. The `STATE` column looks like it was copied from the `container ls`
example a few lines below, where a `STATE` column does exist.

This updates the sample to the real two-column output:

```
NETWORK  SUBNET
default  192.168.64.0/24
foo      192.168.65.0/24
```

The column spacing matches the CLI's table renderer (two spaces, last column
unpadded), so the block reflects exactly what a user sees.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [x] Added/updated docs

Documentation-only change; no code path is affected. The two-column contract is
already covered by `NetworkResourceDisplayTests` in
`Tests/ContainerCommandsTests/ListFormattingTests.swift`, which asserts
`NetworkResource.tableHeader == ["NETWORK", "SUBNET"]`, so the corrected sample
now matches what that test guarantees. Verified the block against the renderer
output; `swift build` is unaffected since no Swift source changed.
```
