### PR TITLE
Add container upgrade command

### DIFF
--- a/Sources/ContainerCommands/Application.swift
+++ b/Sources/ContainerCommands/Application.swift
@@ -225,6 +225,7 @@ public struct Application: AsyncLoggableCommand {
             return [
                 BuilderCommand.self,
                 SystemCommand.self,
+                UpgradeCommand.self,
             ]
         }
 
@@ -232,6 +233,7 @@ public struct Application: AsyncLoggableCommand {
             BuilderCommand.self,
             NetworkCommand.self,
             SystemCommand.self,
+            UpgradeCommand.self,
         ]
     }
 

--- a/Sources/ContainerCommands/Upgrade/GitHubRelease.swift
+++ b/Sources/ContainerCommands/Upgrade/GitHubRelease.swift
@@ -1,0 +1,89 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// A downloadable asset attached to a GitHub release.
+struct GitHubReleaseAsset: Decodable, Equatable {
+    let name: String
+    let browserDownloadURL: URL
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case browserDownloadURL = "browser_download_url"
+    }
+}
+
+/// The subset of the GitHub release API response needed to upgrade `container`.
+struct GitHubRelease: Decodable, Equatable {
+    let tagName: String
+    let assets: [GitHubReleaseAsset]
+
+    enum CodingKeys: String, CodingKey {
+        case tagName = "tag_name"
+        case assets
+    }
+}
+
+/// An installer package selected from a release's assets.
+struct InstallerPackage: Equatable {
+    let url: URL
+    let isSigned: Bool
+}
+
+extension GitHubRelease {
+    /// The GitHub API endpoint for a release: the latest release when
+    /// `version` is nil, otherwise the release tagged `version`.
+    static func endpoint(forVersion version: String?) -> URL {
+        let base = "https://api.github.com/repos/apple/container/releases"
+        guard let version else {
+            return URL(string: "\(base)/latest")!
+        }
+        return URL(string: "\(base)/tags/\(version)")!
+    }
+
+    /// Selects the installer package, preferring signed packages, with the
+    /// same name precedence as `scripts/update-container.sh`.
+    func installerPackage() -> InstallerPackage? {
+        let signedNames = [
+            "container-installer-signed.pkg",
+            "container-\(tagName)-installer-signed.pkg",
+        ]
+        let unsignedNames = [
+            "container-installer-unsigned.pkg",
+            "container-\(tagName)-installer-unsigned.pkg",
+        ]
+        for name in signedNames {
+            if let match = assets.first(where: { $0.name == name }) {
+                return InstallerPackage(url: match.browserDownloadURL, isSigned: true)
+            }
+        }
+        for name in unsignedNames {
+            if let match = assets.first(where: { $0.name == name }) {
+                return InstallerPackage(url: match.browserDownloadURL, isSigned: false)
+            }
+        }
+        return nil
+    }
+}
+
+/// Decides whether an upgrade should proceed, mirroring the plain string
+/// comparison in `scripts/update-container.sh` (no semver ordering).
+enum UpgradePolicy {
+    static func shouldUpgrade(target: String, installed: String, force: Bool) -> Bool {
+        force || target != installed
+    }
+}

