### PR TITLE
Fix XPC file handle ownership

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -477,6 +477,12 @@ let package = Package(
                 "CAuditToken",
             ]
         ),
+        .testTarget(
+            name: "ContainerXPCTests",
+            dependencies: [
+                "ContainerXPC"
+            ]
+        ),
         .target(
             name: "ContainerOS",
             dependencies: [

--- a/Sources/ContainerCommands/Container/ContainerLogs.swift
+++ b/Sources/ContainerCommands/Container/ContainerLogs.swift
@@ -49,6 +49,8 @@ extension Application {
             let client = ContainerClient()
             let fhs = try await client.logs(id: containerId)
             let fileHandle = boot ? fhs[1] : fhs[0]
+            let unusedFileHandle = boot ? fhs[0] : fhs[1]
+            try? unusedFileHandle.close()
 
             try await Self.tail(
                 fh: fileHandle,

--- a/Sources/ContainerCommands/Machine/MachineLogs.swift
+++ b/Sources/ContainerCommands/Machine/MachineLogs.swift
@@ -59,6 +59,8 @@ extension Application {
 
             let fhs = try await client.logs(id: id)
             let fileHandle = boot ? fhs[1] : fhs[0]
+            let unusedFileHandle = boot ? fhs[0] : fhs[1]
+            try? unusedFileHandle.close()
 
             try await Self.tail(
                 fh: fileHandle,

--- a/Sources/ContainerXPC/XPCMessage.swift
+++ b/Sources/ContainerXPC/XPCMessage.swift
@@ -221,14 +221,16 @@ extension XPCMessage {
         }
         if let fd {
             let fd2 = xpc_fd_dup(fd)
-            return FileHandle(fileDescriptor: fd2, closeOnDealloc: false)
+            guard fd2 != -1 else {
+                return nil
+            }
+            return FileHandle(fileDescriptor: fd2, closeOnDealloc: true)
         }
         return nil
     }
 
     public func set(key: String, value: FileHandle) {
         let fd = xpc_fd_create(value.fileDescriptor)
-        close(value.fileDescriptor)
         lock.withLock {
             xpc_dictionary_set_value(self.object, key, fd)
         }
@@ -242,11 +244,17 @@ extension XPCMessage {
             let fd1 = xpc_array_dup_fd(fds, 0)
             let fd2 = xpc_array_dup_fd(fds, 1)
             if fd1 == -1 || fd2 == -1 {
+                if fd1 != -1 {
+                    close(fd1)
+                }
+                if fd2 != -1 {
+                    close(fd2)
+                }
                 return nil
             }
             return [
-                FileHandle(fileDescriptor: fd1, closeOnDealloc: false),
-                FileHandle(fileDescriptor: fd2, closeOnDealloc: false),
+                FileHandle(fileDescriptor: fd1, closeOnDealloc: true),
+                FileHandle(fileDescriptor: fd2, closeOnDealloc: true),
             ]
         }
         return nil
@@ -262,7 +270,6 @@ extension XPCMessage {
                 )
             }
             xpc_array_append_value(fdArray, xpcFd)
-            close(fh.fileDescriptor)
         }
         lock.withLock {
             xpc_dictionary_set_value(self.object, key, fdArray)

--- a/Tests/ContainerXPCTests/XPCMessageTests.swift
+++ b/Tests/ContainerXPCTests/XPCMessageTests.swift
@@ -1,0 +1,107 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerXPC
+import Darwin
+import Foundation
+import Testing
+
+@Suite(.serialized)
+struct XPCMessageTests {
+    @Test("Repeatedly reading log handles closes the returned descriptors")
+    func repeatedLogFileHandlesDoNotLeak() throws {
+        let sources = [
+            try #require(FileHandle(forReadingAtPath: "/dev/null")),
+            try #require(FileHandle(forReadingAtPath: "/dev/null")),
+        ]
+        defer { sources.forEach { try? $0.close() } }
+
+        let message = XPCMessage(route: "logs")
+        try message.set(key: "logs", value: sources)
+
+        for _ in 0..<100 {
+            let descriptors: [Int32] = autoreleasepool {
+                var handles: [FileHandle]? = message.fileHandles(key: "logs")!
+                defer { handles = nil }
+                return handles!.map(\.fileDescriptor)
+            }
+            assertDescriptorsAreClosed(descriptors)
+        }
+    }
+
+    @Test("Repeatedly reading a dial handle closes the returned descriptor")
+    func repeatedDialFileHandleDoesNotLeak() throws {
+        let source = try #require(FileHandle(forReadingAtPath: "/dev/null"))
+        defer { try? source.close() }
+
+        let message = XPCMessage(route: "dial")
+        message.set(key: "fd", value: source)
+
+        for _ in 0..<100 {
+            let descriptor: Int32 = autoreleasepool {
+                var handle: FileHandle? = message.fileHandle(key: "fd")!
+                defer { handle = nil }
+                return handle!.fileDescriptor
+            }
+            assertDescriptorsAreClosed([descriptor])
+        }
+    }
+
+    @Test("Setting a file handle does not consume the source descriptor")
+    func settingFileHandleDoesNotConsumeSource() throws {
+        let source = try #require(FileHandle(forReadingAtPath: "/dev/null"))
+        defer { try? source.close() }
+
+        let message = XPCMessage(route: "dial")
+        message.set(key: "fd", value: source)
+
+        #expect(isDescriptorOpen(source.fileDescriptor))
+    }
+
+    @Test("Setting file handles does not consume the source descriptors")
+    func settingFileHandlesDoesNotConsumeSources() throws {
+        let sources = [
+            try #require(FileHandle(forReadingAtPath: "/dev/null")),
+            try #require(FileHandle(forReadingAtPath: "/dev/null")),
+        ]
+        defer { sources.forEach { try? $0.close() } }
+
+        let message = XPCMessage(route: "logs")
+        try message.set(key: "logs", value: sources)
+
+        #expect(sources.allSatisfy { isDescriptorOpen($0.fileDescriptor) })
+    }
+
+    private func assertDescriptorsAreClosed(_ descriptors: [Int32]) {
+        for descriptor in descriptors {
+            let closed = isDescriptorClosed(descriptor)
+            #expect(closed)
+            if !closed {
+                close(descriptor)
+            }
+        }
+    }
+
+    private func isDescriptorOpen(_ descriptor: Int32) -> Bool {
+        errno = 0
+        return fcntl(descriptor, F_GETFD) != -1
+    }
+
+    private func isDescriptorClosed(_ descriptor: Int32) -> Bool {
+        errno = 0
+        return fcntl(descriptor, F_GETFD) == -1 && errno == EBADF
+    }
+}


### PR DESCRIPTION
## Summary

- Make file handles returned by `XPCMessage` own their duplicated descriptors.
- Keep caller-owned `FileHandle` values open when adding them to an XPC message.
- Close the unused log descriptor in the container and machine log commands.
- Add repeated log/dial descriptor lifetime tests.

`xpc_fd_create` duplicates its input descriptor, so the setters do not need to consume the caller's `FileHandle`. The getters also duplicate descriptors; making the returned handles close on deallocation gives those descriptors a clear owner and prevents repeated log/dial operations from leaking them.

## Validation

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make test`
- Swift format lint
- Hawkeye license check
