### PR TITLE
Use `enum` for warmup images.

### DIFF
--- a/Sources/ContainerTestSupport/ContainerFixture+ContainerHelpers.swift
+++ b/Sources/ContainerTestSupport/ContainerFixture+ContainerHelpers.swift
@@ -57,7 +57,7 @@ extension ContainerFixture {
         autoRemove: Bool = true,
         containerEnv: [String: String] = [:]
     ) throws {
-        let imageRef = image ?? ContainerFixture.warmupImages[0]
+        let imageRef = image ?? WarmupImage.alpine320.rawValue
         var runArgs = ["run"]
         if autoRemove { runArgs.append("--rm") }
         runArgs += ["--name", name, "-d"]
@@ -78,7 +78,7 @@ extension ContainerFixture {
         networks: [String] = [],
         ports: [String] = []
     ) throws {
-        let imageRef = image ?? ContainerFixture.warmupImages[0]
+        let imageRef = image ?? WarmupImage.alpine320.rawValue
         var createArgs = ["create", "--rm", "--name", name]
         createArgs += proxyEnvironmentArgs
         for v in volumes { createArgs += ["-v", v] }

--- a/Sources/ContainerTestSupport/ContainerFixture.swift
+++ b/Sources/ContainerTestSupport/ContainerFixture.swift
@@ -59,16 +59,6 @@ import Testing
 /// pattern the structured helpers don't cover.
 public final class ContainerFixture: Sendable {
 
-    // MARK: - Configuration
-
-    /// Images preloaded by the ``ImageWarmup`` suite before concurrent tests run.
-    /// Add new commonly-used images here; the warmup pass pulls them in parallel.
-    public static let warmupImages: [String] = [
-        "ghcr.io/linuxcontainers/alpine:3.20",
-        "ghcr.io/linuxcontainers/alpine:3.18",
-        "ghcr.io/containerd/busybox:1.36",
-    ]
-
     // MARK: - State
 
     /// Short random identifier prefixed to every resource this test creates.
@@ -249,7 +239,8 @@ public final class ContainerFixture: Sendable {
     /// The returned name is `{testID}-{imageName}:{tag}`, e.g.
     /// `a3f7c2b1-alpine:3.20`. Tests operate freely on this reference;
     /// the canonical warmup image is never touched.
-    public func copyWarmupImage(_ canonical: String) throws -> String {
+    public func copyWarmupImage(_ image: WarmupImage) throws -> String {
+        let canonical = image.rawValue
         let lastComponent = canonical.split(separator: "/").last.map(String.init) ?? canonical
         let parts = lastComponent.split(separator: ":", maxSplits: 1)
         let name = String(parts[0])

--- a/Sources/ContainerTestSupport/WarmupImage.swift
+++ b/Sources/ContainerTestSupport/WarmupImage.swift
@@ -14,19 +14,10 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import ContainerTestSupport
-import Testing
-
-/// Pulls each image in ``WarmupImage`` in parallel before concurrent
-/// integration tests run. The Makefile's warmup pass runs this suite first
-/// so that ``ContainerFixture/copyWarmupImage(_:)`` can tag from a
-/// pre-populated store rather than pulling on demand.
-@Suite
-struct ImageWarmup {
-    @Test(arguments: WarmupImage.allCases)
-    func pull(image: WarmupImage) async throws {
-        try await ContainerFixture.with { f in
-            try f.run(["image", "pull", image.rawValue]).check("failed to pull \(image.rawValue)")
-        }
-    }
+/// Images preloaded by the ``ImageWarmup`` suite before concurrent tests run.
+/// Add new commonly-used images here; the warmup pass pulls them in parallel.
+public enum WarmupImage: String, CaseIterable, Sendable {
+    case alpine320 = "ghcr.io/linuxcontainers/alpine:3.20"
+    case alpine318 = "ghcr.io/linuxcontainers/alpine:3.18"
+    case busybox136 = "ghcr.io/containerd/busybox:1.36"
 }

--- a/Tests/IntegrationTests/Build/TestCLIBuilderSerial.swift
+++ b/Tests/IntegrationTests/Build/TestCLIBuilderSerial.swift
@@ -876,7 +876,7 @@ struct TestCLIBuilderSerial {
                 let dir = try f.createTempDir()
                 try f.createContext(
                     dir: dir,
-                    dockerfile: "FROM \(ContainerFixture.warmupImages[0])\nADD emptyFile /",
+                    dockerfile: "FROM \(WarmupImage.alpine320.rawValue)\nADD emptyFile /",
                     context: [.file("emptyFile", content: .zeroFilled(size: 1))])
                 let image = "registry.local/no-cache-pull:\(UUID().uuidString)"
                 try f.buildWithPaths(tags: [image], contextDir: dir, otherArgs: ["--pull", "--no-cache"])

--- a/Tests/IntegrationTests/Containers/TestCLICopyCommand.swift
+++ b/Tests/IntegrationTests/Containers/TestCLICopyCommand.swift
@@ -25,7 +25,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyHostToContainer() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let src = f.testDir.appending("testfile.txt")
                 let content = "hello from host"
@@ -39,7 +39,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyContainerToHost() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let content = "hello from container"
                 try f.doExec(name, cmd: ["sh", "-c", "echo -n '\(content)' > /tmp/containerfile.txt"])
@@ -53,7 +53,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyUsingCpAlias() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let src = f.testDir.appending("aliasfile.txt")
                 let content = "testing cp alias"
@@ -74,7 +74,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyContainerToContainerFails() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             let name = "\(f.testID)-c"
             try f.doCreate(name: name, image: image)
             f.addCleanup { try f.doRemoveIfExists(name, ignoreFailure: true) }
@@ -85,7 +85,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyToNonRunningContainerFails() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             let name = "\(f.testID)-c"
             try f.doCreate(name: name, image: image)
             f.addCleanup { try f.doRemoveIfExists(name, ignoreFailure: true) }
@@ -98,7 +98,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyDirectoryHostToContainer() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let srcDir = f.testDir.appending("hostdir")
                 try FileManager.default.createDirectory(atPath: srcDir.string, withIntermediateDirectories: true, attributes: nil)
@@ -115,7 +115,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyDirectoryContainerToHost() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/guestdir && echo -n 'aaa' > /tmp/guestdir/a.txt && echo -n 'bbb' > /tmp/guestdir/b.txt"])
                 let dest = f.testDir.appending("guestdir")
@@ -130,7 +130,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyNestedDirectoryHostToContainer() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let srcDir = f.testDir.appending("nested")
                 let subDir = srcDir.appending("sub")
@@ -148,7 +148,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyNestedDirectoryContainerToHost() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/nested/sub && echo -n 'root file' > /tmp/nested/root.txt && echo -n 'nested file' > /tmp/nested/sub/deep.txt"])
                 let dest = f.testDir.appending("nested")
@@ -165,7 +165,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutFileToExistingFile() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let content = "container content"
                 try f.doExec(name, cmd: ["sh", "-c", "echo -n '\(content)' > /tmp/source.txt"])
@@ -180,7 +180,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutDirectoryToExistingFileFails() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/srcdir && echo -n 'x' > /tmp/srcdir/file.txt"])
                 let dest = f.testDir.appending("existing.txt")
@@ -193,7 +193,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutFileToExistingDirectory() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let content = "container content"
                 try f.doExec(name, cmd: ["sh", "-c", "echo -n '\(content)' > /tmp/source.txt"])
@@ -208,7 +208,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutDirectoryToExistingDirectory() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/srcdir && echo -n 'hello' > /tmp/srcdir/file.txt"])
                 let destDir = f.testDir.appending("dstdir")
@@ -224,7 +224,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutFileToNonExistingTrailingSlashFails() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "echo -n 'x' > /tmp/source.txt"])
                 let dest = f.testDir.appending("nonexistent").string + "/"
@@ -236,7 +236,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutDirectoryToNonExistingTrailingSlash() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/srcdir && echo -n 'hello' > /tmp/srcdir/file.txt"])
                 let destDir = f.testDir.appending("newdir")
@@ -251,7 +251,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutFileToExistingDirectoryTrailingSlash() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let content = "container content"
                 try f.doExec(name, cmd: ["sh", "-c", "echo -n '\(content)' > /tmp/source.txt"])
@@ -266,7 +266,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutDirectoryToExistingDirectoryTrailingSlash() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/srcdir && echo -n 'hello' > /tmp/srcdir/file.txt"])
                 let destDir = f.testDir.appending("dstdir")
@@ -282,7 +282,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutDirectoryContentsToNonExisting() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/srcdir/sub && echo -n 'hello' > /tmp/srcdir/file.txt"])
                 let destDir = f.testDir.appending("newdir")
@@ -297,7 +297,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutDirectoryContentsToExistingFileFails() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/srcdir && echo -n 'x' > /tmp/srcdir/file.txt"])
                 let dest = f.testDir.appending("existing.txt")
@@ -310,7 +310,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutDirectoryContentsToExistingDirectory() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/srcdir && echo -n 'hello' > /tmp/srcdir/file.txt"])
                 let destDir = f.testDir.appending("dstdir")
@@ -326,7 +326,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutDirectoryContentsToNonExistingTrailingSlash() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/srcdir && echo -n 'hello' > /tmp/srcdir/file.txt"])
                 let destDir = f.testDir.appending("newdir")
@@ -339,7 +339,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutDirectoryContentsToExistingDirectoryTrailingSlash() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/srcdir && echo -n 'hello' > /tmp/srcdir/file.txt"])
                 let destDir = f.testDir.appending("dstdir")
@@ -355,7 +355,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInFileToExistingFile() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let content = "new content"
                 let src = f.testDir.appending("source.txt")
@@ -370,7 +370,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInDirectoryToExistingFileFails() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let srcDir = f.testDir.appending("srcdir")
                 try FileManager.default.createDirectory(atPath: srcDir.string, withIntermediateDirectories: true, attributes: nil)
@@ -384,7 +384,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInFileToExistingDirectory() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let content = "host content"
                 let src = f.testDir.appending("source.txt")
@@ -399,7 +399,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInDirectoryToExistingDirectory() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let srcDir = f.testDir.appending("srcdir")
                 try FileManager.default.createDirectory(atPath: srcDir.string, withIntermediateDirectories: true, attributes: nil)
@@ -416,7 +416,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInFileToNonExistingTrailingSlashFails() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let src = f.testDir.appending("source.txt")
                 try "x".write(toFile: src.string, atomically: true, encoding: .utf8)
@@ -428,7 +428,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInDirectoryToNonExistingTrailingSlash() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let srcDir = f.testDir.appending("srcdir")
                 try FileManager.default.createDirectory(atPath: srcDir.string, withIntermediateDirectories: true, attributes: nil)
@@ -444,7 +444,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInDirectoryContentsToNonExisting() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let srcDir = f.testDir.appending("srcdir")
                 let subDir = srcDir.appending("sub")
@@ -459,7 +459,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInDirectoryContentsToExistingFileFails() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let srcDir = f.testDir.appending("srcdir")
                 try FileManager.default.createDirectory(atPath: srcDir.string, withIntermediateDirectories: true, attributes: nil)
@@ -473,7 +473,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInDirectoryContentsToExistingDirectory() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let srcDir = f.testDir.appending("srcdir")
                 try FileManager.default.createDirectory(atPath: srcDir.string, withIntermediateDirectories: true, attributes: nil)
@@ -490,7 +490,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInDirectoryContentsToNonExistingTrailingSlash() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let srcDir = f.testDir.appending("srcdir")
                 try FileManager.default.createDirectory(atPath: srcDir.string, withIntermediateDirectories: true, attributes: nil)
@@ -504,7 +504,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInDirectoryContentsToExistingDirectoryTrailingSlash() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let srcDir = f.testDir.appending("srcdir")
                 try FileManager.default.createDirectory(atPath: srcDir.string, withIntermediateDirectories: true, attributes: nil)
@@ -521,7 +521,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInRelativeSourcePath() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let content = "relative source"
                 try content.write(toFile: f.testDir.appending("relfile.txt").string, atomically: true, encoding: .utf8)
@@ -534,7 +534,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutRelativeDestinationPath() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let content = "relative dest"
                 try f.doExec(name, cmd: ["sh", "-c", "echo -n '\(content)' > /tmp/relfile.txt"])

--- a/Tests/IntegrationTests/Containers/TestCLICreateCommand.swift
+++ b/Tests/IntegrationTests/Containers/TestCLICreateCommand.swift
@@ -23,7 +23,7 @@ import Testing
 struct TestCLICreateCommand {
     @Test func testCreateArgsPassthrough() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             let name = "\(f.testID)-c"
             try f.doCreate(name: name, image: image, args: ["echo", "-n", "hello", "world"])
             try f.doRemove(name)
@@ -32,7 +32,7 @@ struct TestCLICreateCommand {
 
     @Test func testCreateWithMACAddress() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             let name = "\(f.testID)-c"
             let expectedMAC = try MACAddress("02:42:ac:11:00:03")
 
@@ -52,7 +52,7 @@ struct TestCLICreateCommand {
 
     @Test func testPublishPortParserMaxPorts() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             let name = "\(f.testID)-c"
             var args: [String] = ["create", "--name", name]
             for i in 0..<64 {
@@ -68,7 +68,7 @@ struct TestCLICreateCommand {
 
     @Test func testPublishPortParserTooManyPorts() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             let name = "\(f.testID)-c"
             var args: [String] = ["create", "--name", name]
             for i in 0..<65 {
@@ -84,7 +84,7 @@ struct TestCLICreateCommand {
 
     @Test func testCreateWithFQDNName() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             // Prefix with testID to avoid name collisions; hostname is the first FQDN component.
             let name = "\(f.testID).example.com"
             let expectedHostname = f.testID

--- a/Tests/IntegrationTests/Containers/TestCLIExecCommand.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIExecCommand.swift
@@ -21,7 +21,7 @@ import Testing
 struct TestCLIExecCommand {
     @Test func testCreateExecCommand() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             let name = "\(f.testID)-c"
             try f.doCreate(name: name, image: image)
             f.addCleanup { try? f.doStop(name) }
@@ -36,7 +36,7 @@ struct TestCLIExecCommand {
 
     @Test func testExecDetach() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             let name = "\(f.testID)-c"
             try f.doCreate(name: name, image: image)
             f.addCleanup { try? f.doStop(name) }
@@ -70,7 +70,7 @@ struct TestCLIExecCommand {
 
     @Test func testExecDetachProcessRunning() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             let name = "\(f.testID)-c"
             try f.doCreate(name: name, image: image)
             f.addCleanup { try? f.doStop(name) }
@@ -92,7 +92,7 @@ struct TestCLIExecCommand {
 
     @Test func testExecOnExitingContainer() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             let name = "\(f.testID)-c"
             // sh exits immediately in detached mode with no stdin; container stops on its own.
             try f.doLongRun(name: name, image: image, containerArgs: ["sh"], autoRemove: false)

--- a/Tests/IntegrationTests/Containers/TestCLIExportCommand.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIExportCommand.swift
@@ -23,7 +23,7 @@ import Testing
 struct TestCLIExportCommand {
     @Test func testExportCommand() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image, autoRemove: false) { name in
                 let mustBeInImage = "must-be-in-image"
                 try f.doExec(name, cmd: ["sh", "-c", "echo \(mustBeInImage) > /foo"])

--- a/Tests/IntegrationTests/Containers/TestCLIPruneCommandSerial.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIPruneCommandSerial.swift
@@ -37,7 +37,7 @@ struct TestCLIPruneCommandSerial {
 
     @Test func testContainerPruneStoppedContainers() async throws {
         try await ContainerFixture.with { f in
-            let image = ContainerFixture.warmupImages[0]
+            let image = WarmupImage.alpine320.rawValue
             if try !f.isImagePresent(image) { try f.doPull(image) }
 
             // One running container that must survive the prune.

--- a/Tests/IntegrationTests/Containers/TestCLIRemove.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIRemove.swift
@@ -23,7 +23,7 @@ import Testing
 struct TestCLIRemove {
     @Test func testDeleteStopped() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             let name = "\(f.testID)-c"
             // create without --rm so the container persists after being stopped
             try f.doCreate(name: name, image: image)
@@ -35,7 +35,7 @@ struct TestCLIRemove {
 
     @Test func testDeleteAlias() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             let name = "\(f.testID)-c"
             try f.doCreate(name: name, image: image)
             try f.run(["rm", name]).check("rm alias failed")
@@ -46,7 +46,7 @@ struct TestCLIRemove {
 
     @Test func testDeleteForceRunning() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 try f.doRemove(name, force: true)
                 let result = try f.run(["inspect", name])
@@ -72,7 +72,7 @@ struct TestCLIRemove {
 
     @Test func testDeleteDuplicateIds() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             let name = "\(f.testID)-c"
             try f.doCreate(name: name, image: image)
             f.addCleanup { try f.doRemoveIfExists(name, force: true, ignoreFailure: true) }

--- a/Tests/IntegrationTests/Containers/TestCLIRemoveSerial.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIRemoveSerial.swift
@@ -23,7 +23,7 @@ import Testing
 struct TestCLIRemoveSerial {
     @Test func testDeleteAllStopped() async throws {
         try await ContainerFixture.with { f in
-            let image = ContainerFixture.warmupImages[0]
+            let image = WarmupImage.alpine320.rawValue
             if try !f.isImagePresent(image) { try f.doPull(image) }
             let name1 = "\(f.testID)-c1"
             let name2 = "\(f.testID)-c2"
@@ -41,7 +41,7 @@ struct TestCLIRemoveSerial {
 
     @Test func testDeleteAllSkipsRunning() async throws {
         try await ContainerFixture.with { f in
-            let image = ContainerFixture.warmupImages[0]
+            let image = WarmupImage.alpine320.rawValue
             if try !f.isImagePresent(image) { try f.doPull(image) }
             let runningName = "\(f.testID)-running"
             let stoppedName = "\(f.testID)-stopped"
@@ -63,7 +63,7 @@ struct TestCLIRemoveSerial {
 
     @Test func testDeleteAllForce() async throws {
         try await ContainerFixture.with { f in
-            let image = ContainerFixture.warmupImages[0]
+            let image = WarmupImage.alpine320.rawValue
             if try !f.isImagePresent(image) { try f.doPull(image) }
             let name = "\(f.testID)-c"
             try f.doLongRun(name: name, image: image, autoRemove: false)

--- a/Tests/IntegrationTests/Containers/TestCLIStatsCommand.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIStatsCommand.swift
@@ -23,7 +23,7 @@ import Testing
 struct TestCLIStatsCommand {
     @Test func testStatsNoStreamJSONFormat() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let result = try f.run(["stats", "--format", "json", "--no-stream", name]).check()
                 let stats = try JSONDecoder().decode([ContainerStats].self, from: result.outputData)
@@ -39,7 +39,7 @@ struct TestCLIStatsCommand {
 
     @Test func testStatsIdleCPUPercentage() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image, containerArgs: ["sleep", "3600"]) { name in
                 let result = try f.run(["stats", "--no-stream", name]).check()
                 let lines = result.output.components(separatedBy: .newlines)
@@ -57,7 +57,7 @@ struct TestCLIStatsCommand {
 
     @Test func testStatsHighCPUPercentage() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image, containerArgs: ["sh", "-c", "while true; do :; done"]) { name in
                 let result = try f.run(["stats", "--no-stream", name]).check()
                 let lines = result.output.components(separatedBy: .newlines)
@@ -76,7 +76,7 @@ struct TestCLIStatsCommand {
 
     @Test func testStatsTableFormat() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let result = try f.run(["stats", "--no-stream", name]).check()
                 #expect(result.output.contains("Container ID"), "output should contain table header")
@@ -89,7 +89,7 @@ struct TestCLIStatsCommand {
 
     @Test func testStatsAllContainers() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             // Run two containers simultaneously so both appear in the global stats snapshot.
             try await f.withContainer(image: image, tag: "c1") { name1 in
                 try await f.withContainer(image: image, tag: "c2") { name2 in

--- a/Tests/IntegrationTests/Containers/TestCLIStop.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIStop.swift
@@ -21,7 +21,7 @@ import Testing
 struct TestCLIStop {
     @Test func testStopWithExplicitSignal() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image, autoRemove: false) { name in
                 try f.doStop(name, signal: "SIGTERM")
                 #expect(try f.getContainerStatus(name) == "stopped")
@@ -31,7 +31,7 @@ struct TestCLIStop {
 
     @Test func testStopWithoutSignal() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image, autoRemove: false) { name in
                 try f.doStop(name, signal: nil)
                 #expect(try f.getContainerStatus(name) == "stopped")
@@ -41,7 +41,7 @@ struct TestCLIStop {
 
     @Test func testStopSignalInInspect() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image, autoRemove: false) { name in
                 let inspect = try f.inspectContainer(name)
                 // Alpine doesn't set a STOPSIGNAL, so this should be nil.
@@ -52,7 +52,7 @@ struct TestCLIStop {
 
     @Test func testStopIdempotent() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image, autoRemove: false) { name in
                 try f.doStop(name, signal: "SIGKILL")
                 #expect(try f.getContainerStatus(name) == "stopped")

--- a/Tests/IntegrationTests/Images/TestCLIImagePruneSerial.swift
+++ b/Tests/IntegrationTests/Images/TestCLIImagePruneSerial.swift
@@ -17,8 +17,8 @@
 import ContainerTestSupport
 import Testing
 
-private let alpine = ContainerFixture.warmupImages[0]
-private let busybox = ContainerFixture.warmupImages[2]
+private let alpine = WarmupImage.alpine320.rawValue
+private let busybox = WarmupImage.busybox136.rawValue
 
 /// Serial tests for `image prune` and `--max-concurrent-downloads`.
 /// These use `image rm --all` which affects global state.

--- a/Tests/IntegrationTests/Images/TestCLIImagesCommand.swift
+++ b/Tests/IntegrationTests/Images/TestCLIImagesCommand.swift
@@ -22,9 +22,9 @@ import Testing
 
 @Suite
 struct TestCLIImagesCommand {
-    private let alpine = ContainerFixture.warmupImages[0]  // ghcr.io/linuxcontainers/alpine:3.20
-    private let alpine318 = ContainerFixture.warmupImages[1]  // ghcr.io/linuxcontainers/alpine:3.18
-    private let busybox = ContainerFixture.warmupImages[2]  // ghcr.io/containerd/busybox:1.36
+    private let alpine = WarmupImage.alpine320.rawValue  // ghcr.io/linuxcontainers/alpine:3.20
+    private let alpine318 = WarmupImage.alpine318.rawValue  // ghcr.io/linuxcontainers/alpine:3.18
+    private let busybox = WarmupImage.busybox136.rawValue  // ghcr.io/containerd/busybox:1.36
 
     /// Host architecture string for platform tests.
     private var hostArchitecture: String {

--- a/Tests/IntegrationTests/Images/TestCLIProgressAuto.swift
+++ b/Tests/IntegrationTests/Images/TestCLIProgressAuto.swift
@@ -19,7 +19,7 @@ import Testing
 
 @Suite
 struct TestCLIProgressAuto {
-    private let alpine = ContainerFixture.warmupImages[0]
+    private let alpine = WarmupImage.alpine320.rawValue
 
     @Test func testAutoProgressFallsBackToPlainWhenPiped() async throws {
         try await ContainerFixture.with { f in

--- a/Tests/IntegrationTests/Network/TestCLINetwork.swift
+++ b/Tests/IntegrationTests/Network/TestCLINetwork.swift
@@ -112,7 +112,7 @@ struct TestCLINetwork {
 
     @Test func testNetworkMTU() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             let c = "\(f.testID)-c"
             try f.doLongRun(name: c, image: image, args: ["--network", "default,mtu=1500"], autoRemove: false)
             f.addCleanup {

--- a/Tests/IntegrationTests/Run/TestCLIRunCapabilities.swift
+++ b/Tests/IntegrationTests/Run/TestCLIRunCapabilities.swift
@@ -20,7 +20,7 @@ import Testing
 
 @Suite
 struct TestCLIRunCapabilities {
-    private let alpine = ContainerFixture.warmupImages[0]
+    private let alpine = WarmupImage.alpine320
 
     // MARK: - Invalid capability names
 

--- a/Tests/IntegrationTests/Run/TestCLIRunCommand.swift
+++ b/Tests/IntegrationTests/Run/TestCLIRunCommand.swift
@@ -23,7 +23,7 @@ import Testing
 
 @Suite
 struct TestCLIRunCommand {
-    private let alpine = ContainerFixture.warmupImages[0]
+    private let alpine = WarmupImage.alpine320
 
     // MARK: - Basic run options
 

--- a/Tests/IntegrationTests/Run/TestCLIRunFilesystem.swift
+++ b/Tests/IntegrationTests/Run/TestCLIRunFilesystem.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerTestSupport
 import Foundation
 import Testing
 
@@ -31,7 +32,7 @@ import Testing
 // therefore 1024+92=1116 and 1024+256=1280.
 @Suite
 struct TestCLIRunFilesystem {
-    private let alpine = ContainerFixture.warmupImages[0]
+    private let alpine = WarmupImage.alpine320
 
     private static let featureCompatOffset = 1116
     private static let defaultMountOptsOffset = 1280

--- a/Tests/IntegrationTests/Run/TestCLIRunInitImage.swift
+++ b/Tests/IntegrationTests/Run/TestCLIRunInitImage.swift
@@ -26,7 +26,7 @@ import Testing
 /// once a test init image is published to the registry.
 @Suite
 struct TestCLIRunInitImage {
-    private let alpine = ContainerFixture.warmupImages[0]
+    private let alpine = WarmupImage.alpine320
 
     @Test func testRunWithNonExistentInitImage() async throws {
         try await ContainerFixture.with { f in

--- a/Tests/IntegrationTests/Run/TestCLIRunLifecycle.swift
+++ b/Tests/IntegrationTests/Run/TestCLIRunLifecycle.swift
@@ -23,7 +23,7 @@ import Testing
 struct TestCLIRunLifecycle {
     @Test func testRunFailureCleanup() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             let name = "\(f.testID)-c"
 
             // First attempt with an invalid user — must fail.
@@ -43,7 +43,7 @@ struct TestCLIRunLifecycle {
 
     @Test func testStartIdempotent() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let result = try f.run(["start", name])
                 #expect(result.status == 0, "expected start to succeed on already running container")
@@ -57,7 +57,7 @@ struct TestCLIRunLifecycle {
 
     @Test func testStartIdempotentAttachFails() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let result = try f.run(["start", "-a", name])
                 #expect(
@@ -70,7 +70,7 @@ struct TestCLIRunLifecycle {
 
     @Test func testRunInvalidExecutable() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             let name = "\(f.testID)-c"
             f.addCleanup { try f.doRemoveIfExists(name, force: true, ignoreFailure: true) }
             let result = try f.run(["run", "--rm", "--name", name, "-d", image, "foobarbaz"])
@@ -80,7 +80,7 @@ struct TestCLIRunLifecycle {
 
     @Test func testExecInvalidExecutable() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             try await f.withContainer(image: image) { name in
                 let result = try f.run(["exec", name, "foobarbaz"])
                 #expect(result.status != 0, "executing invalid executable must fail, not hang")
@@ -90,7 +90,7 @@ struct TestCLIRunLifecycle {
 
     @Test func testSSHForwarding() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
 
             let socketPath = try f.makeFakeSSHAgentSocket()
 

--- a/Tests/IntegrationTests/Run/TestCLITermIO.swift
+++ b/Tests/IntegrationTests/Run/TestCLITermIO.swift
@@ -23,7 +23,7 @@ import Testing
 struct TestCLITermIO {
     @Test func testTermIODoesNotPanic() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(ContainerFixture.warmupImages[0])
+            let image = try f.copyWarmupImage(.alpine320)
             let name = "\(f.testID)-c"
             f.addCleanup { try f.doRemoveIfExists(name, force: true, ignoreFailure: true) }
 

--- a/Tests/IntegrationTests/System/TestCLIKernelSetSerial.swift
+++ b/Tests/IntegrationTests/System/TestCLIKernelSetSerial.swift
@@ -167,7 +167,7 @@ struct TestCLIKernelSetSerial {
     /// on the host — that is, `uname -r` matches the release parsed from the kernel
     /// binary filename (see ``expectedKernelRelease``).
     private func validateGuestKernel(_ f: ContainerFixture) async throws {
-        let image = ContainerFixture.warmupImages[0]
+        let image = WarmupImage.alpine320.rawValue
         if try !f.isImagePresent(image) { try f.doPull(image) }
         try await f.withContainer(image: image) { name in
             let release = try f.doExec(name, cmd: ["uname", "-r"])

--- a/Tests/IntegrationTests/System/TestCLISystemDFSerial.swift
+++ b/Tests/IntegrationTests/System/TestCLISystemDFSerial.swift
@@ -32,7 +32,7 @@ struct TestCLISystemDFSerial {
         let total: Int
     }
 
-    private let alpine = ContainerFixture.warmupImages[0]
+    private let alpine = WarmupImage.alpine320.rawValue
 
     // Issue #1526: reported image size must include content blobs, not just unpacked snapshots.
     @Test func imageDiskUsageIsPopulatedAfterPull() async throws {

--- a/Tests/IntegrationTests/Volumes/TestCLIAnonymousVolumes.swift
+++ b/Tests/IntegrationTests/Volumes/TestCLIAnonymousVolumes.swift
@@ -25,7 +25,7 @@ import Testing
 /// global volume state, so the suite runs in the concurrent pass.
 @Suite
 struct TestCLIAnonymousVolumes {
-    private let alpine = ContainerFixture.warmupImages[0]
+    private let alpine = WarmupImage.alpine320
 
     @Test func testAnonymousVolumeCreationAndPersistence() async throws {
         try await ContainerFixture.with { f in

--- a/Tests/IntegrationTests/Volumes/TestCLIVolumes.swift
+++ b/Tests/IntegrationTests/Volumes/TestCLIVolumes.swift
@@ -20,7 +20,7 @@ import Testing
 
 @Suite
 struct TestCLIVolumes {
-    private let alpine = ContainerFixture.warmupImages[0]
+    private let alpine = WarmupImage.alpine320.rawValue
 
     @Test func testVolumeDataPersistenceAcrossContainers() async throws {
         try await ContainerFixture.with { f in

--- a/Tests/IntegrationTests/Volumes/TestCLIVolumesSerial.swift
+++ b/Tests/IntegrationTests/Volumes/TestCLIVolumesSerial.swift
@@ -20,7 +20,7 @@ import Testing
 
 @Suite(.serialized)
 struct TestCLIVolumesSerial {
-    private let alpine = ContainerFixture.warmupImages[0]
+    private let alpine = WarmupImage.alpine320.rawValue
 
     @Test func testVolumePruneNoVolumes() async throws {
         try await ContainerFixture.with { f in


### PR DESCRIPTION
- Closes #1982.
- Makes warmup image code more readable in tests.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs
