### PR TITLE
Fix `container logs -n` truncating the oldest line past a read chunk

### DIFF
--- a/Sources/ContainerCommands/Container/ContainerLogs.swift
+++ b/Sources/ContainerCommands/Container/ContainerLogs.swift
@@ -63,27 +63,7 @@ extension Application {
             follow: Bool
         ) async throws {
             if let n {
-                var buffer = Data()
-                let size = try fh.seekToEnd()
-                var offset = size
-                var lines: [String] = []
-
-                while offset > 0, lines.count < n {
-                    let readSize = min(1024, offset)
-                    offset -= readSize
-                    try fh.seek(toOffset: offset)
-
-                    let data = fh.readData(ofLength: Int(readSize))
-                    buffer.insert(contentsOf: data, at: 0)
-
-                    if let chunk = String(data: buffer, encoding: .utf8) {
-                        lines = chunk.components(separatedBy: .newlines)
-                        lines = lines.filter { !$0.isEmpty }
-                    }
-                }
-
-                lines = Array(lines.suffix(n))
-                for line in lines {
+                for line in try Self.lastLines(fh: fh, n: n) {
                     print(line)
                 }
             } else {
@@ -107,6 +87,39 @@ extension Application {
                 setbuf(stdout, nil)
                 try await Self.followFile(fh: fh)
             }
+        }
+
+        /// Returns the last `n` complete lines from `fh`, reading backwards in
+        /// 1024-byte chunks. Exposed (internal) for testing.
+        ///
+        /// The loop keeps reading until it has accumulated *more* than `n`
+        /// non-empty lines, or it reaches the start of the file. Reading one
+        /// line past `n` guarantees the oldest returned line is complete: the
+        /// first line in the buffer may be a fragment truncated at a chunk
+        /// boundary, and `suffix(n)` drops it. Stopping at exactly `n`
+        /// (`lines.count < n`) could return that fragment as the oldest line
+        /// whenever the last `n` lines span more than one 1024-byte chunk.
+        static func lastLines(fh: FileHandle, n: Int) throws -> [String] {
+            var buffer = Data()
+            let size = try fh.seekToEnd()
+            var offset = size
+            var lines: [String] = []
+
+            while offset > 0, lines.count <= n {
+                let readSize = min(1024, offset)
+                offset -= readSize
+                try fh.seek(toOffset: offset)
+
+                let data = fh.readData(ofLength: Int(readSize))
+                buffer.insert(contentsOf: data, at: 0)
+
+                if let chunk = String(data: buffer, encoding: .utf8) {
+                    lines = chunk.components(separatedBy: .newlines)
+                    lines = lines.filter { !$0.isEmpty }
+                }
+            }
+
+            return Array(lines.suffix(n))
         }
 
         private static func followFile(fh: FileHandle) async throws {

--- a/Tests/ContainerCommandsTests/ContainerLogsTailTests.swift
+++ b/Tests/ContainerCommandsTests/ContainerLogsTailTests.swift
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import ContainerCommands
+
+struct ContainerLogsTailTests {
+    private func withTempLog(_ contents: String, _ body: (FileHandle) throws -> Void) throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("container-logs-tail-\(UUID().uuidString).log")
+        try Data(contents.utf8).write(to: url)
+        let fh = try FileHandle(forReadingFrom: url)
+        defer {
+            try? fh.close()
+            try? FileManager.default.removeItem(at: url)
+        }
+        try body(fh)
+    }
+
+    @Test("returns the last n complete lines for short input")
+    func lastNShortLines() throws {
+        let contents = (1...10).map { "line-\($0)" }.joined(separator: "\n") + "\n"
+        try withTempLog(contents) { fh in
+            let lines = try Application.ContainerLogs.lastLines(fh: fh, n: 3)
+            #expect(lines == ["line-8", "line-9", "line-10"])
+        }
+    }
+
+    @Test("n larger than the line count returns every line")
+    func nLargerThanLineCount() throws {
+        try withTempLog("a\nb\n") { fh in
+            let lines = try Application.ContainerLogs.lastLines(fh: fh, n: 10)
+            #expect(lines == ["a", "b"])
+        }
+    }
+
+    @Test("a single line longer than the 1024-byte chunk is not truncated")
+    func longSingleLineNotTruncated() throws {
+        // Regression: a log line larger than the 1024-byte backward-read chunk
+        // was returned with its beginning cut off by `container logs -n 1`.
+        let long = "START" + String(repeating: "X", count: 3000) + "END"
+        try withTempLog(long + "\n") { fh in
+            let lines = try Application.ContainerLogs.lastLines(fh: fh, n: 1)
+            #expect(lines == [long])
+        }
+    }
+
+    @Test("multiple lines spanning several chunks keep the oldest line intact")
+    func longLinesSpanningChunks() throws {
+        // Each line is 800 bytes; the last two together exceed one 1024-byte
+        // chunk, which previously truncated the older of the two.
+        let a = String(repeating: "A", count: 800)
+        let b = String(repeating: "B", count: 800)
+        let c = String(repeating: "C", count: 800)
+        try withTempLog([a, b, c].joined(separator: "\n") + "\n") { fh in
+            let lines = try Application.ContainerLogs.lastLines(fh: fh, n: 2)
+            #expect(lines == [b, c])
+        }
+    }
+}


### PR DESCRIPTION
## Type of Change

- [x] Bug fix

## Motivation and Context

`container logs -n N` truncated the oldest returned line whenever the last N log lines spanned more than one 1024-byte backward-read chunk. The clearest case: a single log line longer than 1024 bytes with `-n 1` returns only its last 1024 bytes — the beginning of the line is cut off. The full-log path (`container logs` without `-n`) is unaffected.

Fixes #1967.

## Description

`ContainerLogs.tail` reads the log file backwards in 1024-byte chunks and stopped at `lines.count < n`. When a read landed on exactly N non-empty segments whose first was a fragment (buffer starting mid-line, `offset > 0`), that fragment was returned as the oldest line.

- Extracted the backward-read logic into a testable `lastLines(fh:n:) -> [String]`.
- Changed the loop bound from `lines.count < n` to `lines.count <= n`, so it always reads one line past N (or to the start of the file). The extra, possibly-partial leading line is then dropped by `suffix(n)`, guaranteeing the oldest returned line is complete.

No behavior change for the common case (last N lines within one chunk); the full-log path is untouched.

## Testing

Added `Tests/ContainerCommandsTests/ContainerLogsTailTests.swift` covering:
- a single line longer than the 1024-byte chunk (`-n 1`),
- multiple long lines spanning several chunks (`-n 2`),
- short input, and
- `n` greater than the number of lines.

Transparency note: I was unable to run the in-repo test suite locally — this machine only has an Xcode 27 beta toolchain (which fails building a transitive dependency under strict concurrency) and the Command Line Tools, which lack the test frameworks. I verified the fix logic in isolation (old logic truncates the oldest line; new logic returns it in full for all four cases above) and confirmed the change compiles as part of the `ContainerCommands` target. CI runs the added tests.
