### PR TITLE
[images]: resolve local tagged-digest reference instead of pulling

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/ClientImage.swift
+++ b/Sources/Services/ContainerAPIService/Client/ClientImage.swift
@@ -235,6 +235,13 @@ extension ClientImage {
         if let locallyBuiltImage {
             return locallyBuiltImage
         }
+        // A digest-bearing reference (`name:tag@sha256:...` or `name@sha256:...`)
+        // identifies an image by its index descriptor digest. Resolve it against a
+        // locally stored image with that digest, including one stored under a tag,
+        // so an exact local reference is not normalized to Docker Hub and pulled.
+        if let matchByDigest = try Self.matchByDigest(reference: reference, in: all) {
+            return matchByDigest
+        }
         // If we don't find a match, try matching `ImageDescription.name` against the given
         // input string, while also checking against its normalized form.
         // Return the first match.
@@ -242,6 +249,16 @@ extension ClientImage {
         return all.first(where: { image in
             image.reference == reference || image.reference == normalizedReference
         })
+    }
+
+    // Returns the locally stored image whose index descriptor digest matches the
+    // digest component of `reference`, or nil when the reference carries no digest
+    // or no local image matches.
+    static func matchByDigest(reference: String, in all: [ClientImage]) throws -> ClientImage? {
+        guard let digest = try Reference.parse(reference).digest else {
+            return nil
+        }
+        return all.first { $0.digest == digest }
     }
 
     public static func pull(

--- a/Tests/ContainerAPIClientTests/ClientImageSearchTests.swift
+++ b/Tests/ContainerAPIClientTests/ClientImageSearchTests.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerResource
+import ContainerizationOCI
+import Testing
+
+@testable import ContainerAPIClient
+
+struct ClientImageSearchTests {
+    private func image(reference: String, digest: String) -> ClientImage {
+        let descriptor = Descriptor(
+            mediaType: "application/vnd.oci.image.index.v1+json",
+            digest: digest,
+            size: 100
+        )
+        return ClientImage(description: ImageDescription(reference: reference, descriptor: descriptor))
+    }
+
+    private let digest = "sha256:" + String(repeating: "a", count: 64)
+    private let otherDigest = "sha256:" + String(repeating: "b", count: 64)
+
+    private var images: [ClientImage] {
+        [
+            image(reference: "docker.io/library/other:latest", digest: otherDigest),
+            image(reference: "docker.io/library/local-digest-repro:test", digest: digest),
+        ]
+    }
+
+    @Test func resolvesTaggedDigestToLocalImage() throws {
+        // name:tag@digest must resolve the locally stored tagged image by its
+        // index descriptor digest instead of falling back to a remote pull.
+        let match = try ClientImage.matchByDigest(reference: "local-digest-repro:test@\(digest)", in: images)
+        #expect(match?.digest == digest)
+    }
+
+    @Test func resolvesNameDigestToLocalImage() throws {
+        // The canonical name@digest form resolves the same way.
+        let match = try ClientImage.matchByDigest(reference: "local-digest-repro@\(digest)", in: images)
+        #expect(match?.digest == digest)
+    }
+
+    @Test func referenceWithoutDigestDoesNotMatch() throws {
+        let match = try ClientImage.matchByDigest(reference: "local-digest-repro:test", in: images)
+        #expect(match == nil)
+    }
+
+    @Test func unknownDigestDoesNotMatch() throws {
+        let missing = "sha256:" + String(repeating: "c", count: 64)
+        let match = try ClientImage.matchByDigest(reference: "local-digest-repro:test@\(missing)", in: images)
+        #expect(match == nil)
+    }
+}


### PR DESCRIPTION
## Motivation and Context

a create/run using a `name:tag@sha256:...` (or `name@sha256:...`) reference missed the local store: the reference parser gives the digest precedence and drops the tag, so the annotation-name lookup couldn't match a locally built image stored under its tag, and the reference was normalized to Docker Hub and pulled

add a digest-based local lookup in `ClientImage._search`: when a reference carries a digest, resolve it against a locally stored image whose index descriptor digest matches before falling back to a pull

fixes #1962

## Type of Change

- [x] Bug fix

## Testing

- [x] Added/updated tests (`ClientImageSearchTests`)
