### PR TITLE
Cancel the SIGWINCH forwarding task when a build ends

### DIFF
--- a/Sources/ContainerBuild/Builder.swift
+++ b/Sources/ContainerBuild/Builder.swift
@@ -101,37 +101,36 @@ public struct Builder: Sendable {
             throw Error.invalidContinuation
         }
 
-        defer {
-            continuation.finish()
+        let winchHandler = config.terminal != nil ? AsyncSignalHandler.create(notify: [SIGWINCH]) : nil
+        let winchTask: Task<Void, Never>? = config.terminal.map { terminal in
+            let signals = winchHandler!.signals
+            return Task {
+                await Self.forwardTerminalResize(
+                    signals: signals,
+                    readSize: {
+                        let size = try terminal.size
+                        return (rows: size.height, cols: size.width)
+                    },
+                    send: { rows, cols in
+                        var winch = ClientStream()
+                        winch.command = .init()
+                        if let cmdString = try TerminalCommand(rows: rows, cols: cols).json() {
+                            winch.command.command = cmdString
+                            continuation.yield(winch)
+                        }
+                    },
+                    logger: self.logger
+                )
+            }
         }
 
-        if let terminal = config.terminal {
-            Task {
-                let winchHandler = AsyncSignalHandler.create(notify: [SIGWINCH])
-                let setWinch = { (rows: UInt16, cols: UInt16) in
-                    var winch = ClientStream()
-                    winch.command = .init()
-                    if let cmdString = try TerminalCommand(rows: rows, cols: cols).json() {
-                        winch.command.command = cmdString
-                        continuation.yield(winch)
-                    }
-                }
-                let size = try terminal.size
-                var width = size.width
-                var height = size.height
-                try setWinch(height, width)
-
-                for await _ in winchHandler.signals {
-                    let size = try terminal.size
-                    let cols = size.width
-                    let rows = size.height
-                    if cols != width || rows != height {
-                        width = cols
-                        height = rows
-                        try setWinch(height, width)
-                    }
-                }
-            }
+        defer {
+            // Tear down the SIGWINCH forwarder so its signal handler is not left
+            // registered and the task does not outlive the build (finishing the
+            // stream ends the `for await` loop, then cancel the task).
+            winchHandler?.cancel()
+            winchTask?.cancel()
+            continuation.finish()
         }
 
         let pipeline = try await BuildPipeline(config)
@@ -153,6 +152,48 @@ public struct Builder: Sendable {
             self.clientTask.cancel()
             try await group.shutdownGracefully()
             return
+        }
+    }
+
+    /// Forwards terminal window-size (SIGWINCH) changes to the remote build.
+    ///
+    /// Sends the initial size, then re-sends whenever a signal arrives and the
+    /// size has changed. Errors from `readSize`/`send` are logged rather than
+    /// dropped so a single transient failure (for example a momentarily
+    /// unavailable controlling tty) does not silently stop resize forwarding for
+    /// the rest of the build. Returns when `signals` finishes, which happens when
+    /// the owning task is cancelled and its signal handler is torn down.
+    static func forwardTerminalResize(
+        signals: AsyncStream<Int32>,
+        readSize: @escaping @Sendable () throws -> (rows: UInt16, cols: UInt16),
+        send: @escaping @Sendable (_ rows: UInt16, _ cols: UInt16) throws -> Void,
+        logger: Logger
+    ) async {
+        var width: UInt16?
+        var height: UInt16?
+
+        func update() {
+            do {
+                let size = try readSize()
+                guard size.cols != width || size.rows != height else {
+                    return
+                }
+                try send(size.rows, size.cols)
+                width = size.cols
+                height = size.rows
+            } catch {
+                logger.error(
+                    "failed to forward terminal resize event",
+                    metadata: [
+                        "error": "\(error)"
+                    ]
+                )
+            }
+        }
+
+        update()
+        for await _ in signals {
+            update()
         }
     }
 

--- a/Tests/ContainerBuildTests/BuilderResizeForwardingTests.swift
+++ b/Tests/ContainerBuildTests/BuilderResizeForwardingTests.swift
@@ -1,0 +1,131 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Logging
+import Synchronization
+import Testing
+
+@testable import ContainerBuild
+
+struct BuilderResizeForwardingTests {
+    /// A transient failure while reading the terminal size must be logged and
+    /// must not stop resize forwarding for the rest of the build: a later signal
+    /// with a changed size should still be forwarded.
+    @Test func readSizeFailureIsLoggedAndForwardingContinues() async throws {
+        let collector = CollectingLogHandler.Storage()
+        var logger = Logger(label: "test") { _ in CollectingLogHandler(storage: collector) }
+        logger.logLevel = .trace
+
+        let readCount = Mutex(0)
+        let sent = Mutex<[(rows: UInt16, cols: UInt16)]>([])
+
+        let (signals, continuation) = AsyncStream.makeStream(of: Int32.self)
+
+        let forwarder = Task {
+            await Builder.forwardTerminalResize(
+                signals: signals,
+                readSize: {
+                    let call = readCount.withLock { value -> Int in
+                        value += 1
+                        return value
+                    }
+                    switch call {
+                    case 1: return (rows: 24, cols: 80)  // initial size
+                    case 2: throw POSIXError(.EIO)  // transient failure
+                    default: return (rows: 30, cols: 100)  // recovered, changed size
+                    }
+                },
+                send: { rows, cols in
+                    sent.withLock { $0.append((rows: rows, cols: cols)) }
+                },
+                logger: logger
+            )
+        }
+
+        continuation.yield(SIGWINCH)  // triggers the failing read
+        continuation.yield(SIGWINCH)  // triggers the recovered read
+        continuation.finish()
+        await forwarder.value
+
+        let sentSizes = sent.withLock { $0 }
+        #expect(sentSizes.count == 2)
+        #expect(sentSizes.first.map { $0 == (rows: 24, cols: 80) } == true)
+        #expect(sentSizes.last.map { $0 == (rows: 30, cols: 100) } == true)
+        #expect(collector.errorMessages.contains { $0.contains("terminal resize") })
+    }
+
+    /// The forwarder must return once the signal stream finishes. In production
+    /// the owning task cancels the signal handler, which finishes the stream, so
+    /// the SIGWINCH watcher does not outlive the build.
+    @Test func forwarderReturnsWhenSignalStreamFinishes() async throws {
+        let sent = Mutex(0)
+        let (signals, continuation) = AsyncStream.makeStream(of: Int32.self)
+
+        let forwarder = Task {
+            await Builder.forwardTerminalResize(
+                signals: signals,
+                readSize: { (rows: 24, cols: 80) },
+                send: { _, _ in sent.withLock { $0 += 1 } },
+                logger: Logger(label: "test") { _ in SwiftLogNoOpLogHandler() }
+            )
+        }
+
+        continuation.finish()
+        await forwarder.value  // returns only if the loop exited on stream finish
+
+        // Only the initial size is sent; no signals were delivered.
+        #expect(sent.withLock { $0 } == 1)
+    }
+}
+
+/// Minimal `LogHandler` that records emitted error messages for assertions.
+private struct CollectingLogHandler: LogHandler {
+    final class Storage: Sendable {
+        private let messages = Mutex<[String]>([])
+
+        var errorMessages: [String] {
+            messages.withLock { $0 }
+        }
+
+        func append(_ message: String) {
+            messages.withLock { $0.append(message) }
+        }
+    }
+
+    let storage: Storage
+    var metadata: Logger.Metadata = [:]
+    var logLevel: Logger.Level = .trace
+
+    subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+        get { metadata[key] }
+        set { metadata[key] = newValue }
+    }
+
+    func log(
+        level: Logger.Level,
+        message: Logger.Message,
+        metadata: Logger.Metadata?,
+        source: String,
+        file: String,
+        function: String,
+        line: UInt
+    ) {
+        if level >= .error {
+            storage.append(message.description)
+        }
+    }
+}


