### PR TITLE
Fix `container --label` rejecting values that contain "="

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/Parser.swift
+++ b/Sources/Services/ContainerAPIService/Client/Parser.swift
@@ -245,7 +245,10 @@ public struct Parser {
             if label.isEmpty {
                 throw ContainerizationError(.invalidArgument, message: "label cannot be an empty string")
             }
-            let parts = label.split(separator: "=", maxSplits: 2)
+            // Split on the first '=' only: a label value may itself contain
+            // '=' (e.g. `--label rule=Host(`x`)&&Path(`/`)` or
+            // `--label config=key=value`), matching `docker run --label`.
+            let parts = label.split(separator: "=", maxSplits: 1)
             switch parts.count {
             case 1:
                 result[String(parts[0])] = ""

--- a/Tests/ContainerAPIClientTests/ParserTest.swift
+++ b/Tests/ContainerAPIClientTests/ParserTest.swift
@@ -1348,6 +1348,23 @@ struct ParserTest {
         #expect(result["key99"] == "value99")
     }
 
+    @Test("labels preserve '=' characters in the value")
+    func testLabelsValueWithEquals() throws {
+        // Regression: a label whose value contained '=' (a common shape,
+        // e.g. router rules or nested key=value config) was rejected as an
+        // "invalid label format" because the entry was split on every '='.
+        let result = try Parser.labels([
+            "plain=value",
+            "config=key=value",
+            "expr=a=b=c",
+            "flag",
+        ])
+        #expect(result["plain"] == "value")
+        #expect(result["config"] == "key=value")
+        #expect(result["expr"] == "a=b=c")
+        #expect(result["flag"] == "")
+    }
+
     @Test("resolve with large input preserves all entries")
     func testParseKeyValuePairsLargeInput() {
         let pairs = (0..<100).map { "key\($0)=value\($0)" }


### PR DESCRIPTION
## Type of Change

- [x] Bug fix

## Motivation and Context

`container run --label KEY=VALUE` rejected any label whose value contained a `=`, failing with `invalid label format` — even though such values are valid and common (a reverse-proxy router rule, a nested `key=value` config, a URL with a query string). `docker run --label` splits the label on the first `=` only.

Fixes #1977.

## Description

`Parser.labels` split each entry with `split(separator: "=", maxSplits: 2)` and only handled 1 or 2 parts, so a value containing `=` produced 3+ parts and hit the throwing `default` branch. Changed it to `maxSplits: 1` (split on the first `=` only) — a label key cannot contain `=`, but the value may. This matches how the env-file parser already handles values (`URL=https://foo.bar?baz=woo`) and `docker run --label`.

## Testing

Added `testLabelsValueWithEquals` to `ParserTest.swift`, covering a plain value, a value with one `=`, a value with several `=`, and a key with no value.

Transparency note: I could not run the in-repo test suite locally — this machine only has an Xcode 27 beta toolchain (which fails building a transitive dependency under strict concurrency) and the Command Line Tools, which lack the test frameworks. I confirmed the change compiles as part of the `ContainerAPIClient` target and reproduced the fix against the cases above. CI runs the added test.
