### PR TITLE
Add rosetta installation instruction

### DIFF
--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -86,6 +86,12 @@ Linux c0376e0a-0bfd-4eea-9e9e-9f9a2c327051 6.1.68 #1 SMP Mon Mar 31 18:27:51 UTC
 %
 </pre>
 
+Running `amd64` images requires Rosetta. If you receive an installation error, navigate to `/System/Library/CoreServices/` and open `Rosetta 2 Updater.app` to install it.
+
+<pre>
+Error: failed to bootstrap container ... "Rosetta is not installed" ...
+</pre>
+
 The command to push your multiplatform image to a registry is no different than that for a single-platform image:
 
 ```bash


### PR DESCRIPTION

## Type of Change
- [x] Documentation update

## Motivation and Context
Helps user with multi-architecture example, and make them aware to install Rosetta.

```
% container run --arch amd64 --rm hashicorp/terraform:1.15 terraform version
Error:  Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"
Error: failed to start process 87d4d882-b9a2-4d76-a222-4c67053ba1d3 in container 87d4d882-b9a2-4d76-a222-4c67053ba1d3 (cause: "internalError: "failed to start process (cause: "internalErro
r: "startProcess: failed to start process: internalError: "vmexec error: internalError: " Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory""""")"")
```

## Testing
- [ ] Tested locally
- [ ] Added/updated tests
- [x] Added/updated docs
