### PR TITLE
Pass build config in when building protoc dependencies

### DIFF
--- a/Protobuf.Makefile
+++ b/Protobuf.Makefile
@@ -36,8 +36,8 @@ $(PROTOC):
 
 .PHONY: protoc-gen-swift
 protoc-gen-swift:
-	@$(SWIFT) build --product protoc-gen-swift
-	@$(SWIFT) build --product protoc-gen-grpc-swift-2
+	@$(SWIFT) build -c $(BUILD_CONFIGURATION) --product protoc-gen-swift
+	@$(SWIFT) build -c $(BUILD_CONFIGURATION) --product protoc-gen-grpc-swift-2
 
 .PHONY: protos
 protos: $(PROTOC) protoc-gen-swift


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context
The protobuf makefile relies on being able to find the built protoc dependencies under the build directory. Since we were not passing the build configuration to the swift command to build those dependencies, the built binaries were goin into the debug build folder. If `make protos` was run when `BUILD_CONFIGURATION=release`, then we'd fail to find the dependencies since the build folder should now be the release build folder. This PR fixes that. 

## Testing
- [x] Tested locally