--- a/Sources/ContainerCommands/Upgrade/InstallationMethod.swift
+++ b/Sources/ContainerCommands/Upgrade/InstallationMethod.swift
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// How the `container` toolset was installed on this host, which determines
+/// how `container upgrade` performs the upgrade.
+enum InstallationMethod: Equatable {
+    /// Installed with the installer package from the GitHub release page;
+    /// identified by the `com.apple.container-installer` receipt.
+    case installerPackage
+    /// Installed with the Homebrew `container` formula; identified by the
+    /// executable resolving into a Homebrew Cellar.
+    case homebrew
+    /// No known installation source, e.g. a build from source.
+    case unknown
+
+    /// The package identifier recorded by the release-page installer,
+    /// matching `scripts/uninstall-container.sh`.
+    static let installerPackageID = "com.apple.container-installer"
+
+    /// Classifies the installation from the symlink-resolved path of the
+    /// running executable and the presence of the installer receipt. The
+    /// Cellar check runs first: on Intel Macs Homebrew shares the
+    /// `/usr/local` prefix with the installer package, and the resolved
+    /// path identifies which copy is actually running.
+    static func classify(resolvedExecutablePath: String, hasInstallerReceipt: Bool) -> InstallationMethod {
+        if resolvedExecutablePath.contains("/Cellar/container/") {
+            return .homebrew
+        }
+        if hasInstallerReceipt {
+            return .installerPackage
+        }
+        return .unknown
+    }
+
+    /// Detects the installation method of the running executable.
+    static func detect() -> InstallationMethod {
+        let executablePath = Bundle.main.executablePath ?? CommandLine.arguments[0]
+        let resolved = URL(fileURLWithPath: executablePath).resolvingSymlinksInPath().path
+        return classify(resolvedExecutablePath: resolved, hasInstallerReceipt: hasInstallerReceipt())
+    }
+
+    private static func hasInstallerReceipt() -> Bool {
+        let query = Process()
+        query.executableURL = URL(fileURLWithPath: "/usr/sbin/pkgutil")
+        query.arguments = ["--pkg-info", installerPackageID]
+        query.standardOutput = FileHandle.nullDevice
+        query.standardError = FileHandle.nullDevice
+        do {
+            try query.run()
+        } catch {
+            return false
+        }
+        query.waitUntilExit()
+        return query.terminationStatus == 0
+    }
+}

--- a/Sources/ContainerCommands/Upgrade/UpgradeCommand.swift
+++ b/Sources/ContainerCommands/Upgrade/UpgradeCommand.swift
@@ -31,8 +31,8 @@ extension Application {
         /// Launchd prefix of the services that must be stopped before upgrading.
         private static let launchdPrefix = "com.apple.container."
 
-        @Option(name: .shortAndLong, help: "Upgrade to a specific release version (defaults to the latest release)")
-        var version: String?
+        @Option(name: [.customShort("v"), .customLong("release")], help: "Upgrade to a specific release version (defaults to the latest release)")
+        var release: String?
 
         @Flag(name: .shortAndLong, help: "Force the upgrade even if the target version is already installed")
         var force = false
@@ -52,25 +52,25 @@ extension Application {
                 )
             }
 
-            let release = try await fetchRelease()
-            let target = release.tagName
+            let targetRelease = try await fetchRelease()
+            let target = targetRelease.tagName
             let installed = ReleaseVersion.version()
 
             guard UpgradePolicy.shouldUpgrade(target: target, installed: installed, force: force) else {
-                if version == nil {
+                if release == nil {
                     print("Container is already on latest version \(target) (use -f to force update)")
                 } else {
                     print("Container is already on version \(target) (use -f to force update)")
                 }
                 return
             }
-            if version == nil {
+            if release == nil {
                 print("Updating to latest version \(target)")
             } else {
                 print("Updating to release version \(target)")
             }
 
-            guard let package = release.installerPackage() else {
+            guard let package = targetRelease.installerPackage() else {
                 throw ContainerizationError(.notFound, message: "No suitable package found")
             }
             if !package.isSigned {
@@ -94,23 +94,21 @@ extension Application {
         }
 
         private func fetchRelease() async throws -> GitHubRelease {
-            let endpoint = GitHubRelease.endpoint(forVersion: version)
+            let endpoint = GitHubRelease.endpoint(forVersion: release)
             let failureMessage =
-                version.map { "Release '\($0)' not found" } ?? "Failed fetching latest release"
+                release.map { "Release '\($0)' not found" } ?? "Failed fetching latest release"
 
-            let data: Data
             do {
                 let (body, response) = try await URLSession.shared.data(from: endpoint)
                 guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
                     throw ContainerizationError(.notFound, message: failureMessage)
                 }
-                data = body
+                return try JSONDecoder().decode(GitHubRelease.self, from: body)
             } catch let error as ContainerizationError {
                 throw error
             } catch {
                 throw ContainerizationError(.internalError, message: "\(failureMessage): \(error)")
             }
-            return try JSONDecoder().decode(GitHubRelease.self, from: data)
         }
 
         private func confirmUnsignedPackage() -> Bool {

--- a/Sources/ContainerCommands/Upgrade/UpgradeCommand.swift
+++ b/Sources/ContainerCommands/Upgrade/UpgradeCommand.swift
@@ -1,0 +1,168 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ContainerAPIClient
+import ContainerPlugin
+import ContainerVersion
+import ContainerizationError
+import Foundation
+
+extension Application {
+    public struct UpgradeCommand: AsyncLoggableCommand {
+        public static let configuration = CommandConfiguration(
+            commandName: "upgrade",
+            abstract: "Upgrade container to the latest or a specific release"
+        )
+
+        /// Launchd prefix of the services that must be stopped before upgrading.
+        private static let launchdPrefix = "com.apple.container."
+
+        @Option(name: .shortAndLong, help: "Upgrade to a specific release version (defaults to the latest release)")
+        var version: String?
+
+        @Flag(name: .shortAndLong, help: "Force the upgrade even if the target version is already installed")
+        var force = false
+
+        @OptionGroup
+        public var logOptions: Flags.Logging
+
+        public init() {}
+
+        public func run() async throws {
+            let runningServices = try ServiceManager.enumerate()
+                .filter { $0.hasPrefix(Self.launchdPrefix) }
+            guard runningServices.isEmpty else {
+                throw ContainerizationError(
+                    .invalidState,
+                    message: "`container` is still running. Please ensure the service is stopped by running `container system stop`"
+                )
+            }
+
+            let release = try await fetchRelease()
+            let target = release.tagName
+            let installed = ReleaseVersion.version()
+
+            guard UpgradePolicy.shouldUpgrade(target: target, installed: installed, force: force) else {
+                if version == nil {
+                    print("Container is already on latest version \(target) (use -f to force update)")
+                } else {
+                    print("Container is already on version \(target) (use -f to force update)")
+                }
+                return
+            }
+            if version == nil {
+                print("Updating to latest version \(target)")
+            } else {
+                print("Updating to release version \(target)")
+            }
+
+            guard let package = release.installerPackage() else {
+                throw ContainerizationError(.notFound, message: "No suitable package found")
+            }
+            if !package.isSigned {
+                guard confirmUnsignedPackage() else {
+                    print("Exiting without updating")
+                    return
+                }
+                print("NOTE: re-run this command to upgrade to the signed package, when it becomes available")
+            }
+
+            let temporaryDirectory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("container-upgrade-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+            let packageFile = try await download(package: package, to: temporaryDirectory)
+            try install(packageFile: packageFile)
+
+            print("Updated successfully")
+            try printInstalledVersion()
+        }
+
+        private func fetchRelease() async throws -> GitHubRelease {
+            let endpoint = GitHubRelease.endpoint(forVersion: version)
+            let failureMessage =
+                version.map { "Release '\($0)' not found" } ?? "Failed fetching latest release"
+
+            let data: Data
+            do {
+                let (body, response) = try await URLSession.shared.data(from: endpoint)
+                guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                    throw ContainerizationError(.notFound, message: failureMessage)
+                }
+                data = body
+            } catch let error as ContainerizationError {
+                throw error
+            } catch {
+                throw ContainerizationError(.internalError, message: "\(failureMessage): \(error)")
+            }
+            return try JSONDecoder().decode(GitHubRelease.self, from: data)
+        }
+
+        private func confirmUnsignedPackage() -> Bool {
+            print("No signed package found. Upgrade using the unsigned package instead? (Y/n): ", terminator: "")
+            guard let answer = readLine() else {
+                return false
+            }
+            return answer.range(of: "^[yY]([eE][sS])?$", options: .regularExpression) != nil
+        }
+
+        private func download(package: InstallerPackage, to directory: URL) async throws -> URL {
+            print("Downloading package from: \(package.url.absoluteString)...")
+            let (downloadedFile, response) = try await URLSession.shared.download(from: package.url)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                throw ContainerizationError(.internalError, message: "Failed to download package")
+            }
+            let packageFile = directory.appendingPathComponent(package.url.lastPathComponent)
+            try FileManager.default.moveItem(at: downloadedFile, to: packageFile)
+
+            let attributes = try FileManager.default.attributesOfItem(atPath: packageFile.path)
+            let size = (attributes[.size] as? Int64) ?? 0
+            guard size > 0 else {
+                throw ContainerizationError(.empty, message: "Downloaded package is empty")
+            }
+            return packageFile
+        }
+
+        private func install(packageFile: URL) throws {
+            print("Installing package to /usr/local...")
+            let installer = Process()
+            installer.executableURL = URL(fileURLWithPath: "/usr/bin/sudo")
+            installer.arguments = ["installer", "-pkg", packageFile.path, "-target", "/"]
+            // Silence installer output like the script; stdin stays attached
+            // so sudo can prompt for the password on the terminal.
+            installer.standardOutput = FileHandle.nullDevice
+            installer.standardError = FileHandle.nullDevice
+            try installer.run()
+            installer.waitUntilExit()
+            guard installer.terminationStatus == 0 else {
+                throw ContainerizationError(.internalError, message: "Installer failed")
+            }
+        }
+
+        private func printInstalledVersion() throws {
+            let verify = Process()
+            verify.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            verify.arguments = ["container", "--version"]
+            try verify.run()
+            verify.waitUntilExit()
+            guard verify.terminationStatus == 0 else {
+                throw ContainerizationError(.notFound, message: "'container' command not found")
+            }
+        }
+    }
+}

--- a/Sources/ContainerCommands/Upgrade/UpgradeCommand.swift
+++ b/Sources/ContainerCommands/Upgrade/UpgradeCommand.swift
@@ -52,6 +52,21 @@ extension Application {
                 )
             }
 
+            switch InstallationMethod.detect() {
+            case .installerPackage:
+                try await upgradeInstallerPackage()
+            case .homebrew:
+                try upgradeHomebrew()
+            case .unknown:
+                throw ContainerizationError(
+                    .invalidState,
+                    message:
+                        "Cannot determine how container was installed: found neither the \(InstallationMethod.installerPackageID) package receipt nor a Homebrew installation. Upgrade using the method you installed with, e.g. the installer package from https://github.com/apple/container/releases"
+                )
+            }
+        }
+
+        private func upgradeInstallerPackage() async throws {
             let targetRelease = try await fetchRelease()
             let target = targetRelease.tagName
             let installed = ReleaseVersion.version()
@@ -109,6 +124,29 @@ extension Application {
             } catch {
                 throw ContainerizationError(.internalError, message: "\(failureMessage): \(error)")
             }
+        }
+
+        private func upgradeHomebrew() throws {
+            guard release == nil else {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message:
+                        "container was installed with Homebrew, which only upgrades to the latest formula version; re-run without --release, or install the release from https://github.com/apple/container/releases"
+                )
+            }
+            // `brew reinstall` covers --force: `brew upgrade` is a no-op when
+            // the installed formula is already the latest version.
+            let subcommand = force ? "reinstall" : "upgrade"
+            print("Detected Homebrew installation, running `brew \(subcommand) container`...")
+            let brew = Process()
+            brew.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            brew.arguments = ["brew", subcommand, "container"]
+            try brew.run()
+            brew.waitUntilExit()
+            guard brew.terminationStatus == 0 else {
+                throw ContainerizationError(.internalError, message: "brew \(subcommand) failed")
+            }
+            try printInstalledVersion()
         }
 
         private func confirmUnsignedPackage() -> Bool {

--- a/Tests/ContainerCommandsTests/UpgradeCommandTests.swift
+++ b/Tests/ContainerCommandsTests/UpgradeCommandTests.swift
@@ -128,6 +128,41 @@ struct UpgradeCommandTests {
     }
 
     @Test
+    func classifiesHomebrewInstallation() {
+        // Apple Silicon prefix.
+        #expect(
+            InstallationMethod.classify(
+                resolvedExecutablePath: "/opt/homebrew/Cellar/container/0.6.0/bin/container",
+                hasInstallerReceipt: false
+            ) == .homebrew)
+        // Intel prefix, where /usr/local is shared with the installer
+        // package: the Cellar path must win even when a receipt exists.
+        #expect(
+            InstallationMethod.classify(
+                resolvedExecutablePath: "/usr/local/Cellar/container/0.6.0/bin/container",
+                hasInstallerReceipt: true
+            ) == .homebrew)
+    }
+
+    @Test
+    func classifiesInstallerPackageInstallation() {
+        #expect(
+            InstallationMethod.classify(
+                resolvedExecutablePath: "/usr/local/bin/container",
+                hasInstallerReceipt: true
+            ) == .installerPackage)
+    }
+
+    @Test
+    func classifiesUnknownInstallation() {
+        #expect(
+            InstallationMethod.classify(
+                resolvedExecutablePath: "/Users/dev/container/.build/release/container",
+                hasInstallerReceipt: false
+            ) == .unknown)
+    }
+
+    @Test
     func parsesDefaults() throws {
         let command = try Application.UpgradeCommand.parse([])
         #expect(command.release == nil)

--- a/Tests/ContainerCommandsTests/UpgradeCommandTests.swift
+++ b/Tests/ContainerCommandsTests/UpgradeCommandTests.swift
@@ -130,18 +130,18 @@ struct UpgradeCommandTests {
     @Test
     func parsesDefaults() throws {
         let command = try Application.UpgradeCommand.parse([])
-        #expect(command.version == nil)
+        #expect(command.release == nil)
         #expect(command.force == false)
     }
 
     @Test
-    func parsesVersionAndForce() throws {
-        let long = try Application.UpgradeCommand.parse(["--version", "0.6.0", "--force"])
-        #expect(long.version == "0.6.0")
+    func parsesReleaseAndForce() throws {
+        let long = try Application.UpgradeCommand.parse(["--release", "0.6.0", "--force"])
+        #expect(long.release == "0.6.0")
         #expect(long.force == true)
 
         let short = try Application.UpgradeCommand.parse(["-v", "0.6.0", "-f"])
-        #expect(short.version == "0.6.0")
+        #expect(short.release == "0.6.0")
         #expect(short.force == true)
     }
 }

--- a/Tests/ContainerCommandsTests/UpgradeCommandTests.swift
+++ b/Tests/ContainerCommandsTests/UpgradeCommandTests.swift
@@ -1,0 +1,128 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import ContainerCommands
+
+struct UpgradeCommandTests {
+    private func asset(_ name: String) -> GitHubReleaseAsset {
+        GitHubReleaseAsset(
+            name: name,
+            browserDownloadURL: URL(string: "https://example.com/\(name)")!
+        )
+    }
+
+    @Test
+    func endpointForLatestRelease() {
+        let url = GitHubRelease.endpoint(forVersion: nil)
+        #expect(url.absoluteString == "https://api.github.com/repos/apple/container/releases/latest")
+    }
+
+    @Test
+    func endpointForPinnedRelease() {
+        let url = GitHubRelease.endpoint(forVersion: "0.6.0")
+        #expect(url.absoluteString == "https://api.github.com/repos/apple/container/releases/tags/0.6.0")
+    }
+
+    @Test
+    func decodesReleaseJSON() throws {
+        let json = """
+            {
+                "tag_name": "0.6.0",
+                "assets": [
+                    {
+                        "name": "container-installer-signed.pkg",
+                        "browser_download_url": "https://example.com/container-installer-signed.pkg"
+                    }
+                ]
+            }
+            """
+        let release = try JSONDecoder().decode(GitHubRelease.self, from: Data(json.utf8))
+        #expect(release.tagName == "0.6.0")
+        #expect(release.assets.count == 1)
+        #expect(release.assets[0].name == "container-installer-signed.pkg")
+        #expect(release.assets[0].browserDownloadURL.absoluteString == "https://example.com/container-installer-signed.pkg")
+    }
+
+    @Test
+    func prefersSignedPrimaryPackage() {
+        let release = GitHubRelease(
+            tagName: "0.6.0",
+            assets: [
+                asset("container-installer-unsigned.pkg"),
+                asset("container-0.6.0-installer-signed.pkg"),
+                asset("container-installer-signed.pkg"),
+            ]
+        )
+        let package = release.installerPackage()
+        #expect(package == InstallerPackage(url: URL(string: "https://example.com/container-installer-signed.pkg")!, isSigned: true))
+    }
+
+    @Test
+    func fallsBackToVersionedSignedPackage() {
+        let release = GitHubRelease(
+            tagName: "0.6.0",
+            assets: [
+                asset("container-installer-unsigned.pkg"),
+                asset("container-0.6.0-installer-signed.pkg"),
+            ]
+        )
+        let package = release.installerPackage()
+        #expect(package == InstallerPackage(url: URL(string: "https://example.com/container-0.6.0-installer-signed.pkg")!, isSigned: true))
+    }
+
+    @Test
+    func fallsBackToUnsignedPackages() {
+        let primary = GitHubRelease(
+            tagName: "0.6.0",
+            assets: [asset("container-installer-unsigned.pkg")]
+        )
+        #expect(
+            primary.installerPackage()
+                == InstallerPackage(url: URL(string: "https://example.com/container-installer-unsigned.pkg")!, isSigned: false))
+
+        let fallback = GitHubRelease(
+            tagName: "0.6.0",
+            assets: [asset("container-0.6.0-installer-unsigned.pkg")]
+        )
+        #expect(
+            fallback.installerPackage()
+                == InstallerPackage(url: URL(string: "https://example.com/container-0.6.0-installer-unsigned.pkg")!, isSigned: false))
+    }
+
+    @Test
+    func returnsNilWhenNoInstallerPackageExists() {
+        let release = GitHubRelease(
+            tagName: "0.6.0",
+            assets: [asset("checksums.txt"), asset("container-0.6.0.tar.gz")]
+        )
+        #expect(release.installerPackage() == nil)
+    }
+
+    @Test
+    func upgradePolicyDecisionTable() {
+        // Same version, no force: do not upgrade.
+        #expect(!UpgradePolicy.shouldUpgrade(target: "0.6.0", installed: "0.6.0", force: false))
+        // Same version, force: upgrade.
+        #expect(UpgradePolicy.shouldUpgrade(target: "0.6.0", installed: "0.6.0", force: true))
+        // Different version: upgrade (string comparison only, matching the script).
+        #expect(UpgradePolicy.shouldUpgrade(target: "0.7.0", installed: "0.6.0", force: false))
+        // "Downgrade" is just a different string: upgrade.
+        #expect(UpgradePolicy.shouldUpgrade(target: "0.5.0", installed: "0.6.0", force: false))
+    }
+}

--- a/Tests/ContainerCommandsTests/UpgradeCommandTests.swift
+++ b/Tests/ContainerCommandsTests/UpgradeCommandTests.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ArgumentParser
 import Foundation
 import Testing
 
@@ -124,5 +125,23 @@ struct UpgradeCommandTests {
         #expect(UpgradePolicy.shouldUpgrade(target: "0.7.0", installed: "0.6.0", force: false))
         // "Downgrade" is just a different string: upgrade.
         #expect(UpgradePolicy.shouldUpgrade(target: "0.5.0", installed: "0.6.0", force: false))
+    }
+
+    @Test
+    func parsesDefaults() throws {
+        let command = try Application.UpgradeCommand.parse([])
+        #expect(command.version == nil)
+        #expect(command.force == false)
+    }
+
+    @Test
+    func parsesVersionAndForce() throws {
+        let long = try Application.UpgradeCommand.parse(["--version", "0.6.0", "--force"])
+        #expect(long.version == "0.6.0")
+        #expect(long.force == true)
+
+        let short = try Application.UpgradeCommand.parse(["-v", "0.6.0", "-f"])
+        #expect(short.version == "0.6.0")
+        #expect(short.force == true)
     }
 }

--- a/Tests/IntegrationTests/System/TestCLIUpgrade.swift
+++ b/Tests/IntegrationTests/System/TestCLIUpgrade.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+/// Tests for `container upgrade`. Only the running-service guard is exercised:
+/// the integration environment always has container services running, and
+/// actually installing a package would modify the host.
+@Suite
+struct TestCLIUpgrade {
+    @Test func refusesToRunWhileServicesAreRunning() async throws {
+        try await ContainerFixture.with { f in
+            let result = try f.run(["upgrade"])
+            #expect(result.status == 1, "upgrade should refuse while services run, stdout: \(result.output)")
+            #expect(
+                result.error.contains("container system stop"),
+                "error should direct the user to stop services, stderr: \(result.error)")
+        }
+    }
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1577,3 +1577,34 @@ container system property list
 # output as JSON for scripting
 container system property list --format json
 ```
+
+## Software Update
+
+### `container upgrade`
+
+Upgrades the installed `container` toolset to a release published on GitHub. The command refuses to run while container services are running; stop them first with `container system stop`. It downloads the signed installer package for the target release (asking for confirmation before falling back to an unsigned package) and installs it with `sudo installer`, which prompts for an administrator password.
+
+**Usage**
+
+```bash
+container upgrade [--version <version>] [--force] [--debug]
+```
+
+**Options**
+
+*   `-v, --version <version>`: Upgrade to a specific release version (defaults to the latest release)
+*   `-f, --force`: Force the upgrade even if the target version is already installed
+
+**Examples**
+
+```bash
+# Upgrade to the latest release
+container system stop
+container upgrade
+
+# Upgrade (or downgrade) to a specific release
+container upgrade --version 0.6.0
+
+# Reinstall the current version
+container upgrade --force
+```

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1587,12 +1587,12 @@ Upgrades the installed `container` toolset to a release published on GitHub. The
 **Usage**
 
 ```bash
-container upgrade [--version <version>] [--force] [--debug]
+container upgrade [--release <release>] [--force] [--debug]
 ```
 
 **Options**
 
-*   `-v, --version <version>`: Upgrade to a specific release version (defaults to the latest release)
+*   `-v, --release <release>`: Upgrade to a specific release version (defaults to the latest release)
 *   `-f, --force`: Force the upgrade even if the target version is already installed
 
 **Examples**
@@ -1603,7 +1603,7 @@ container system stop
 container upgrade
 
 # Upgrade (or downgrade) to a specific release
-container upgrade --version 0.6.0
+container upgrade --release 0.6.0
 
 # Reinstall the current version
 container upgrade --force

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1582,7 +1582,13 @@ container system property list --format json
 
 ### `container upgrade`
 
-Upgrades the installed `container` toolset to a release published on GitHub. The command refuses to run while container services are running; stop them first with `container system stop`. It downloads the signed installer package for the target release (asking for confirmation before falling back to an unsigned package) and installs it with `sudo installer`, which prompts for an administrator password.
+Upgrades the installed `container` toolset. The command refuses to run while container services are running; stop them first with `container system stop`.
+
+The upgrade follows the method used to install `container`:
+
+*   **Installer package** (release page): downloads the signed installer package for the target release (asking for confirmation before falling back to an unsigned package) and installs it with `sudo installer`, which prompts for an administrator password.
+*   **Homebrew**: runs `brew upgrade container` (`brew reinstall container` with `--force`). The `--release` option is not supported for Homebrew installations, since the formula only offers its latest version.
+*   Any other installation (for example, a build from source) is not upgraded; the command exits with an error describing how to upgrade manually.
 
 **Usage**
 


### PR DESCRIPTION
## Type of Change
- [x] New feature

## Motivation and Context
Fixes #1942.

Upgrading `container` currently requires the `update-container.sh` shell
script installed under /usr/local/bin. This PR adds a native, discoverable
`container upgrade` command with behavioral parity to the script:

- refuses to run while `com.apple.container.*` services are running and
  directs the user to `container system stop`
- resolves the latest release (or a pinned one via `-v/--release`) from the
  GitHub releases API
- exits successfully when already on the target version unless `-f/--force`
- prefers the signed installer package, asking for confirmation before
  falling back to an unsigned one
- installs via `sudo installer -pkg <pkg> -target /` (trust anchored in
  macOS Installer/Gatekeeper validating the signed package, as with the
  script)

The release-resolution and asset-selection logic is implemented as pure
functions with unit tests.

Deliberate deviations from the script, for reviewers:

- The pin option's long form is `--release` (short `-v` kept): a subcommand
  `--version` option would shadow the `--version` flag subcommands inherit
  from the root command.
- Errors go to stderr with the CLI's standard `Error:` prefix (repo
  convention) rather than the script's plain stdout echo; exit codes match.
- One release fetch for the latest-version path (the script fetches twice),
  and no unsigned-package prompt when the release has no installer asset at
  all (the script prompts before discovering there is nothing to download).
- No pre-flight "requires admin privileges" notice; sudo prompts when
  installation starts.
- With `-v <installed-version>`, the "already on version" answer requires
  the release lookup first (the script answers before fetching), so it
  needs network access.
- The installed version comes from the CLI's own `ReleaseVersion.version()`
  rather than parsing `container --version` output — identical for any
  installed binary.

Non-goals for this PR (possible follow-ups, listed in the issue):
auto-stopping services, semver-aware comparison, `--dry-run`, download
progress bar.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [x] Added/updated docs

Unit tests cover the GitHub release decoding, endpoint construction, asset
selection precedence, upgrade policy, and argument parsing (`make test`:
568 tests / 70 suites passing). An integration test verifies the
running-service guard — the only path that can safely run in CI, since
actually installing a package would modify the host. The guard and the
release-not-found path were additionally verified end-to-end against the
debug binary (exit code 1 with the expected messages in both cases).
`make fmt` is clean and `make docs` builds. The full integration suite was
not run locally (this environment hits the BUILDING.md `~/Documents` vmnet
limitation); relying on CI for that.