### PR DESCRIPTION

```markdown
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
In `Builder.build` (`Sources/ContainerBuild/Builder.swift`), when a terminal is
attached the SIGWINCH terminal-resize watcher is launched as a bare, unstructured
`Task {}` that returns `Void` and is never stored or cancelled. That causes three
lifecycle and error-handling problems:

- Dropped errors: because the task returns `Void`, every `try` inside it silently
  discards its error. A single throw from `terminal.size` (for example a momentarily
  unavailable controlling tty) tears down the whole `for await` resize loop, so
  terminal-resize forwarding to the remote build stops for the rest of the build with
  no diagnostic.
- Leaked handler and task: the fire-and-forget task keeps a process-wide
  `AsyncSignalHandler` registered for SIGWINCH and stays parked in `for await` after
  `build` returns (via either the normal completion or the `catch Error.buildComplete`
  path), so in a long-lived invocation both outlive the build.
- Use-after-finish: `build` finishes the request stream in a `defer`, but the
  still-live task can `continuation.yield` to the finished stream on the next resize.
  That is a silent no-op today, but the resize is lost and the ownership is wrong.

This is the build path (`Builder.build`), which is distinct from the in-flight
`container run` process-signal changes (#1854, #1871, #1778); no open PR touches this
resize-forwarding code.

The fix extracts the forwarding loop into a small `forwardTerminalResize` helper that
logs read/send errors instead of dropping them, mirroring the existing pattern in
`ProcessIO.handleProcess`, which already logs "failed to send terminal resize event"
rather than swallowing it. So a transient failure no longer permanently stops
forwarding. `build` now stores the watcher task and its signal handler and tears both
down alongside the continuation finish in the same `defer`, so the watcher never
outlives the build. Initial-size behavior is unchanged: the first update always sends
the current size, then re-sends only when the size changes.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

Added `Tests/ContainerBuildTests/BuilderResizeForwardingTests.swift`:
- `readSizeFailureIsLoggedAndForwardingContinues`: a transient `readSize` failure is
  logged and forwarding continues, so a later changed size is still forwarded (two
  sends across the error, and the error is logged). This fails on the old
  drop-and-teardown behavior and passes with the fix.
- `forwarderReturnsWhenSignalStreamFinishes`: the helper returns once the signal
  stream finishes, which is what task cancellation triggers via the handler teardown,
  so the watcher does not outlive the build.

Verified with the Xcode toolchain:
- `swift build --target ContainerBuild` - build complete.
- `swift test --filter ContainerBuildTests` - 42 tests across 4 suites pass,
  including both new tests.
- `swift format lint --strict` on the two changed files - clean.
- License header on the new file applied via `make update-licenses`.
```

---

## Files changed (2, both intended; no unrelated edits)
- `Sources/ContainerBuild/Builder.swift` (+70/-29): extract `forwardTerminalResize`
  (log-not-drop errors); `build` creates the `AsyncSignalHandler` eagerly only when a
  terminal is set, stores the watcher `Task`, and cancels handler+task in the existing
  `defer` next to `continuation.finish()`.
- `Tests/ContainerBuildTests/BuilderResizeForwardingTests.swift` (new, 131 lines):
  the two regression tests + a minimal collecting `LogHandler`.

## Where to open the PR
- Base: `apple/container` `main`. Head: fork `anxkhn/container` branch `patch-4`.
- Fork/push/PR happen ONLY at the gated ship step. The upstream commit must be
  cryptographically signed (GPG/SSH) per apple/containerization CONTRIBUTING (this is
  signing, NOT DCO `-s`); the local implement commit is unsigned, so signing is applied
  when the commit is created/amended at ship.
