### PR TITLE
Fix XPCClient ContinuationResolver deadlock

### DIFF
--- a/Sources/ContainerXPC/XPCClient.swift
+++ b/Sources/ContainerXPC/XPCClient.swift
@@ -95,45 +95,69 @@ extension XPCClient {
         XPCClientSession(client: self)
     }
 
+    /// An actor that ensures a `CheckedContinuation` is resumed at most once.
+    ///
+    /// When both a timeout and the XPC reply race to resume the same continuation,
+    /// the loser's call becomes a safe no-op instead of a fatal double-resume.
+    private actor ContinuationResolver {
+        var continuation: CheckedContinuation<XPCMessage, Error>?
+
+        init(_ continuation: CheckedContinuation<XPCMessage, Error>) {
+            self.continuation = continuation
+        }
+
+        func resume(returning value: XPCMessage) {
+            continuation?.resume(returning: value)
+            continuation = nil
+        }
+
+        func resume(throwing error: Error) {
+            continuation?.resume(throwing: error)
+            continuation = nil
+        }
+    }
+
     /// Send the provided message to the service.
     @discardableResult
     public func send(_ message: XPCMessage, responseTimeout: Duration? = nil) async throws -> XPCMessage {
-        try await withThrowingTaskGroup(of: XPCMessage.self, returning: XPCMessage.self) { group in
-            if let responseTimeout {
-                group.addTask {
-                    try await Task.sleep(for: responseTimeout)
-                    let route = message.string(key: XPCMessage.routeKey) ?? "nil"
-                    throw ContainerizationError(
-                        .internalError,
-                        message: "XPC timeout for request to \(self.service)/\(route)"
-                    )
-                }
-            }
+        try await withCheckedThrowingContinuation { continuation in
+            let resolver = ContinuationResolver(continuation)
 
-            group.addTask {
-                try await withCheckedThrowingContinuation { cont in
-                    xpc_connection_send_message_with_reply(self.connection, message.underlying, nil) { reply in
-                        do {
-                            let message = try self.parseReply(reply)
-                            cont.resume(returning: message)
-                        } catch {
-                            cont.resume(throwing: error)
-                        }
+            let timeoutTask = responseTimeout.map { timeout in
+                Task {
+                    do {
+                        try await Task.sleep(for: timeout)
+                        let route = message.string(key: XPCMessage.routeKey) ?? "nil"
+                        await resolver.resume(
+                            throwing: ContainerizationError(
+                                .internalError,
+                                message: "XPC timeout for request to \(self.service)/\(route)"
+                            ))
+                    } catch {
+                        // Task was cancelled before timeout elapsed — nothing to do.
                     }
                 }
             }
 
-            let response = try await group.next()
-            // once one task has finished, cancel the rest.
-            group.cancelAll()
-            // we don't really care about the second error here
-            // as it's most likely a `CancellationError`.
-            try? await group.waitForAll()
+            xpc_connection_send_message_with_reply(self.connection, message.underlying, nil) { reply in
+                timeoutTask?.cancel()
 
-            guard let response else {
-                throw ContainerizationError(.invalidState, message: "failed to receive XPC response")
+                let result: Result<XPCMessage, Error>
+                do {
+                    let parsed = try self.parseReply(reply)
+                    result = .success(parsed)
+                } catch {
+                    result = .failure(error)
+                }
+                Task {
+                    switch result {
+                    case .success(let message):
+                        await resolver.resume(returning: message)
+                    case .failure(let error):
+                        await resolver.resume(throwing: error)
+                    }
+                }
             }
-            return response
         }
     }
 


### PR DESCRIPTION
Fix #2007

### Motivation and Context
This PR addresses a fatal concurrency issue in `XPCClient.swift` where a race condition between an XPC timeout and a delayed XPC reply can cause a Swift task continuation misuse crash or a permanent task group hang.

Previously, the `XPCClient.send()` method utilized a `withThrowingTaskGroup` to race a timeout task against an XPC callback. However, because Swift Task cancellation cannot cancel registered C `libxpc` callbacks, if the timeout elapsed first, the XPC callback could still fire later. This led to a fatal `SWIFT TASK CONTINUATION MISUSE` crash (resuming a continuation more than once). Furthermore, because `waitForAll()` was used, certain XPC hanging behaviors could cause the task group to deadlock indefinitely.

### Description
This PR refactors `XPCClient.send()` to safely bridge the C-level XPC callback into Swift Concurrency:
- Introduces a private `ContinuationResolver` actor to wrap the `CheckedContinuation`.
- The actor guarantees thread-safe, atomic resolution, ensuring the continuation is resumed exactly once. If both the timeout and the XPC reply race to complete, the loser's call safely becomes a no-op instead of causing a fatal crash.
- Replaces `withThrowingTaskGroup` with a single `withCheckedThrowingContinuation` and a detached `timeoutTask`. This removes the `group.waitForAll()` dependency, preventing the deadlock entirely while cleanly isolating the C-callback lifecycle.

### Testing
- [x] Verified `make check` passes with zero formatting or header issues.
- [x] Verified `swift test` passes locally without deadlocks.
- [x] Tested against simulated XPC hang environments to confirm the timeout resolves instantly without crashing when the delayed reply eventually arrives.