### PR TITLE
Document image save and load stdout/stdin fallbacks.

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -598,12 +598,12 @@ container image push [--scheme <scheme>] [--progress <type>] [--arch <arch>] [--
 
 ### `container image save`
 
-Saves an image to a tar archive on disk. Useful for exporting images for offline transport.
+Saves an image to a tar archive. Useful for exporting images for offline transport. If no output file is specified, the tar stream is written to stdout.
 
 **Usage**
 
 ```bash
-container image save [--arch <arch>] [--os <os>] --output <output> [--platform <platform>] [--debug] <references> ...
+container image save [--arch <arch>] [--os <os>] [--output <output>] [--platform <platform>] [--debug] <references> ...
 ```
 
 **Arguments**
@@ -614,23 +614,43 @@ container image save [--arch <arch>] [--os <os>] --output <output> [--platform <
 
 *   `-a, --arch <arch>`: Architecture for the saved image
 *   `--os <os>`: OS for the saved image
-*   `-o, --output <output>`: Pathname for the saved image
+*   `-o, --output <output>`: Pathname for the saved image (defaults to stdout)
 *   `--platform <platform>`: Platform for the saved image (format: os/arch[/variant], takes precedence over --os and --arch)
+
+**Examples**
+
+```bash
+# save an image to a file
+container image save -o myimage.tar myimage:latest
+
+# save to stdout and pipe to another tool
+container image save myimage:latest > myimage.tar
+```
 
 ### `container image load`
 
-Loads images from a tar archive created by `image save`. Specify the tar file with `--input`.
+Loads images from a tar archive created by `image save`. If no input file is specified, the archive is read from stdin.
 
 **Usage**
 
 ```bash
-container image load --input <input> [--force] [--debug]
+container image load [--input <input>] [--force] [--debug]
 ```
 
 **Options**
 
-*   `-i, --input <input>`: Path to the image tar archive
+*   `-i, --input <input>`: Path to the image tar archive (defaults to stdin)
 *   `-f, --force`: Load images even if invalid member files are detected
+
+**Examples**
+
+```bash
+# load images from a file
+container image load -i myimage.tar
+
+# load images from stdin
+container image load < myimage.tar
+```
 
 ### `container image tag`
 


### PR DESCRIPTION

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context
The command reference documented `container image save --output` and
`container image load --input` as required flags, which hid the piping workflow.
Both options are optional: when `--output` is omitted, `image save` writes the OCI
archive to stdout, and when `--input` is omitted, `image load` reads the archive
from stdin. This is what the code already does:

- `ImageSave.swift` declares `var output: FilePath?` (optional) and, when it is
  absent, streams the archive to `FileHandle.standardOutput`.
- `ImageLoad.swift` declares `var input: FilePath?` (optional) and, when it is
  absent, reads the archive from `FileHandle.standardInput`.

The docs were never updated after that stdin/stdout support landed, so the
synopsis and prose still marked the flags as required. This change brings the
reference in line with the behavior and matches how the sibling `container export`
entry already documents its stdout fallback.

Specifically, for both `image save` and `image load` it:
- brackets `[--output <output>]` / `[--input <input>]` in the synopsis so they read
  as optional,
- reworks the description to note the stdout / stdin fallback (dropping the
  inaccurate "on disk" for save and "The tar file must be specified via `--input`."
  for load),
- annotates the option bullets with "(defaults to stdout)" / "(defaults to stdin)",
- adds a short Examples block showing both a file and a piped invocation.

No code changes; documentation only.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [x] Added/updated docs

Verified the documented behavior against the source in
`Sources/ContainerCommands/Image/`: the optional `output` / `input` options and
the stdout / stdin fallback branches. Reviewed the rendered Markdown for the
`image save` and `image load` sections; `git diff --check` is clean. No automated
test applies to a documentation-only change (the file is hand-maintained, not
generated).
