### PR TITLE
Fix `container cp` rejecting paths that contain a colon

### DIFF
--- a/Sources/ContainerCommands/Container/ContainerCopy.swift
+++ b/Sources/ContainerCommands/Container/ContainerCopy.swift
@@ -24,21 +24,27 @@ import SystemPackage
 
 extension Application {
     public struct ContainerCopy: AsyncLoggableCommand {
-        enum PathRef {
+        enum PathRef: Equatable {
             case local(String)
             case container(id: String, path: String)
         }
 
         static func parsePathRef(_ ref: String) throws -> PathRef {
-            let parts = ref.components(separatedBy: ":")
-            switch parts.count {
-            case 1:
+            // A container reference is "<id>:<absolute-path>". The id never
+            // contains a path separator, but the path may itself contain ':'
+            // (e.g. an ISO-8601 timestamp in a filename), so split on the FIRST
+            // ':' only rather than on every colon. If the text before the first
+            // ':' contains '/', the whole ref is a local path that happens to
+            // contain a colon (e.g. "/home/2026-01-01T00:00:00.log").
+            guard let colon = ref.firstIndex(of: ":"), !ref[..<colon].contains("/") else {
                 return .local(ref)
-            case 2 where !parts[0].isEmpty && parts[1].starts(with: "/"):
-                return .container(id: parts[0], path: parts[1])
-            default:
+            }
+            let id = String(ref[..<colon])
+            let path = String(ref[ref.index(after: colon)...])
+            guard !id.isEmpty, path.hasPrefix("/") else {
                 throw ContainerizationError(.invalidArgument, message: "invalid path given: \(ref)")
             }
+            return .container(id: id, path: path)
         }
 
         public init() {}

--- a/Tests/ContainerCommandsTests/ContainerCopyPathRefTests.swift
+++ b/Tests/ContainerCommandsTests/ContainerCopyPathRefTests.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import ContainerCommands
+
+struct ContainerCopyPathRefTests {
+    private func parse(_ ref: String) throws -> Application.ContainerCopy.PathRef {
+        try Application.ContainerCopy.parsePathRef(ref)
+    }
+
+    @Test("a path without a colon is a local path")
+    func localNoColon() throws {
+        #expect(try parse("/tmp/file.txt") == .local("/tmp/file.txt"))
+    }
+
+    @Test("an id followed by an absolute path is a container reference")
+    func containerRef() throws {
+        #expect(try parse("box:/tmp/file.txt") == .container(id: "box", path: "/tmp/file.txt"))
+    }
+
+    @Test("a container path containing colons is preserved")
+    func containerPathWithColons() throws {
+        // Regression: an ISO-8601 timestamp filename was rejected as an
+        // "invalid path" because the reference was split on every colon
+        // instead of only the first.
+        #expect(
+            try parse("box:/var/log/app-2026-07-20T10:30:00.log")
+                == .container(id: "box", path: "/var/log/app-2026-07-20T10:30:00.log")
+        )
+    }
+
+    @Test("a local path containing colons is a local path")
+    func localPathWithColons() throws {
+        #expect(
+            try parse("/home/user/2026-07-20T10:30:00.log")
+                == .local("/home/user/2026-07-20T10:30:00.log")
+        )
+    }
+
+    @Test("an empty container id is rejected")
+    func emptyId() {
+        #expect(throws: (any Error).self) { try parse(":/tmp/x") }
+    }
+
+    @Test("a non-absolute container path is rejected")
+    func relativeContainerPath() {
+        #expect(throws: (any Error).self) { try parse("box:relative/path") }
+    }
+}


### PR DESCRIPTION
## Type of Change

- [x] Bug fix

## Motivation and Context

`container cp` rejected a `container:path` reference whenever the path contained a colon — e.g. an ISO-8601 timestamp filename such as `/var/log/app-2026-07-20T10:30:00.log` — failing with `invalid path given` even though the file exists. `docker cp` splits the reference on the first colon only.

Fixes #1969.

## Description

`ContainerCopy.parsePathRef` used `components(separatedBy: ":")` and rejected any reference producing more than two parts. It now:

- splits on the **first** colon only — a container id never contains a path separator, but the path may contain colons; and
- treats a reference whose pre-colon segment contains `/` as a local path, which additionally lets local paths containing a colon be copied.

Error behavior for genuinely invalid references (empty id, non-absolute container path) is unchanged. `PathRef` is now `Equatable` to support the added unit tests.

## Testing

Added `Tests/ContainerCommandsTests/ContainerCopyPathRefTests.swift` covering: a plain local path, a container reference, a container path containing colons (the regression), a local path containing colons, an empty id, and a non-absolute container path.

Transparency note: I was unable to run the in-repo test suite locally — this machine only has an Xcode 27 beta toolchain (which fails building a transitive dependency under strict concurrency) and the Command Line Tools, which lack the test frameworks. I verified the parser change in isolation against all the cases above and confirmed it compiles as part of the `ContainerCommands` target. CI runs the added tests.
