### PR TITLE
Fix exec hang and stop timeout

### DIFF
--- a/Sources/APIServer/APIServer+Start.swift
+++ b/Sources/APIServer/APIServer+Start.swift
@@ -298,7 +298,7 @@ extension APIServer {
             routes[XPCRoute.containerDial] = XPCServer.route(harness.dial)
             routes[XPCRoute.containerStop] = XPCServer.route(harness.stop)
             routes[XPCRoute.containerStartProcess] = XPCServer.route(harness.startProcess)
-            routes[XPCRoute.containerCreateProcess] = XPCServer.route(harness.createProcess)
+            routes[XPCRoute.containerCreateProcess] = harness.createProcess
             routes[XPCRoute.containerResize] = XPCServer.route(harness.resize)
             routes[XPCRoute.containerWait] = XPCServer.route(harness.wait)
             routes[XPCRoute.containerKill] = XPCServer.route(harness.kill)

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersHarness.swift
@@ -203,7 +203,7 @@ public struct ContainersHarness: Sendable {
     }
 
     @Sendable
-    public func createProcess(_ message: XPCMessage) async throws -> XPCMessage {
+    public func createProcess(_ message: XPCMessage, session: XPCServerSession) async throws -> XPCMessage {
         let id = message.string(key: .id)
         guard let id else {
             throw ContainerizationError(
@@ -227,6 +227,11 @@ public struct ContainersHarness: Sendable {
             config: config,
             stdio: stdio
         )
+
+        await session.onDisconnect { [service] in
+            // Clean up the process if the client connection drops unexpectedly
+            try? await service.kill(id: id, processID: processID, signal: "SIGKILL")
+        }
 
         return message.reply()
     }

--- a/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
+++ b/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
@@ -583,7 +583,7 @@ public actor RuntimeService {
         let id = try message.id()
         let signal = try Signal(message.signal())
 
-        try await self.lock.withLock { [self] _ in
+        let skipWait: Bool = try await self.lock.withLock { [self] _ in
             switch await self.state {
             case .running:
                 let ctr = try await getContainer()
@@ -595,11 +595,30 @@ public actor RuntimeService {
                     guard let proc = processInfo.process else {
                         throw ContainerizationError(.invalidState, message: "process \(id) not started")
                     }
-                    try await proc.kill(signal)
-                    return
+                    do {
+                        try await proc.kill(signal)
+                    } catch {
+                        let errStr = String(describing: error)
+                        if errStr.contains("clientIsStopped") {
+                            return true
+                        } else {
+                            throw error
+                        }
+                    }
+                    return false
                 }
 
-                try await ctr.container.kill(signal)
+                do {
+                    try await ctr.container.kill(signal)
+                } catch {
+                    let errStr = String(describing: error)
+                    if errStr.contains("clientIsStopped") {
+                        return true
+                    } else {
+                        throw error
+                    }
+                }
+                return false
             default:
                 throw ContainerizationError(
                     .invalidState,
@@ -608,9 +627,14 @@ public actor RuntimeService {
             }
         }
 
+        if skipWait {
+            self.log.debug("Kill ignored because agent is stopped (process likely already exited)", metadata: ["id": "\(id)"])
+            self.releaseWaiters(for: id, status: ExitStatus(exitCode: 255))
+        }
+
         // SIGKILL is guaranteed by the kernel to terminate the target, so block
         // until we observe the exit.
-        if signal == .kill {
+        if signal == .kill && !skipWait {
             _ = await withCheckedContinuation { cc in
                 self.waitForExit(id: id, cont: cc)
             }

--- a/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
+++ b/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
@@ -518,31 +518,52 @@ public actor RuntimeService {
         let signal = try Signal(stopOptions.signal ?? "SIGTERM")
         let timeout: Duration = .seconds(stopOptions.timeoutInSeconds)
 
-        return try await self.lock.withLock { _ in
-            switch await self.state {
-            case .running, .booted:
-                await self.setState(.stopping)
+        return try await withThrowingTaskGroup(of: XPCMessage.self) { group in
+            group.addTask {
+                return try await self.lock.withLock { _ in
+                    switch await self.state {
+                    case .running, .booted:
+                        await self.setState(.stopping)
 
-                let ctr = try await self.getContainer()
-                let exitStatus = try await self.gracefulStopContainer(
-                    ctr.container,
-                    signal: signal,
-                    timeout: timeout
-                )
+                        let ctr = try await self.getContainer()
+                        let exitStatus = try await self.gracefulStopContainer(
+                            ctr.container,
+                            signal: signal,
+                            timeout: timeout
+                        )
 
-                do {
-                    if case .stopped = await self.state {
-                        return message.reply()
+                        do {
+                            if case .stopped = await self.state {
+                                return message.reply()
+                            }
+                            try await self.cleanUpContainer(containerInfo: ctr, exitStatus: exitStatus)
+                        } catch {
+                            self.log.error("failed to clean up container", metadata: ["error": "\(error)"])
+                        }
+                        await self.setState(.stopped)
+                    default:
+                        break
                     }
-                    try await self.cleanUpContainer(containerInfo: ctr, exitStatus: exitStatus)
-                } catch {
-                    self.log.error("failed to clean up container", metadata: ["error": "\(error)"])
+                    return message.reply()
                 }
-                await self.setState(.stopped)
-            default:
-                break
             }
-            return message.reply()
+
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                self.log.warning("stop operation timed out; force killing the container")
+                if let ctr = try? await self.getContainer() {
+                    try? await ctr.container.kill(.kill)
+                    try? await self.cleanUpContainer(containerInfo: ctr, exitStatus: ExitStatus(exitCode: 137))
+                    await self.setState(.stopped)
+                }
+                return message.reply()
+            }
+
+            guard let result = try await group.next() else {
+                throw ContainerizationError(.internalError, message: "stop failed")
+            }
+            group.cancelAll()
+            return result
         }
     }
 


### PR DESCRIPTION
Fixes #1916 

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
This PR resolves a critical bug where `container exec` and `container stop` commands hang indefinitely when an SSH session disconnects abruptly (or the terminal window is closed without cleanly exiting). 

The underlying issues were identified and addressed in two distinct commits:

1. **PTY Resource Leak / Orphaned Process:** When an XPC client connection dropped unexpectedly (e.g., SIGHUP, broken pipe), the corresponding exec process inside the container remained orphaned. Subsequent `exec` attempts would try to acquire the same resources, hit a blocking read/write on a dead file descriptor, and hang indefinitely. This was fixed by registering an `onDisconnect` listener in `ContainersHarness` to forcefully kill the specific orphaned process upon a client disconnect.
2. **Ignored Stop Timeout:** The `container stop` command completely ignored the `stopTimeoutSeconds` flag if an exec session was blocking the `RuntimeService` actor lock. This PR wraps the lock acquisition and the graceful stop sequence inside a `withThrowingTaskGroup`. This ensures that even if an exec session is infinitely holding the lock, the container is forcefully killed if it doesn't shut down within the designated 5-second timeout window.

Fixing these primary issues also inherently prevents the secondary symptom where `container list` incorrectly reports the container as `running` while `container exec` fails.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

**Local Test Verification:**
```text
# Simulated a SIGHUP abrupt disconnect to an active SSH/bash session, 
# then immediately started a new exec session. It connected instantly without hanging:
./.build/debug/container exec -it test0 bash
root@test0:/# echo SUCCESS_EXEC
SUCCESS_EXEC

# Verified the stop timeout enforcement triggers gracefully:
./.build/debug/container stop test0
test0
./.build/debug/container stop test0  0.02s user 0.01s system 0% cpu 5.875 total

# Verified correct state sync:
./.build/debug/container list --all
ID     IMAGE                            OS     ARCH   STATE    STARTED
test0  docker.io/library/ubuntu:latest  linux  arm64  stopped  2026-07-09T11:22:51Z