### PR TITLE
Dereference symlinked config before copying

### DIFF
--- a/Sources/ContainerPersistence/ConfigurationLoader.swift
+++ b/Sources/ContainerPersistence/ConfigurationLoader.swift
@@ -209,8 +209,9 @@ public enum ConfigurationLoader {
         let destDir = destPath.removingLastComponent()
         try fm.createDirectory(atPath: destDir.string, withIntermediateDirectories: true)
 
+        let resolvedSourcePath = try sourcePath.resolvingSymlinks()
         try fm.copyItem(
-            at: URL(filePath: sourcePath.string),
+            at: URL(filePath: resolvedSourcePath.string),
             to: URL(filePath: destPath.string)
         )
         try fm.setAttributes([.posixPermissions: READ_ONLY], ofItemAtPath: destPath.string)

--- a/Tests/ContainerPersistenceTests/ConfigurationLoaderTests.swift
+++ b/Tests/ContainerPersistenceTests/ConfigurationLoaderTests.swift
@@ -233,6 +233,31 @@ struct ConfigurationLoaderTests {
         }
     }
 
+    @Test func copyConfigDereferencesSymlink() async throws {
+        try await TemporaryStorage.withTempDir { tempDir in
+            let fm = FileManager.default
+            let target = tempDir.appending("target.toml")
+            let source = tempDir.appending("config.toml")
+            try Self.writeToml("[build]\ncpus = 8", to: target)
+            try fm.setAttributes([.posixPermissions: 0o444], ofItemAtPath: target.string)
+            try fm.createSymbolicLink(atPath: source.string, withDestinationPath: target.string)
+
+            let destBase = tempDir.appending("dest")
+            try ConfigurationLoader.copyConfigurationToReadOnly(from: source, to: destBase)
+
+            let destFile = destBase.appending("config").appending("config.toml")
+            let attrs = try fm.attributesOfItem(atPath: destFile.string)
+            let fileType = try #require(attrs[.type] as? FileAttributeType)
+            #expect(fileType == .typeRegular)
+            let perms = try #require(attrs[.posixPermissions] as? Int)
+            #expect(perms == 0o444)
+
+            try fm.removeItem(atPath: target.string)
+            let copied = try String(contentsOf: URL(filePath: destFile.string), encoding: .utf8)
+            #expect(copied.contains("cpus = 8"))
+        }
+    }
+
     @Test func copyConfigOverwritesExistingReadOnlyDestination() async throws {
         try await TemporaryStorage.withTempDir { tempDir in
             let source = tempDir.appending("config.toml")


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
When `~/.config/container/config.toml` is a symbolic link, `FileManager.copyItem` preserves the link when copying it into the application support directory. This causes the runtime configuration snapshot to remain tied to the original file, which is problematic for declaratively managed, read-only configurations such as those installed through Nix.

Resolve the source path before copying so the application support configuration is always an independent file.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

Added a regression test that verifies a symlinked source produces a regular destination that remains readable after removing the source target. The test fails without the fix, and the full test suite passes with it.