### PR TITLE
fix: correct typos in documentation comments

### DIFF
--- a/Sources/ContainerLog/ServiceLogger.swift
+++ b/Sources/ContainerLog/ServiceLogger.swift
@@ -24,7 +24,7 @@ public struct ServiceLogger {
     /// - Parameters:
     ///   - label: A unique identifier for the application.
     ///   - category: An identifier for the application subsystem.
-    ///   - metadata: Metadata to include for all messsages. A message
+    ///   - metadata: Metadata to include for all messages. A message
     ///     specific value for a duplicate key overrides these values.
     ///   - debug: Enable debug logging.
     ///   - logPath: If supplied, create log files under the named

--- a/Sources/ContainerResource/Container/PublishPort.swift
+++ b/Sources/ContainerResource/Container/PublishPort.swift
@@ -22,7 +22,7 @@ public enum PublishProtocol: String, Sendable, Codable {
     case tcp = "tcp"
     case udp = "udp"
 
-    /// Initialize a protocol with to default value, `.tcp`.
+    /// Initialize a protocol with the default value, `.tcp`.
     public init() {
         self = .tcp
     }


### PR DESCRIPTION
## Summary

Fix two typos found in documentation comments:

- `Sources/ContainerLog/ServiceLogger.swift` (line 27): `messsages` → `messages` (triple "s")
- `Sources/ContainerResource/Container/PublishPort.swift` (line 25): `with to default value` → `with the default value`

These are minor documentation-only changes with no functional impact.