### PR TITLE
Fix calculateCPUPercent docstring parameter names and units

### DIFF
--- a/Sources/ContainerCommands/Container/ContainerStats.swift
+++ b/Sources/ContainerCommands/Container/ContainerStats.swift
@@ -199,9 +199,9 @@ extension Application {
 
         /// Calculate CPU percentage from two stat snapshots
         /// - Parameters:
-        ///   - cpuUsageUsec1: CPU usage in microseconds from first sample
-        ///   - cpuUsageUsec2: CPU usage in microseconds from second sample
-        ///   - timeDeltaUsec: Time delta between samples in microseconds
+        ///   - cpuUsage1: Cumulative CPU time from the first sample
+        ///   - cpuUsage2: Cumulative CPU time from the second sample
+        ///   - timeInterval: Elapsed wall-clock time between the two samples
         /// - Returns: CPU percentage where 100% = one fully utilized core
         static func calculateCPUPercent(
             cpuUsage1: Duration,


### PR DESCRIPTION

```
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context
The DocC docstring for `calculateCPUPercent` in
`Sources/ContainerCommands/Container/ContainerStats.swift` documented parameters
that no longer exist on the function. The `- Parameters:` block listed
`cpuUsageUsec1`, `cpuUsageUsec2`, and `timeDeltaUsec`, each described as "in
microseconds", but the actual signature is:

```swift
static func calculateCPUPercent(
    cpuUsage1: Duration,
    cpuUsage2: Duration,
    timeInterval: Duration
) -> Double
```

So all three documented names were stale and the "microseconds" unit contradicted
the `Duration` parameter types (the body divides `Duration` by `Duration`
directly). DocC / Xcode flag `- Parameters:` entries whose names do not match the
signature, so this produced parameter-name warnings and misleading docs.

This updates the docstring to the real parameter names and describes them as the
durations they are:
- `cpuUsage1` / `cpuUsage2`: cumulative CPU time from each sample (the call site
  builds these with `.microseconds(cpuUsageUsec)` from the cumulative usage
  fields).
- `timeInterval`: the elapsed wall-clock time between the two samples (the call
  site passes `.seconds(2)`, the sampling interval).

Comment-only change; no behavior change.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

Doc-only change, so no unit test applies. Verified with the repo's tooling:
- `swift format lint --strict --configuration .swift-format-nolint` on the file:
  exit 0.
- `swift format --configuration .swift-format` on the file: no diff (already
  canonical).
- `swift build --target ContainerCommands`: builds cleanly; the file recompiles.
```
