### PR TITLE
fix(version): preserve unspecified commit placeholder

### DIFF
--- a/Sources/ContainerVersion/ReleaseVersion.swift
+++ b/Sources/ContainerVersion/ReleaseVersion.swift
@@ -20,10 +20,17 @@ import Foundation
 public struct ReleaseVersion {
     public static func singleLine(appName: String) -> String {
         var versionDetails: [String: String] = ["build": buildType()]
-        versionDetails["commit"] = gitCommit().map { String($0.prefix(7)) } ?? "unspecified"
+        versionDetails["commit"] = displayCommit(gitCommit())
         let extras: String = versionDetails.map { "\($0): \($1)" }.sorted().joined(separator: ", ")
 
         return "\(appName) version \(version()) (\(extras))"
+    }
+
+    static func displayCommit(_ commit: String?) -> String {
+        guard let commit, !commit.isEmpty, commit != "unspecified" else {
+            return "unspecified"
+        }
+        return String(commit.prefix(7))
     }
 
     public static func buildType() -> String {

--- a/Tests/ContainerVersionTests/ReleaseVersionTests.swift
+++ b/Tests/ContainerVersionTests/ReleaseVersionTests.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import ContainerVersion
+
+struct ReleaseVersionTests {
+    @Test func displayCommitKeepsUnspecifiedPlaceholder() {
+        #expect(ReleaseVersion.displayCommit(nil) == "unspecified")
+        #expect(ReleaseVersion.displayCommit("") == "unspecified")
+        #expect(ReleaseVersion.displayCommit("unspecified") == "unspecified")
+    }
+
+    @Test func displayCommitShortensGitCommit() {
+        #expect(ReleaseVersion.displayCommit("1234567890abcdef") == "1234567")
+    }
+}


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Supersedes #1831, whose deleted fork head cannot be reattached to the closed review.

When `container` is built without a `GIT_COMMIT` value, the C version shim returns `unspecified`. `ReleaseVersion.singleLine(appName:)` currently shortens every non-nil commit string to seven characters, so the version banner reports `commit: unspeci`.

The change preserves missing, empty, and `unspecified` commit values as the full placeholder while retaining the seven-character display for real commit hashes.

## What Changed

- Centralizes commit display formatting in `ReleaseVersion.displayCommit(_:)`.
- Preserves the complete `unspecified` placeholder.
- Keeps seven-character short hashes for real commits.
- Adds focused tests for nil, empty, placeholder, and real-hash values.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

Validation:

- `make swift-fmt-check`
- `make test`: 94 XCTest cases and 560 Swift Testing cases passed
- `swift test --disable-automatic-resolution --enable-code-coverage --filter ReleaseVersionTests`
- `env -u GIT_COMMIT swift build --disable-automatic-resolution --product container`
- `env -u GIT_COMMIT .build/debug/container --version`
- `git diff --check origin/main..HEAD`

The version smoke check reports:

```text
container CLI version 0.0.0 (build: debug, commit: unspecified)
```

The coverage run executes every branch and return path added by `displayCommit(_:)`.
