### PR TITLE
Fix machine ID length test.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,15 @@ ifneq ($(strip $(LOG_ROOT)),)
 	SYSTEM_START_OPTS += --log-root "$(strip $(LOG_ROOT))"
 endif
 
+# swift test event-stream JSON output for the concurrent/global integration
+# passes, only when LOG_ROOT is set.
+CONCURRENT_EVENT_STREAM_OPTS :=
+GLOBAL_EVENT_STREAM_OPTS :=
+ifneq ($(strip $(LOG_ROOT)),)
+	CONCURRENT_EVENT_STREAM_OPTS += --event-stream-output-path "$(strip $(LOG_ROOT))/integration-concurrent.json" --event-stream-version 6.3
+	GLOBAL_EVENT_STREAM_OPTS += --event-stream-output-path "$(strip $(LOG_ROOT))/integration-global.json" --event-stream-version 6.3
+endif
+
 MACOS_VERSION := $(shell sw_vers -productVersion)
 MACOS_MAJOR := $(shell echo $(MACOS_VERSION) | cut -d. -f1)
 
@@ -285,9 +294,9 @@ define RUN_INTEGRATION
 		echo "==> Warmup pass" && \
 		$(SWIFT) test $(INTEGRATION_SWIFT_EXTRA) -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter "$(WARMUP_FILTER)" && \
 		echo "==> Concurrent pass (width=$(PARALLEL_WIDTH))" && \
-		$(SWIFT) test $(INTEGRATION_SWIFT_EXTRA) -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --experimental-maximum-parallelization-width $(PARALLEL_WIDTH) --filter "$(CONCURRENT_FILTER)" && \
+		$(SWIFT) test $(INTEGRATION_SWIFT_EXTRA) -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) $(CONCURRENT_EVENT_STREAM_OPTS) --experimental-maximum-parallelization-width $(PARALLEL_WIDTH) --filter "$(CONCURRENT_FILTER)" && \
 		echo "==> Global pass (serial)" && \
-		$(SWIFT) test $(INTEGRATION_SWIFT_EXTRA) -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --experimental-maximum-parallelization-width 1 --filter "$(SERIAL_FILTER)" ; \
+		$(SWIFT) test $(INTEGRATION_SWIFT_EXTRA) -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) $(GLOBAL_EVENT_STREAM_OPTS) --experimental-maximum-parallelization-width 1 --filter "$(SERIAL_FILTER)" ; \
 		exit_code=$$? ; \
 		$(INTEGRATION_POST_TEST) \
 		echo Ensuring apiserver stopped after the CLI integration tests ; \

--- a/Tests/IntegrationTests/Machine/TestCLIMachineCommand.swift
+++ b/Tests/IntegrationTests/Machine/TestCLIMachineCommand.swift
@@ -43,7 +43,11 @@ struct TestCLIMachineCommand {
     @Test func testCreateNameLongestValid() async {
         await withKnownIssue("XPC timeout on machine-apiserver.bootMachine", isIntermittent: true) {
             try await ContainerFixture.with { f in
-                let maxNameLength = LinuxContainer.maxIDLength - MachineConfiguration.containerUUIDLength - 1
+                // Start with container ID or DNS label length, whichever is shorter.
+                // Reduce by length of UUID suffix.
+                // Reduce by 1 for dash separator between ID and suffix.
+                let maxHostnameLength = min(LinuxContainer.maxIDLength, 63)
+                let maxNameLength = maxHostnameLength - MachineConfiguration.containerUUIDLength - 2
                 let name = String(repeating: "a", count: maxNameLength)
                 f.addCleanup { f.cleanupMachine(name) }
                 try f.doMachineCreate(name: name, image: machineImage)


### PR DESCRIPTION
- PR #1956 limited the container ID length to 63, the maximum DNS label length.
- The machine ID test was still using the maximum Linux hostname length of 64 as a starting point.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Fixes regression in test code due to recent functional change.

## Testing
- [ ] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs
