### PR TITLE
Do not follow destination symlink when copying user configuration

### DIFF
--- a/Sources/ContainerPersistence/ConfigurationLoader.swift
+++ b/Sources/ContainerPersistence/ConfigurationLoader.swift
@@ -17,6 +17,7 @@
 import Configuration
 import ConfigurationTOML
 import ContainerizationError
+import Darwin
 import Foundation
 import SystemPackage
 
@@ -34,7 +35,6 @@ public enum ConfigurationLoader {
     private static let configFilename = "config.toml"
     private static let configDirectory = "config"
     private static let READ_ONLY: Int = 0o444
-    private static let READ_AND_WRITE: Int = 0o644
 
     /// Returns the configuration file path for a given base kind, resolving the base
     /// directory via `BaseConfigPath.basePath()` (env-driven, with fallbacks).
@@ -182,8 +182,8 @@ public enum ConfigurationLoader {
 
     /// Copies the user's runtime configuration into the app-root as a read-only snapshot.
     ///
-    /// If `source` does not exist, this is a no-op. Otherwise, any existing destination
-    /// is deleted and replaced with a fresh copy, which is then marked read-only.
+    /// If `source` does not exist, this is a no-op. Otherwise, the source is written to a
+    /// temporary file alongside the destination and then moved into place with `rename(2)`.
     ///
     /// - Parameters:
     ///   - source: File to copy from. Defaults to `<home>/container/config.toml`.
@@ -198,21 +198,28 @@ public enum ConfigurationLoader {
         let destPath = configurationFile(in: destBase)
 
         let fm = FileManager.default
-
-        if fm.fileExists(atPath: destPath.string) {
-            try fm.setAttributes([.posixPermissions: READ_AND_WRITE], ofItemAtPath: destPath.string)
-            try fm.removeItem(at: URL(filePath: destPath.string))
-        }
-
         guard fm.fileExists(atPath: sourcePath.string) else { return }
 
         let destDir = destPath.removingLastComponent()
         try fm.createDirectory(atPath: destDir.string, withIntermediateDirectories: true)
 
+        let tempPath = destDir.appending(".\(configFilename).\(ProcessInfo.processInfo.globallyUniqueString)")
+        defer { try? fm.removeItem(atPath: tempPath.string) }
+
         try fm.copyItem(
             at: URL(filePath: sourcePath.string),
-            to: URL(filePath: destPath.string)
+            to: URL(filePath: tempPath.string)
         )
-        try fm.setAttributes([.posixPermissions: READ_ONLY], ofItemAtPath: destPath.string)
+        try fm.setAttributes([.posixPermissions: READ_ONLY], ofItemAtPath: tempPath.string)
+
+        // `rename` replaces the file at `destination` without following symlinks and
+        // regardless of `destination`'s file permissions.
+        guard rename(tempPath.string, destPath.string) == 0 else {
+            let err = errno
+            throw ContainerizationError(
+                .internalError,
+                message: "failed to move '\(tempPath)' to '\(destPath)': \(String(cString: strerror(err)))"
+            )
+        }
     }
 }

--- a/Tests/ContainerPersistenceTests/ConfigurationLoaderTests.swift
+++ b/Tests/ContainerPersistenceTests/ConfigurationLoaderTests.swift
@@ -263,6 +263,22 @@ struct ConfigurationLoaderTests {
         }
     }
 
+    @Test func loadFollowsSymlinkedSourceFile() async throws {
+        try await TemporaryStorage.withTempDir { tempDir in
+            let realFile = tempDir.appending("real-config.toml")
+            try Self.writeToml("[build]\ncpus = 8\n", to: realFile)
+
+            let symlinkPath = tempDir.appending("config.toml")
+            try FileManager.default.createSymbolicLink(
+                atPath: symlinkPath.string, withDestinationPath: realFile.string)
+
+            let config: ContainerSystemConfig = try await ConfigurationLoader.load(
+                configurationFiles: [symlinkPath]
+            )
+            #expect(config.build.cpus == 8)
+        }
+    }
+
     @Test func copyConfigToAppRoot() async throws {
         try await TemporaryStorage.withTempDir { tempDir in
             let source = tempDir.appending("config.toml")
@@ -309,6 +325,45 @@ struct ConfigurationLoaderTests {
             try ConfigurationLoader.copyConfigurationToReadOnly(from: source, to: destBase)
             let destFile = destBase.appending("config").appending("config.toml")
             #expect(!FileManager.default.fileExists(atPath: destFile.string))
+        }
+    }
+
+    @Test func copyConfigDoesNotFollowDestinationSymlink() async throws {
+        try await TemporaryStorage.withTempDir { tempDir in
+            let source = tempDir.appending("config.toml")
+            try Self.writeToml("[build]\ncpus = 8", to: source)
+
+            let outsideDir = tempDir.appending("outside")
+            try FileManager.default.createDirectory(
+                atPath: outsideDir.string, withIntermediateDirectories: true)
+            let outsideFile = outsideDir.appending("do-not-touch")
+            try Self.writeToml("untouched", to: outsideFile)
+
+            let destBase = tempDir.appending("dest")
+            let destFile = destBase.appending("config").appending("config.toml")
+            try FileManager.default.createDirectory(
+                atPath: destFile.removingLastComponent().string,
+                withIntermediateDirectories: true)
+            try FileManager.default.createSymbolicLink(
+                atPath: destFile.string, withDestinationPath: outsideDir.string)
+
+            try ConfigurationLoader.copyConfigurationToReadOnly(from: source, to: destBase)
+
+            var isDirectory: ObjCBool = false
+            let exists = FileManager.default.fileExists(atPath: destFile.string, isDirectory: &isDirectory)
+            #expect(exists)
+            #expect(!isDirectory.boolValue)
+
+            let attrs = try FileManager.default.attributesOfItem(atPath: destFile.string)
+            #expect(attrs[.type] as? FileAttributeType != .typeSymbolicLink)
+            let perms = try #require(attrs[.posixPermissions] as? Int)
+            #expect(perms == 0o444)
+
+            let copied = try String(contentsOf: URL(filePath: destFile.string), encoding: .utf8)
+            #expect(copied.contains("cpus = 8"))
+
+            let outsideContents = try String(contentsOf: URL(filePath: outsideFile.string), encoding: .utf8)
+            #expect(outsideContents == "untouched")
         }
     }
 


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context
This PR fixes a narrow case where a user may have modified the user configuration file in the application root to use a symlink. In this case, upon restarting the service, we would follow the symlink, potentially replacing files unintentionally. This PR fixes this issue by using the `rename(2)` which will override the `destPath` regardless of its file permissions and status as a symlink or otherwise. 

## Testing
- [x] Tested locally
- [x] Added/updated tests
