### PR TITLE
Integration test - miscellaneous fixture and test refinements.

### DIFF
--- a/Sources/ContainerTestSupport/ContainerFixture+ContainerHelpers.swift
+++ b/Sources/ContainerTestSupport/ContainerFixture+ContainerHelpers.swift
@@ -49,14 +49,18 @@ extension ContainerFixture {
     ///
     /// `containerEnv` injects environment variables into the container via `-e` flags.
     /// To set the CLI subprocess environment (e.g. for `--ssh`), use ``run(_:env:)`` directly.
+    ///
+    /// Pass `waitUntilRunning: true` to poll for `running` state before returning,
+    /// eliminating a separate ``ContainerFixture/waitForContainerRunning(_:attempts:)`` call.
     public func doLongRun(
         name: String,
         image: String? = nil,
         args: [String] = [],
         containerArgs: [String] = ["sleep", "infinity"],
         autoRemove: Bool = true,
-        containerEnv: [String: String] = [:]
-    ) throws {
+        containerEnv: [String: String] = [:],
+        waitUntilRunning: Bool = false
+    ) async throws {
         let imageRef = image ?? WarmupImage.alpine320.rawValue
         var runArgs = ["run"]
         if autoRemove { runArgs.append("--rm") }
@@ -67,6 +71,9 @@ extension ContainerFixture {
         runArgs.append(imageRef)
         runArgs += containerArgs
         try run(runArgs).check()
+        if waitUntilRunning {
+            try await waitForContainerRunning(name)
+        }
     }
 
     /// Creates a stopped container (`container create`).

--- a/Sources/ContainerTestSupport/ContainerFixture+NetworkHelpers.swift
+++ b/Sources/ContainerTestSupport/ContainerFixture+NetworkHelpers.swift
@@ -69,4 +69,23 @@ extension ContainerFixture {
     public func makeHTTPClient() -> HTTPClient {
         HTTPClient(eventLoopGroupProvider: .singleton)
     }
+
+    /// Polls `url` via HTTP GET until it returns a 2xx status.
+    ///
+    /// Useful after a container reaches `running` state, since that only proves
+    /// the container's init process is up — a server inside may still be starting.
+    public func waitForHTTPOk(
+        _ url: String, using client: HTTPClient, attempts: Int = 10, delay: Duration = .seconds(1)
+    ) async throws {
+        try await retry(attempts: attempts, delay: delay) {
+            do {
+                var req = HTTPClientRequest(url: url)
+                req.method = .GET
+                let resp = try await client.execute(req, timeout: .seconds(3))
+                return resp.status.code >= 200 && resp.status.code < 300
+            } catch {
+                return false
+            }
+        }
+    }
 }

--- a/Sources/ContainerTestSupport/ContainerFixture+SSHTestHelpers.swift
+++ b/Sources/ContainerTestSupport/ContainerFixture+SSHTestHelpers.swift
@@ -24,21 +24,16 @@ extension ContainerFixture {
     /// Creates a Unix-domain listening socket at a short path under `/tmp`,
     /// suitable for use as `SSH_AUTH_SOCK` in tests that exercise `--ssh` forwarding.
     ///
-    /// The path is `/tmp/{testID}-ssh/ssh-auth.sock`, which fits comfortably within
-    /// `sockaddr_un.sun_path`'s 104-byte limit on macOS regardless of project depth.
-    ///
     /// An accept loop runs on a background thread, closing each incoming connection.
     /// `accept()` is a blocking syscall, so `Thread` is appropriate here — using
     /// `Task.detached` would block a cooperative thread without yielding.
     ///
-    /// The socket fd and its parent directory are auto-cleaned on fixture scope exit;
-    /// closing the listening fd is what causes the accept loop to exit.
+    /// The socket fd is closed on fixture scope exit, which is what causes the
+    /// accept loop to exit; its parent directory is removed by ``makeShortSocketDir(_:)``.
     ///
     /// Returns the socket path. Pass it as `SSH_AUTH_SOCK` in the CLI process env.
     public func makeFakeSSHAgentSocket() throws -> String {
-        let socketDir = "/tmp/\(testID)-ssh"
-        try FileManager.default.createDirectory(
-            atPath: socketDir, withIntermediateDirectories: true, attributes: nil)
+        let socketDir = try makeShortSocketDir("ssh")
         let socketPath = socketDir + "/ssh-auth.sock"
 
         let serverFd = socket(AF_UNIX, SOCK_STREAM, 0)
@@ -81,7 +76,6 @@ extension ContainerFixture {
 
         addCleanup {
             Darwin.close(serverFd)
-            try? FileManager.default.removeItem(atPath: socketDir)
         }
 
         return socketPath

--- a/Sources/ContainerTestSupport/ContainerFixture.swift
+++ b/Sources/ContainerTestSupport/ContainerFixture.swift
@@ -234,6 +234,22 @@ public final class ContainerFixture: Sendable {
             status: process.terminationStatus)
     }
 
+    /// Creates a directory at a short, fixed-depth path under `/tmp`, suitable for
+    /// Unix-domain socket files that must fit within `sockaddr_un.sun_path`'s 104-byte
+    /// limit on macOS regardless of the project checkout's directory depth.
+    ///
+    /// Returns the directory path; the caller creates the socket file inside it.
+    /// The directory is removed on fixture cleanup.
+    public func makeShortSocketDir(_ suffix: String) throws -> String {
+        let dir = "/tmp/\(testID)-\(suffix)"
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true, attributes: nil)
+        addCleanup {
+            try? FileManager.default.removeItem(atPath: dir)
+        }
+        return dir
+    }
+
     /// Tags a warmup image to a test-local reference and registers its removal.
     ///
     /// The returned name is `{testID}-{imageName}:{tag}`, e.g.

--- a/Tests/IntegrationTests/Containers/TestCLICopyCommand.swift
+++ b/Tests/IntegrationTests/Containers/TestCLICopyCommand.swift
@@ -25,7 +25,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyHostToContainer() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let src = f.testDir.appending("testfile.txt")
                 let content = "hello from host"
@@ -39,7 +39,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyContainerToHost() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let content = "hello from container"
                 try f.doExec(name, cmd: ["sh", "-c", "echo -n '\(content)' > /tmp/containerfile.txt"])
@@ -53,7 +53,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyUsingCpAlias() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let src = f.testDir.appending("aliasfile.txt")
                 let content = "testing cp alias"
@@ -74,7 +74,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyContainerToContainerFails() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             let name = "\(f.testID)-c"
             try f.doCreate(name: name, image: image)
             f.addCleanup { try f.doRemoveIfExists(name, ignoreFailure: true) }
@@ -85,7 +85,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyToNonRunningContainerFails() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             let name = "\(f.testID)-c"
             try f.doCreate(name: name, image: image)
             f.addCleanup { try f.doRemoveIfExists(name, ignoreFailure: true) }
@@ -98,7 +98,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyDirectoryHostToContainer() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let srcDir = f.testDir.appending("hostdir")
                 try FileManager.default.createDirectory(atPath: srcDir.string, withIntermediateDirectories: true, attributes: nil)
@@ -115,7 +115,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyDirectoryContainerToHost() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/guestdir && echo -n 'aaa' > /tmp/guestdir/a.txt && echo -n 'bbb' > /tmp/guestdir/b.txt"])
                 let dest = f.testDir.appending("guestdir")
@@ -130,7 +130,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyNestedDirectoryHostToContainer() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let srcDir = f.testDir.appending("nested")
                 let subDir = srcDir.appending("sub")
@@ -148,7 +148,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyNestedDirectoryContainerToHost() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/nested/sub && echo -n 'root file' > /tmp/nested/root.txt && echo -n 'nested file' > /tmp/nested/sub/deep.txt"])
                 let dest = f.testDir.appending("nested")
@@ -165,7 +165,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutFileToExistingFile() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let content = "container content"
                 try f.doExec(name, cmd: ["sh", "-c", "echo -n '\(content)' > /tmp/source.txt"])
@@ -180,7 +180,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutDirectoryToExistingFileFails() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/srcdir && echo -n 'x' > /tmp/srcdir/file.txt"])
                 let dest = f.testDir.appending("existing.txt")
@@ -193,7 +193,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutFileToExistingDirectory() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let content = "container content"
                 try f.doExec(name, cmd: ["sh", "-c", "echo -n '\(content)' > /tmp/source.txt"])
@@ -208,7 +208,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutDirectoryToExistingDirectory() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/srcdir && echo -n 'hello' > /tmp/srcdir/file.txt"])
                 let destDir = f.testDir.appending("dstdir")
@@ -224,7 +224,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutFileToNonExistingTrailingSlashFails() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "echo -n 'x' > /tmp/source.txt"])
                 let dest = f.testDir.appending("nonexistent").string + "/"
@@ -236,7 +236,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutDirectoryToNonExistingTrailingSlash() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/srcdir && echo -n 'hello' > /tmp/srcdir/file.txt"])
                 let destDir = f.testDir.appending("newdir")
@@ -251,7 +251,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutFileToExistingDirectoryTrailingSlash() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let content = "container content"
                 try f.doExec(name, cmd: ["sh", "-c", "echo -n '\(content)' > /tmp/source.txt"])
@@ -266,7 +266,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutDirectoryToExistingDirectoryTrailingSlash() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/srcdir && echo -n 'hello' > /tmp/srcdir/file.txt"])
                 let destDir = f.testDir.appending("dstdir")
@@ -282,7 +282,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutDirectoryContentsToNonExisting() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/srcdir/sub && echo -n 'hello' > /tmp/srcdir/file.txt"])
                 let destDir = f.testDir.appending("newdir")
@@ -297,7 +297,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutDirectoryContentsToExistingFileFails() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/srcdir && echo -n 'x' > /tmp/srcdir/file.txt"])
                 let dest = f.testDir.appending("existing.txt")
@@ -310,7 +310,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutDirectoryContentsToExistingDirectory() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/srcdir && echo -n 'hello' > /tmp/srcdir/file.txt"])
                 let destDir = f.testDir.appending("dstdir")
@@ -326,7 +326,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutDirectoryContentsToNonExistingTrailingSlash() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/srcdir && echo -n 'hello' > /tmp/srcdir/file.txt"])
                 let destDir = f.testDir.appending("newdir")
@@ -339,7 +339,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutDirectoryContentsToExistingDirectoryTrailingSlash() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 try f.doExec(name, cmd: ["sh", "-c", "mkdir -p /tmp/srcdir && echo -n 'hello' > /tmp/srcdir/file.txt"])
                 let destDir = f.testDir.appending("dstdir")
@@ -355,7 +355,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInFileToExistingFile() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let content = "new content"
                 let src = f.testDir.appending("source.txt")
@@ -370,7 +370,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInDirectoryToExistingFileFails() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let srcDir = f.testDir.appending("srcdir")
                 try FileManager.default.createDirectory(atPath: srcDir.string, withIntermediateDirectories: true, attributes: nil)
@@ -384,7 +384,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInFileToExistingDirectory() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let content = "host content"
                 let src = f.testDir.appending("source.txt")
@@ -399,7 +399,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInDirectoryToExistingDirectory() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let srcDir = f.testDir.appending("srcdir")
                 try FileManager.default.createDirectory(atPath: srcDir.string, withIntermediateDirectories: true, attributes: nil)
@@ -416,7 +416,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInFileToNonExistingTrailingSlashFails() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let src = f.testDir.appending("source.txt")
                 try "x".write(toFile: src.string, atomically: true, encoding: .utf8)
@@ -428,7 +428,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInDirectoryToNonExistingTrailingSlash() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let srcDir = f.testDir.appending("srcdir")
                 try FileManager.default.createDirectory(atPath: srcDir.string, withIntermediateDirectories: true, attributes: nil)
@@ -444,7 +444,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInDirectoryContentsToNonExisting() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let srcDir = f.testDir.appending("srcdir")
                 let subDir = srcDir.appending("sub")
@@ -459,7 +459,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInDirectoryContentsToExistingFileFails() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let srcDir = f.testDir.appending("srcdir")
                 try FileManager.default.createDirectory(atPath: srcDir.string, withIntermediateDirectories: true, attributes: nil)
@@ -473,7 +473,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInDirectoryContentsToExistingDirectory() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let srcDir = f.testDir.appending("srcdir")
                 try FileManager.default.createDirectory(atPath: srcDir.string, withIntermediateDirectories: true, attributes: nil)
@@ -490,7 +490,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInDirectoryContentsToNonExistingTrailingSlash() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let srcDir = f.testDir.appending("srcdir")
                 try FileManager.default.createDirectory(atPath: srcDir.string, withIntermediateDirectories: true, attributes: nil)
@@ -504,7 +504,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInDirectoryContentsToExistingDirectoryTrailingSlash() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let srcDir = f.testDir.appending("srcdir")
                 try FileManager.default.createDirectory(atPath: srcDir.string, withIntermediateDirectories: true, attributes: nil)
@@ -521,7 +521,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyInRelativeSourcePath() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let content = "relative source"
                 try content.write(toFile: f.testDir.appending("relfile.txt").string, atomically: true, encoding: .utf8)
@@ -534,7 +534,7 @@ struct TestCLICopyCommand {
 
     @Test func testCopyOutRelativeDestinationPath() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let content = "relative dest"
                 try f.doExec(name, cmd: ["sh", "-c", "echo -n '\(content)' > /tmp/relfile.txt"])

--- a/Tests/IntegrationTests/Containers/TestCLICreateCommand.swift
+++ b/Tests/IntegrationTests/Containers/TestCLICreateCommand.swift
@@ -23,7 +23,7 @@ import Testing
 struct TestCLICreateCommand {
     @Test func testCreateArgsPassthrough() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             let name = "\(f.testID)-c"
             try f.doCreate(name: name, image: image, args: ["echo", "-n", "hello", "world"])
             try f.doRemove(name)
@@ -32,7 +32,7 @@ struct TestCLICreateCommand {
 
     @Test func testCreateWithMACAddress() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             let name = "\(f.testID)-c"
             let expectedMAC = try MACAddress("02:42:ac:11:00:03")
 
@@ -52,7 +52,7 @@ struct TestCLICreateCommand {
 
     @Test func testPublishPortParserMaxPorts() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             let name = "\(f.testID)-c"
             var args: [String] = ["create", "--name", name]
             for i in 0..<64 {
@@ -68,7 +68,7 @@ struct TestCLICreateCommand {
 
     @Test func testPublishPortParserTooManyPorts() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             let name = "\(f.testID)-c"
             var args: [String] = ["create", "--name", name]
             for i in 0..<65 {
@@ -84,7 +84,7 @@ struct TestCLICreateCommand {
 
     @Test func testCreateWithFQDNName() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             // Prefix with testID to avoid name collisions; hostname is the first FQDN component.
             let name = "\(f.testID).example.com"
             let expectedHostname = f.testID

--- a/Tests/IntegrationTests/Containers/TestCLIExecCommand.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIExecCommand.swift
@@ -21,7 +21,7 @@ import Testing
 struct TestCLIExecCommand {
     @Test func testCreateExecCommand() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             let name = "\(f.testID)-c"
             try f.doCreate(name: name, image: image)
             f.addCleanup { try? f.doStop(name) }
@@ -36,7 +36,7 @@ struct TestCLIExecCommand {
 
     @Test func testExecDetach() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             let name = "\(f.testID)-c"
             try f.doCreate(name: name, image: image)
             f.addCleanup { try? f.doStop(name) }
@@ -70,7 +70,7 @@ struct TestCLIExecCommand {
 
     @Test func testExecDetachProcessRunning() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             let name = "\(f.testID)-c"
             try f.doCreate(name: name, image: image)
             f.addCleanup { try? f.doStop(name) }
@@ -92,10 +92,10 @@ struct TestCLIExecCommand {
 
     @Test func testExecOnExitingContainer() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             let name = "\(f.testID)-c"
             // sh exits immediately in detached mode with no stdin; container stops on its own.
-            try f.doLongRun(name: name, image: image, containerArgs: ["sh"], autoRemove: false)
+            try await f.doLongRun(name: name, image: image, containerArgs: ["sh"], autoRemove: false)
             f.addCleanup { try? f.doRemove(name) }
             try await Task.sleep(for: .seconds(1))
 

--- a/Tests/IntegrationTests/Containers/TestCLIExportCommand.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIExportCommand.swift
@@ -23,7 +23,7 @@ import Testing
 struct TestCLIExportCommand {
     @Test func testExportCommand() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image, autoRemove: false) { name in
                 let mustBeInImage = "must-be-in-image"
                 try f.doExec(name, cmd: ["sh", "-c", "echo \(mustBeInImage) > /foo"])

--- a/Tests/IntegrationTests/Containers/TestCLIPruneCommandSerial.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIPruneCommandSerial.swift
@@ -15,7 +15,6 @@
 //===----------------------------------------------------------------------===//
 
 import ContainerTestSupport
-import Foundation
 import Testing
 
 /// Serial prune tests — `container prune` affects all stopped containers regardless of name.
@@ -56,16 +55,8 @@ struct TestCLIPruneCommandSerial {
                         try f.doStop(pc1Name)
 
                         // Poll until both containers reach stopped state.
-                        let deadline = Date().addingTimeInterval(30)
-                        while true {
-                            let s0 = try f.getContainerStatus(pc0Name)
-                            let s1 = try f.getContainerStatus(pc1Name)
-                            if s0 == "stopped" && s1 == "stopped" { break }
-                            guard Date() < deadline else {
-                                throw CommandError.executionFailed(
-                                    "Timeout waiting for containers to stop: pc0=\(s0), pc1=\(s1)")
-                            }
-                            try await Task.sleep(for: .milliseconds(200))
+                        try await f.retry(attempts: 150, delay: .milliseconds(200)) {
+                            try f.getContainerStatus(pc0Name) == "stopped" && f.getContainerStatus(pc1Name) == "stopped"
                         }
 
                         let result = try f.run(["prune"]).check()

--- a/Tests/IntegrationTests/Containers/TestCLIRemove.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIRemove.swift
@@ -23,7 +23,7 @@ import Testing
 struct TestCLIRemove {
     @Test func testDeleteStopped() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             let name = "\(f.testID)-c"
             // create without --rm so the container persists after being stopped
             try f.doCreate(name: name, image: image)
@@ -35,7 +35,7 @@ struct TestCLIRemove {
 
     @Test func testDeleteAlias() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             let name = "\(f.testID)-c"
             try f.doCreate(name: name, image: image)
             try f.run(["rm", name]).check("rm alias failed")
@@ -46,7 +46,7 @@ struct TestCLIRemove {
 
     @Test func testDeleteForceRunning() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 try f.doRemove(name, force: true)
                 let result = try f.run(["inspect", name])
@@ -72,7 +72,7 @@ struct TestCLIRemove {
 
     @Test func testDeleteDuplicateIds() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             let name = "\(f.testID)-c"
             try f.doCreate(name: name, image: image)
             f.addCleanup { try f.doRemoveIfExists(name, force: true, ignoreFailure: true) }

--- a/Tests/IntegrationTests/Containers/TestCLIRemoveSerial.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIRemoveSerial.swift
@@ -46,7 +46,7 @@ struct TestCLIRemoveSerial {
             let runningName = "\(f.testID)-running"
             let stoppedName = "\(f.testID)-stopped"
 
-            try f.doLongRun(name: runningName, image: image, autoRemove: false)
+            try await f.doLongRun(name: runningName, image: image, autoRemove: false)
             f.addCleanup {
                 try? f.doStop(runningName)
                 try? f.doRemove(runningName)
@@ -66,7 +66,7 @@ struct TestCLIRemoveSerial {
             let image = WarmupImage.alpine320.rawValue
             if try !f.isImagePresent(image) { try f.doPull(image) }
             let name = "\(f.testID)-c"
-            try f.doLongRun(name: name, image: image, autoRemove: false)
+            try await f.doLongRun(name: name, image: image, autoRemove: false)
             f.addCleanup { try f.doRemoveIfExists(name, force: true, ignoreFailure: true) }
 
             try f.run(["delete", "--all", "--force"]).check()

--- a/Tests/IntegrationTests/Containers/TestCLIRmRaceCondition.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIRmRaceCondition.swift
@@ -61,30 +61,18 @@ struct TestCLIRmRaceCondition {
 
             if raceConditionPrevented { return }
 
-            // Race detected — wait for background cleanup then retry with backoff.
+            // Race detected — wait for background cleanup then retry.
             try await Task.sleep(for: .seconds(2))
 
-            var attempts = 0
-            let maxAttempts = 5
-            while attempts < maxAttempts {
-                guard (try? f.getContainerStatus(name)) != nil else { break }
+            try await f.retry(attempts: 5, delay: .seconds(3)) {
+                guard (try? f.getContainerStatus(name)) != nil else { return true }
                 do {
                     try f.doRemove(name)
-                    break
-                } catch CommandError.nonZeroExit(_, let message) {
-                    if message.contains("not found") { break }
-                    guard attempts < maxAttempts - 1 else {
-                        throw CommandError.executionFailed(
-                            "Failed to remove container after \(maxAttempts) attempts: \(message)")
-                    }
-                    let delay = 1 << attempts
-                    try await Task.sleep(for: .seconds(delay))
-                    attempts += 1
+                    return true
+                } catch CommandError.nonZeroExit(_, let message) where message.contains("not found") {
+                    return true
                 } catch {
-                    guard attempts < maxAttempts - 1 else { throw error }
-                    let delay = 1 << attempts
-                    try await Task.sleep(for: .seconds(delay))
-                    attempts += 1
+                    return false
                 }
             }
         }

--- a/Tests/IntegrationTests/Containers/TestCLIStatsCommand.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIStatsCommand.swift
@@ -23,7 +23,7 @@ import Testing
 struct TestCLIStatsCommand {
     @Test func testStatsNoStreamJSONFormat() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let result = try f.run(["stats", "--format", "json", "--no-stream", name]).check()
                 let stats = try JSONDecoder().decode([ContainerStats].self, from: result.outputData)
@@ -39,7 +39,7 @@ struct TestCLIStatsCommand {
 
     @Test func testStatsIdleCPUPercentage() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image, containerArgs: ["sleep", "3600"]) { name in
                 let result = try f.run(["stats", "--no-stream", name]).check()
                 let lines = result.output.components(separatedBy: .newlines)
@@ -57,7 +57,7 @@ struct TestCLIStatsCommand {
 
     @Test func testStatsHighCPUPercentage() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image, containerArgs: ["sh", "-c", "while true; do :; done"]) { name in
                 let result = try f.run(["stats", "--no-stream", name]).check()
                 let lines = result.output.components(separatedBy: .newlines)
@@ -76,7 +76,7 @@ struct TestCLIStatsCommand {
 
     @Test func testStatsTableFormat() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let result = try f.run(["stats", "--no-stream", name]).check()
                 #expect(result.output.contains("Container ID"), "output should contain table header")
@@ -89,7 +89,7 @@ struct TestCLIStatsCommand {
 
     @Test func testStatsAllContainers() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             // Run two containers simultaneously so both appear in the global stats snapshot.
             try await f.withContainer(image: image, tag: "c1") { name1 in
                 try await f.withContainer(image: image, tag: "c2") { name2 in

--- a/Tests/IntegrationTests/Containers/TestCLIStop.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIStop.swift
@@ -21,7 +21,7 @@ import Testing
 struct TestCLIStop {
     @Test func testStopWithExplicitSignal() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image, autoRemove: false) { name in
                 try f.doStop(name, signal: "SIGTERM")
                 #expect(try f.getContainerStatus(name) == "stopped")
@@ -31,7 +31,7 @@ struct TestCLIStop {
 
     @Test func testStopWithoutSignal() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image, autoRemove: false) { name in
                 try f.doStop(name, signal: nil)
                 #expect(try f.getContainerStatus(name) == "stopped")
@@ -41,7 +41,7 @@ struct TestCLIStop {
 
     @Test func testStopSignalInInspect() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image, autoRemove: false) { name in
                 let inspect = try f.inspectContainer(name)
                 // Alpine doesn't set a STOPSIGNAL, so this should be nil.
@@ -52,7 +52,7 @@ struct TestCLIStop {
 
     @Test func testStopIdempotent() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image, autoRemove: false) { name in
                 try f.doStop(name, signal: "SIGKILL")
                 #expect(try f.getContainerStatus(name) == "stopped")

--- a/Tests/IntegrationTests/Images/TestCLIImagePruneSerial.swift
+++ b/Tests/IntegrationTests/Images/TestCLIImagePruneSerial.swift
@@ -90,8 +90,7 @@ struct TestCLIImagePruneSerial {
             #expect(try f.isImagePresent(busybox), "expected \(busybox) to be pulled")
 
             // Keep alpine in use via a running container.
-            try f.doLongRun(name: containerName, image: alpine, autoRemove: false)
-            try await f.waitForContainerRunning(containerName)
+            try await f.doLongRun(name: containerName, image: alpine, autoRemove: false, waitUntilRunning: true)
 
             let result = try f.run(["image", "prune", "-a"]).check()
             #expect(result.output.contains(busybox), "should prune busybox image")

--- a/Tests/IntegrationTests/Network/TestCLINetwork.swift
+++ b/Tests/IntegrationTests/Network/TestCLINetwork.swift
@@ -42,16 +42,15 @@ struct TestCLINetwork {
             #expect(networkIds == networkIds.sorted(), "network IDs should be sorted")
 
             let port = UInt16.random(in: 50000..<60000)
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: c, image: "docker.io/library/python:alpine",
                 args: ["--network", net],
                 containerArgs: ["python3", "-m", "http.server", "--bind", "0.0.0.0", "\(port)"],
-                autoRemove: false)
+                autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
 
             let container = try f.inspectContainer(c)
             #expect(container.networks.count > 0)
@@ -112,14 +111,13 @@ struct TestCLINetwork {
 
     @Test func testNetworkMTU() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--network", "default,mtu=1500"], autoRemove: false)
+            try await f.doLongRun(name: c, image: image, args: ["--network", "default,mtu=1500"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
             let output = try f.doExec(c, cmd: ["ip", "link", "show", "eth0"])
             #expect(output.contains("mtu 1500"), "expected mtu 1500 in ip link output: \(output)")
         }
@@ -143,12 +141,11 @@ struct TestCLINetwork {
                 try f.doNetworkCreate(net, args: ["--internal"])
 
                 let port = UInt16.random(in: 50000..<60000)
-                try f.doLongRun(
+                try await f.doLongRun(
                     name: server, image: pythonImage,
                     args: ["--network", net],
                     containerArgs: ["python3", "-m", "http.server", "--bind", "0.0.0.0", "\(port)"],
-                    autoRemove: false)
-                try await f.waitForContainerRunning(server)
+                    autoRemove: false, waitUntilRunning: true)
 
                 let container = try f.inspectContainer(server)
                 #expect(container.networks.count > 0)

--- a/Tests/IntegrationTests/Network/TestCLINetworkPruneSerial.swift
+++ b/Tests/IntegrationTests/Network/TestCLINetworkPruneSerial.swift
@@ -71,13 +71,12 @@ struct TestCLINetworkPruneSerial {
             try f.doNetworkCreate(netUnused)
 
             let port = UInt16.random(in: 50000..<60000)
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: containerName,
                 image: "docker.io/library/python:alpine",
                 args: ["--network", netInUse],
                 containerArgs: ["python3", "-m", "http.server", "--bind", "0.0.0.0", "\(port)"],
-                autoRemove: false)
-            try await f.waitForContainerRunning(containerName)
+                autoRemove: false, waitUntilRunning: true)
             let container = try f.inspectContainer(containerName)
             #expect(container.networks.count > 0)
 
@@ -103,13 +102,12 @@ struct TestCLINetworkPruneSerial {
             try f.doNetworkCreate(networkName)
 
             let port = UInt16.random(in: 50000..<60000)
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: containerName,
                 image: "docker.io/library/python:alpine",
                 args: ["--network", networkName],
                 containerArgs: ["python3", "-m", "http.server", "--bind", "0.0.0.0", "\(port)"],
-                autoRemove: false)
-            try await f.waitForContainerRunning(containerName)
+                autoRemove: false, waitUntilRunning: true)
 
             // Network is attached to a running container — prune must skip it.
             try f.run(["network", "prune"]).check()

--- a/Tests/IntegrationTests/Run/TestCLIRunCapabilities.swift
+++ b/Tests/IntegrationTests/Run/TestCLIRunCapabilities.swift
@@ -26,7 +26,7 @@ struct TestCLIRunCapabilities {
 
     @Test func testCapDropInvalid() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let result = try f.run(["run", "--rm", "--cap-drop=CHWOWZERS", image, "ls"])
             #expect(result.status != 0)
             #expect(result.error.contains("CHWOWZERS") || result.error.contains("invalid"))
@@ -35,7 +35,7 @@ struct TestCLIRunCapabilities {
 
     @Test func testCapAddInvalid() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let result = try f.run(["run", "--rm", "--cap-add=CHWOWZERS", image, "ls"])
             #expect(result.status != 0)
             #expect(result.error.contains("CHWOWZERS") || result.error.contains("invalid"))
@@ -46,10 +46,9 @@ struct TestCLIRunCapabilities {
 
     @Test func testCapAddStored() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--cap-add", "NET_ADMIN"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, args: ["--cap-add", "NET_ADMIN"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
@@ -63,10 +62,9 @@ struct TestCLIRunCapabilities {
 
     @Test func testCapDropStored() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--cap-drop", "MKNOD"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, args: ["--cap-drop", "MKNOD"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
@@ -80,13 +78,12 @@ struct TestCLIRunCapabilities {
 
     @Test func testCapAddDropALLStored() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: c, image: image,
                 args: ["--cap-drop", "ALL", "--cap-add", "SETGID", "--cap-add", "NET_RAW"],
-                autoRemove: false)
-            try await f.waitForContainerRunning(c)
+                autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
@@ -101,10 +98,9 @@ struct TestCLIRunCapabilities {
 
     @Test func testCapAddALLStored() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--cap-add", "ALL"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, args: ["--cap-add", "ALL"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
@@ -117,10 +113,9 @@ struct TestCLIRunCapabilities {
 
     @Test func testCapDropLowerCase() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--cap-drop", "mknod"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, args: ["--cap-drop", "mknod"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
@@ -135,10 +130,9 @@ struct TestCLIRunCapabilities {
 
     @Test func testCapDropMknodCannotMknod() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--cap-drop", "MKNOD"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, args: ["--cap-drop", "MKNOD"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
@@ -152,10 +146,9 @@ struct TestCLIRunCapabilities {
 
     @Test func testCapDropMknodLowerCaseCannotMknod() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--cap-drop", "mknod"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, args: ["--cap-drop", "mknod"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
@@ -169,12 +162,11 @@ struct TestCLIRunCapabilities {
 
     @Test func testCapDropALLCannotMknod() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: c, image: image,
-                args: ["--cap-drop", "ALL", "--cap-add", "SETGID"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+                args: ["--cap-drop", "ALL", "--cap-add", "SETGID"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
@@ -188,13 +180,12 @@ struct TestCLIRunCapabilities {
 
     @Test func testCapDropALLAddMknodCanMknod() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: c, image: image,
                 args: ["--cap-drop", "ALL", "--cap-add", "MKNOD", "--cap-add", "SETGID"],
-                autoRemove: false)
-            try await f.waitForContainerRunning(c)
+                autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
@@ -207,10 +198,9 @@ struct TestCLIRunCapabilities {
 
     @Test func testCapAddALLCanDownInterface() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--cap-add", "ALL"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, args: ["--cap-add", "ALL"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
@@ -223,12 +213,11 @@ struct TestCLIRunCapabilities {
 
     @Test func testCapAddALLDropNetAdminCannotDownInterface() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: c, image: image,
-                args: ["--cap-add", "ALL", "--cap-drop", "NET_ADMIN"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+                args: ["--cap-add", "ALL", "--cap-drop", "NET_ADMIN"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
@@ -242,10 +231,9 @@ struct TestCLIRunCapabilities {
 
     @Test func testCapAddNetAdminCanDownInterface() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--cap-add", "NET_ADMIN"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, args: ["--cap-add", "NET_ADMIN"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
@@ -260,10 +248,9 @@ struct TestCLIRunCapabilities {
 
     @Test func testDefaultCapChown() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
@@ -275,10 +262,9 @@ struct TestCLIRunCapabilities {
 
     @Test func testNonRootUserCannotReadShadow() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
@@ -292,10 +278,9 @@ struct TestCLIRunCapabilities {
 
     @Test func testCapDropChown() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--cap-drop", "chown"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, args: ["--cap-drop", "chown"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
@@ -308,10 +293,9 @@ struct TestCLIRunCapabilities {
 
     @Test func testDefaultCapFowner() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
@@ -325,13 +309,12 @@ struct TestCLIRunCapabilities {
 
     @Test func testCapDropALLShowsZeroCaps() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: c, image: image,
                 args: ["--cap-drop", "ALL", "--cap-add", "SETUID", "--cap-add", "SETGID"],
-                autoRemove: false)
-            try await f.waitForContainerRunning(c)
+                autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
@@ -348,10 +331,9 @@ struct TestCLIRunCapabilities {
 
     @Test func testNoCapFlagsUsesDefaultCaps() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
@@ -367,10 +349,9 @@ struct TestCLIRunCapabilities {
 
     @Test func testCapAddALLShowsFullCaps() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--cap-add", "ALL"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, args: ["--cap-add", "ALL"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
@@ -386,10 +367,9 @@ struct TestCLIRunCapabilities {
 
     @Test func testCapDropALLOnlyShowsZeroEffective() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--cap-drop", "ALL"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, args: ["--cap-drop", "ALL"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
@@ -405,16 +385,15 @@ struct TestCLIRunCapabilities {
 
     @Test func testMultipleCapAddDrop() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: c, image: image,
                 args: [
                     "--cap-add", "SYS_ADMIN", "--cap-add", "NET_RAW",
                     "--cap-drop", "MKNOD", "--cap-drop", "CHOWN",
                 ],
-                autoRemove: false)
-            try await f.waitForContainerRunning(c)
+                autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)

--- a/Tests/IntegrationTests/Run/TestCLIRunCommand.swift
+++ b/Tests/IntegrationTests/Run/TestCLIRunCommand.swift
@@ -29,28 +29,26 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommand() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, autoRemove: false)
+            try await f.doLongRun(name: c, image: image, autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
             _ = try f.doExec(c, cmd: ["date"])
         }
     }
 
     @Test func testRunCommandCWD() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--cwd", "/tmp"], autoRemove: false)
+            try await f.doLongRun(name: c, image: image, args: ["--cwd", "/tmp"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
             let output = try f.doExec(c, cmd: ["pwd"]).trimmingCharacters(in: .whitespacesAndNewlines)
             #expect(output == "/tmp")
         }
@@ -58,14 +56,13 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandEnv() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--env", "FOO=bar"], autoRemove: false)
+            try await f.doLongRun(name: c, image: image, args: ["--env", "FOO=bar"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
             let inspect = try f.inspectContainer(c)
             #expect(inspect.configuration.initProcess.environment.contains("FOO=bar"))
         }
@@ -73,18 +70,17 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandEnvFile() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
             let envFile = f.testDir.appending("test.env")
             let content = "# comment\nFOO=bar\nBAR=baz wow\nURL=https://foo.bar?baz=wow\n"
             try content.write(toFile: envFile.string, atomically: true, encoding: .utf8)
 
-            try f.doLongRun(name: c, image: image, args: ["--env-file", envFile.string], autoRemove: false)
+            try await f.doLongRun(name: c, image: image, args: ["--env-file", envFile.string], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
 
             let inspect = try f.inspectContainer(c)
             for expected in ["FOO=bar", "BAR=baz wow", "URL=https://foo.bar?baz=wow"] {
@@ -95,14 +91,13 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandUserIDGroupID() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--uid", "10", "--gid", "100"], autoRemove: false)
+            try await f.doLongRun(name: c, image: image, args: ["--uid", "10", "--gid", "100"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
             let output = try f.doExec(c, cmd: ["id"]).trimmingCharacters(in: .whitespacesAndNewlines)
             try #expect(output.contains(Regex("uid=10.*?gid=100.*")))
         }
@@ -110,14 +105,13 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandUser() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--user", "nobody"], autoRemove: false)
+            try await f.doLongRun(name: c, image: image, args: ["--user", "nobody"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
             let output = try f.doExec(c, cmd: ["whoami"]).trimmingCharacters(in: .whitespacesAndNewlines)
             #expect(output == "nobody")
         }
@@ -125,14 +119,13 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandCPUs() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--cpus", "2"], autoRemove: false)
+            try await f.doLongRun(name: c, image: image, args: ["--cpus", "2"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
             let output = try f.doExec(c, cmd: ["cat", "/sys/fs/cgroup/cpu.max"])
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             let fields = output.components(separatedBy: .whitespaces)
@@ -146,14 +139,13 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandMemory() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--memory", "1024M"], autoRemove: false)
+            try await f.doLongRun(name: c, image: image, args: ["--memory", "1024M"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
             let inspect = try f.inspectContainer(c)
             let expectedBytes = UInt64(1024) * 1024 * 1024
             #expect(inspect.configuration.resources.memoryInBytes == expectedBytes)
@@ -162,14 +154,13 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandUlimitNofile() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--ulimit", "nofile=1024:2048"], autoRemove: false)
+            try await f.doLongRun(name: c, image: image, args: ["--ulimit", "nofile=1024:2048"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
 
             let inspect = try f.inspectContainer(c)
             let nofile = inspect.configuration.initProcess.rlimits.first { $0.limit == "RLIMIT_NOFILE" }
@@ -185,14 +176,13 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandUlimitNproc() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--ulimit", "nproc=256"], autoRemove: false)
+            try await f.doLongRun(name: c, image: image, args: ["--ulimit", "nproc=256"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
 
             let inspect = try f.inspectContainer(c)
             let nproc = inspect.configuration.initProcess.rlimits.first { $0.limit == "RLIMIT_NPROC" }
@@ -208,17 +198,16 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandMultipleUlimits() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: c, image: image,
                 args: ["--ulimit", "nofile=1024:2048", "--ulimit", "nproc=512", "--ulimit", "stack=8388608"],
-                autoRemove: false)
+                autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
 
             let rlimits = try f.inspectContainer(c).configuration.initProcess.rlimits
             #expect(rlimits.count == 3)
@@ -235,21 +224,20 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandMount() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
             let testData = "hello world"
             let hostFile = f.testDir.appending("testfile.txt")
             try testData.write(toFile: hostFile.string, atomically: true, encoding: .utf8)
 
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: c, image: image,
                 args: ["--mount", "type=virtiofs,source=\(f.testDir.string),target=/tmp/testmount,readonly"],
-                autoRemove: false)
+                autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
 
             let output = try f.doExec(c, cmd: ["cat", "/tmp/testmount/testfile.txt"])
                 .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -259,14 +247,9 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandUnixSocketMount() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            // sockaddr_un.sun_path is 104 bytes on macOS — use /tmp to keep
-            // the host socket path short regardless of project directory depth.
-            let socketDir = "/tmp/\(f.testID)-sock"
-            try FileManager.default.createDirectory(
-                atPath: socketDir, withIntermediateDirectories: true, attributes: nil)
-            f.addCleanup { try? FileManager.default.removeItem(atPath: socketDir) }
+            let socketDir = try f.makeShortSocketDir("sock")
             let socketPath = socketDir + "/ssh-auth.sock"
             let guestSocketPath = "/run/ssh-auth.sock"
 
@@ -275,15 +258,14 @@ struct TestCLIRunCommand {
             try socket.listen()
             f.addCleanup { try? socket.close() }
 
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: c, image: image,
                 args: ["-v", "\(socketPath):\(guestSocketPath)", "-e", "SSH_AUTH_SOCK=\(guestSocketPath)"],
-                autoRemove: false)
+                autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
 
             _ = try f.doExec(c, cmd: ["apk", "add", "netcat-openbsd"])
             let perms = try f.doExec(
@@ -297,14 +279,13 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandTmpfs() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--tmpfs", "/tmp/testtmpfs"], autoRemove: false)
+            try await f.doLongRun(name: c, image: image, args: ["--tmpfs", "/tmp/testtmpfs"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
 
             let output = try f.doExec(c, cmd: ["df", "/tmp/testtmpfs"])
             let lines = output.split(separator: "\n")
@@ -316,14 +297,13 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandShmSize() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--shm-size", "128m"], autoRemove: false)
+            try await f.doLongRun(name: c, image: image, args: ["--shm-size", "128m"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
 
             let output = try f.doExec(c, cmd: ["mount"])
             let shmLine = output.split(separator: "\n").first { $0.contains("/dev/shm") }
@@ -334,20 +314,19 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandVolume() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
             let testData = "one small step"
             let volumeFile = f.testDir.appending("data.txt")
             try testData.write(toFile: volumeFile.string, atomically: true, encoding: .utf8)
 
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: c, image: image,
-                args: ["--volume", "\(f.testDir.string):/tmp/testvolume"], autoRemove: false)
+                args: ["--volume", "\(f.testDir.string):/tmp/testvolume"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
 
             let output = try f.doExec(c, cmd: ["cat", "/tmp/testvolume/data.txt"])
                 .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -357,16 +336,15 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandCidfile() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
             let cidfile = f.testDir.appending("container.cid")
 
-            try f.doLongRun(name: c, image: image, args: ["--cidfile", cidfile.string], autoRemove: false)
+            try await f.doLongRun(name: c, image: image, args: ["--cidfile", cidfile.string], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
 
             let actualID = try String(contentsOfFile: cidfile.string, encoding: .utf8)
             #expect(actualID == c)
@@ -377,14 +355,13 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandNoDNS() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--no-dns"], autoRemove: false)
+            try await f.doLongRun(name: c, image: image, args: ["--no-dns"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
             let result = try f.run(["exec", c, "cat", "/etc/resolv.conf"])
             #expect(result.status != 0)
         }
@@ -392,14 +369,13 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandDefaultResolvConf() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, autoRemove: false)
+            try await f.doLongRun(name: c, image: image, autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
 
             let output = try f.doExec(c, cmd: ["cat", "/etc/resolv.conf"])
             let actualLines = output.components(separatedBy: .newlines)
@@ -421,20 +397,19 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandNonDefaultResolvConf() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: c, image: image,
                 args: [
                     "--dns", "8.8.8.8", "--dns-domain", "example.com",
                     "--dns-search", "test.com", "--dns-option", "debug",
                 ],
-                autoRemove: false)
+                autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
 
             let output = try f.doExec(c, cmd: ["cat", "/etc/resolv.conf"])
             let actualLines = output.components(separatedBy: .newlines)
@@ -453,14 +428,13 @@ struct TestCLIRunCommand {
 
     @Test func testRunDefaultHostsEntries() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, autoRemove: false)
+            try await f.doLongRun(name: c, image: image, autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
 
             let inspect = try f.inspectContainer(c)
             let ip = inspect.networks[0].ipv4Address.address.description
@@ -481,7 +455,7 @@ struct TestCLIRunCommand {
     @Test func testPrivilegedPortError() async throws {
         try #require(geteuid() != 0)
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
             f.addCleanup { try? f.doRemove(c, force: true) }
             let result = try f.run(["run", "--name", c, "--publish", "127.0.0.1:80:80", image])
@@ -495,14 +469,13 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandOSArch() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--os", "linux", "--arch", "amd64"], autoRemove: false)
+            try await f.doLongRun(name: c, image: image, args: ["--os", "linux", "--arch", "amd64"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
             let output = try f.doExec(c, cmd: ["uname", "-sm"])
                 .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
             #expect(output == "linux x86_64")
@@ -511,14 +484,13 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandPlatform() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--platform", "linux/amd64"], autoRemove: false)
+            try await f.doLongRun(name: c, image: image, args: ["--platform", "linux/amd64"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
             let output = try f.doExec(c, cmd: ["uname", "-sm"])
                 .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
             #expect(output == "linux x86_64")
@@ -529,14 +501,13 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandInit() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--init"], autoRemove: false)
+            try await f.doLongRun(name: c, image: image, args: ["--init"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
 
             let inspect = try f.inspectContainer(c)
             #expect(inspect.configuration.useInit == true)
@@ -549,14 +520,13 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandInitReapsZombies() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--init"], autoRemove: false)
+            try await f.doLongRun(name: c, image: image, args: ["--init"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
 
             _ = try f.doExec(c, cmd: ["sh", "-c", "sh -c 'sh -c \"exit 0\" &' && sleep 1"])
             let ps = try f.doExec(c, cmd: ["sh", "-c", "ps aux | grep -c '\\[sh\\]' || true"])
@@ -567,14 +537,13 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandWithoutInitDefault() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, autoRemove: false)
+            try await f.doLongRun(name: c, image: image, autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
             let inspect = try f.inspectContainer(c)
             #expect(inspect.configuration.useInit == false)
         }
@@ -584,14 +553,13 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandReadOnly() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["--read-only"], autoRemove: false)
+            try await f.doLongRun(name: c, image: image, args: ["--read-only"], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
-            try await f.waitForContainerRunning(c)
             let result = try f.run(["exec", c, "touch", "/testfile"])
             #expect(result.status != 0, "touch on read-only rootfs should fail")
         }
@@ -601,7 +569,7 @@ struct TestCLIRunCommand {
 
     @Test func testRunCommandEnvFileFromNamedPipe() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
             let pipePath = f.testDir.appending("envfile.pipe")
             guard mkfifo(pipePath.string, 0o600) == 0 else {
@@ -618,14 +586,13 @@ struct TestCLIRunCommand {
             }
             defer { writeTask.cancel() }
 
-            try f.doLongRun(name: c, image: image, args: ["--env-file", pipePath.string], autoRemove: false)
+            try await f.doLongRun(name: c, image: image, args: ["--env-file", pipePath.string], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)
             }
             try await writeTask.value
 
-            try await f.waitForContainerRunning(c)
             let inspect = try f.inspectContainer(c)
             #expect(inspect.configuration.initProcess.environment.contains("FOO=bar"))
             #expect(inspect.configuration.initProcess.environment.contains("BAR=baz"))
@@ -639,7 +606,7 @@ struct TestCLIRunCommand {
             let c = "\(f.testID)-c"
             let proxyPort = UInt16.random(in: 50000..<55000)
             let serverPort = UInt16.random(in: 55000..<60000)
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: c, image: "docker.io/library/python:alpine",
                 args: ["--publish", "127.0.0.1:\(proxyPort):\(serverPort)/tcp"],
                 containerArgs: ["python3", "-m", "http.server", "--bind", "0.0.0.0", "\(serverPort)"],
@@ -651,16 +618,7 @@ struct TestCLIRunCommand {
 
             let client = f.makeHTTPClient()
             defer { _ = client.shutdown() }
-            try await f.retry(attempts: 10, delay: .seconds(3)) {
-                do {
-                    var req = HTTPClientRequest(url: "http://127.0.0.1:\(proxyPort)")
-                    req.method = .GET
-                    let resp = try await client.execute(req, timeout: .seconds(3))
-                    return resp.status.code >= 200 && resp.status.code < 300
-                } catch {
-                    return false
-                }
-            }
+            try await f.waitForHTTPOk("http://127.0.0.1:\(proxyPort)", using: client, delay: .seconds(3))
         }
     }
 
@@ -670,7 +628,7 @@ struct TestCLIRunCommand {
             let proxyPortStart = UInt16.random(in: 50000..<55000)
             let serverPortStart = UInt16.random(in: 55000..<60000)
             let c = "\(f.testID)-c"
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: c, image: "docker.io/library/python:alpine",
                 args: ["--publish", "127.0.0.1:\(proxyPortStart)-\(proxyPortStart + range):\(serverPortStart)-\(serverPortStart + range)/tcp"],
                 containerArgs: ["python3", "-m", "http.server", "--bind", "0.0.0.0", "\(serverPortStart)"],
@@ -682,16 +640,7 @@ struct TestCLIRunCommand {
 
             let client2 = f.makeHTTPClient()
             defer { _ = client2.shutdown() }
-            try await f.retry(attempts: 10, delay: .seconds(3)) {
-                do {
-                    var req = HTTPClientRequest(url: "http://127.0.0.1:\(proxyPortStart)")
-                    req.method = .GET
-                    let resp = try await client2.execute(req, timeout: .seconds(3))
-                    return resp.status.code >= 200 && resp.status.code < 300
-                } catch {
-                    return false
-                }
-            }
+            try await f.waitForHTTPOk("http://127.0.0.1:\(proxyPortStart)", using: client2, delay: .seconds(3))
         }
     }
 
@@ -701,7 +650,7 @@ struct TestCLIRunCommand {
             let c = "\(f.testID)-c"
             let proxyPort = UInt16.random(in: 50000..<55000)
             let serverPort = UInt16.random(in: 55000..<60000)
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: c, image: "docker.io/library/node:alpine",
                 args: ["--publish", "[::1]:\(proxyPort):\(serverPort)/tcp"],
                 containerArgs: ["npx", "http-server", "-a", "::", "-p", "\(serverPort)"],
@@ -713,16 +662,7 @@ struct TestCLIRunCommand {
 
             let client3 = f.makeHTTPClient()
             defer { _ = client3.shutdown() }
-            try await f.retry(attempts: 10, delay: .seconds(3)) {
-                do {
-                    var req = HTTPClientRequest(url: "http://[::1]:\(proxyPort)")
-                    req.method = .GET
-                    let resp = try await client3.execute(req, timeout: .seconds(3))
-                    return resp.status.code >= 200 && resp.status.code < 300
-                } catch {
-                    return false
-                }
-            }
+            try await f.waitForHTTPOk("http://[::1]:\(proxyPort)", using: client3, delay: .seconds(3))
         }
     }
 }

--- a/Tests/IntegrationTests/Run/TestCLIRunFilesystem.swift
+++ b/Tests/IntegrationTests/Run/TestCLIRunFilesystem.swift
@@ -41,10 +41,9 @@ struct TestCLIRunFilesystem {
 
     @Test func testRootFilesystemHasOrderedJournal() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)

--- a/Tests/IntegrationTests/Run/TestCLIRunInitImage.swift
+++ b/Tests/IntegrationTests/Run/TestCLIRunInitImage.swift
@@ -30,7 +30,7 @@ struct TestCLIRunInitImage {
 
     @Test func testRunWithNonExistentInitImage() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
             f.addCleanup { try? f.doRemove(c, force: true) }
             let result = try f.run([
@@ -52,7 +52,7 @@ struct TestCLIRunInitImage {
 
     @Test func testCreateWithNonExistentInitImage() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
             f.addCleanup { try? f.doRemove(c, force: true) }
             let result = try f.run([
@@ -66,13 +66,12 @@ struct TestCLIRunInitImage {
 
     @Test func testRunWithExplicitDefaultInitImage() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
             let config = try f.getSystemConfig()
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: c, image: image,
-                args: ["--init-image", config.vminit.image], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+                args: ["--init-image", config.vminit.image], autoRemove: false, waitUntilRunning: true)
             f.addCleanup {
                 try? f.doStop(c)
                 try? f.doRemove(c)

--- a/Tests/IntegrationTests/Run/TestCLIRunLifecycle.swift
+++ b/Tests/IntegrationTests/Run/TestCLIRunLifecycle.swift
@@ -23,7 +23,7 @@ import Testing
 struct TestCLIRunLifecycle {
     @Test func testRunFailureCleanup() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             let name = "\(f.testID)-c"
 
             // First attempt with an invalid user — must fail.
@@ -43,7 +43,7 @@ struct TestCLIRunLifecycle {
 
     @Test func testStartIdempotent() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let result = try f.run(["start", name])
                 #expect(result.status == 0, "expected start to succeed on already running container")
@@ -57,7 +57,7 @@ struct TestCLIRunLifecycle {
 
     @Test func testStartIdempotentAttachFails() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let result = try f.run(["start", "-a", name])
                 #expect(
@@ -70,7 +70,7 @@ struct TestCLIRunLifecycle {
 
     @Test func testRunInvalidExecutable() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             let name = "\(f.testID)-c"
             f.addCleanup { try f.doRemoveIfExists(name, force: true, ignoreFailure: true) }
             let result = try f.run(["run", "--rm", "--name", name, "-d", image, "foobarbaz"])
@@ -80,7 +80,7 @@ struct TestCLIRunLifecycle {
 
     @Test func testExecInvalidExecutable() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let result = try f.run(["exec", name, "foobarbaz"])
                 #expect(result.status != 0, "executing invalid executable must fail, not hang")
@@ -90,7 +90,7 @@ struct TestCLIRunLifecycle {
 
     @Test func testSSHForwarding() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
 
             let socketPath = try f.makeFakeSSHAgentSocket()
 

--- a/Tests/IntegrationTests/Run/TestCLIRunLifecycleSerial.swift
+++ b/Tests/IntegrationTests/Run/TestCLIRunLifecycleSerial.swift
@@ -32,7 +32,7 @@ struct TestCLIRunLifecycleSerial {
             f.addCleanup { try? f.doRemove(name) }
 
             let server = "\(f.testID)-server"
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: server,
                 image: serverImage,
                 args: ["--publish", "\(port):\(port)"],

--- a/Tests/IntegrationTests/Run/TestCLITermIO.swift
+++ b/Tests/IntegrationTests/Run/TestCLITermIO.swift
@@ -23,7 +23,7 @@ import Testing
 struct TestCLITermIO {
     @Test func testTermIODoesNotPanic() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(.alpine320)
+            let image = WarmupImage.alpine320.rawValue
             let name = "\(f.testID)-c"
             f.addCleanup { try f.doRemoveIfExists(name, force: true, ignoreFailure: true) }
 

--- a/Tests/IntegrationTests/Volumes/TestCLIAnonymousVolumes.swift
+++ b/Tests/IntegrationTests/Volumes/TestCLIAnonymousVolumes.swift
@@ -29,10 +29,9 @@ struct TestCLIAnonymousVolumes {
 
     @Test func testAnonymousVolumeCreationAndPersistence() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["-v", "/data"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, args: ["-v", "/data"], autoRemove: false, waitUntilRunning: true)
 
             let volumeIDs = try f.getContainerMountedVolumeNames(c)
             try #require(volumeIDs.count == 1, "should have exactly one anonymous volume")
@@ -47,10 +46,9 @@ struct TestCLIAnonymousVolumes {
 
     @Test func testAnonymousVolumePersistenceWithoutRm() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c1"
-            try f.doLongRun(name: c, image: image, args: ["-v", "/data"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, args: ["-v", "/data"], autoRemove: false, waitUntilRunning: true)
             _ = try f.doExec(c, cmd: ["sh", "-c", "echo 'persistent-data' > /data/test.txt"])
 
             let volumeIDs = try f.getContainerMountedVolumeNames(c)
@@ -63,8 +61,7 @@ struct TestCLIAnonymousVolumes {
             #expect(try f.volumeExists(volumeID), "anonymous volume should persist without --rm")
 
             let c2 = "\(f.testID)-c2"
-            try f.doLongRun(name: c2, image: image, args: ["-v", "\(volumeID):/data"], autoRemove: false)
-            try await f.waitForContainerRunning(c2)
+            try await f.doLongRun(name: c2, image: image, args: ["-v", "\(volumeID):/data"], autoRemove: false, waitUntilRunning: true)
             let output = try f.doExec(c2, cmd: ["cat", "/data/test.txt"])
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             #expect(output == "persistent-data")
@@ -75,12 +72,11 @@ struct TestCLIAnonymousVolumes {
 
     @Test func testMultipleAnonymousVolumes() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: c, image: image,
-                args: ["-v", "/data1", "-v", "/data2", "-v", "/data3"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+                args: ["-v", "/data1", "-v", "/data2", "-v", "/data3"], autoRemove: false, waitUntilRunning: true)
 
             let volumeIDs = try f.getContainerMountedVolumeNames(c)
             #expect(volumeIDs.count == 3, "should have 3 anonymous volumes")
@@ -94,12 +90,11 @@ struct TestCLIAnonymousVolumes {
 
     @Test func testAnonymousMountSyntax() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: c, image: image,
-                args: ["--mount", "type=volume,dst=/mydata"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+                args: ["--mount", "type=volume,dst=/mydata"], autoRemove: false, waitUntilRunning: true)
 
             let volumeIDs = try f.getContainerMountedVolumeNames(c)
             #expect(volumeIDs.count == 1, "should have one anonymous volume from --mount syntax")
@@ -112,10 +107,9 @@ struct TestCLIAnonymousVolumes {
 
     @Test func testAnonymousVolumeUUIDFormat() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["-v", "/data"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, args: ["-v", "/data"], autoRemove: false, waitUntilRunning: true)
 
             // Capture volume IDs before any stop/remove so cleanup and assert can use them.
             let volumeIDs = try f.getContainerMountedVolumeNames(c)
@@ -133,10 +127,9 @@ struct TestCLIAnonymousVolumes {
 
     @Test func testAnonymousVolumeMetadata() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["-v", "/data"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, args: ["-v", "/data"], autoRemove: false, waitUntilRunning: true)
 
             // Capture volume ID before stop/remove.
             let volumeIDs = try f.getContainerMountedVolumeNames(c)
@@ -163,14 +156,13 @@ struct TestCLIAnonymousVolumes {
 
     @Test func testAnonymousVolumeListDisplay() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let namedVol = "\(f.testID)-namedvol"
             let c = "\(f.testID)-c"
             try f.doVolumeCreate(namedVol)
             f.addCleanup { f.doVolumeDeleteIfExists(namedVol) }
 
-            try f.doLongRun(name: c, image: image, args: ["-v", "/data"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, args: ["-v", "/data"], autoRemove: false, waitUntilRunning: true)
 
             // Capture volume IDs while container is running.
             let volumeIDs = try f.getContainerMountedVolumeNames(c)
@@ -190,16 +182,15 @@ struct TestCLIAnonymousVolumes {
 
     @Test func testAnonymousVolumeMixedWithNamedVolume() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let namedVol = "\(f.testID)-namedvol"
             let c = "\(f.testID)-c"
             try f.doVolumeCreate(namedVol)
             f.addCleanup { f.doVolumeDeleteIfExists(namedVol) }
 
-            try f.doLongRun(
+            try await f.doLongRun(
                 name: c, image: image,
-                args: ["-v", "\(namedVol):/named", "-v", "/anon"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+                args: ["-v", "\(namedVol):/named", "-v", "/anon"], autoRemove: false, waitUntilRunning: true)
 
             let allVolumeIDs = try f.getContainerMountedVolumeNames(c)
             let anonVols = allVolumeIDs.filter { $0 != namedVol }
@@ -215,10 +206,9 @@ struct TestCLIAnonymousVolumes {
 
     @Test func testAnonymousVolumeManualDeletion() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["-v", "/data"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, args: ["-v", "/data"], autoRemove: false, waitUntilRunning: true)
 
             let volumeIDs = try f.getContainerMountedVolumeNames(c)
             try #require(volumeIDs.count == 1)
@@ -234,10 +224,9 @@ struct TestCLIAnonymousVolumes {
 
     @Test func testAnonymousVolumeDetachedMode() async throws {
         try await ContainerFixture.with { f in
-            let image = try f.copyWarmupImage(alpine)
+            let image = alpine.rawValue
             let c = "\(f.testID)-c"
-            try f.doLongRun(name: c, image: image, args: ["-v", "/data"], autoRemove: true)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, args: ["-v", "/data"], autoRemove: true, waitUntilRunning: true)
 
             // Capture volume IDs while the container is still running; --rm means
             // doStop will also remove it.

--- a/Tests/IntegrationTests/Volumes/TestCLIVolumes.swift
+++ b/Tests/IntegrationTests/Volumes/TestCLIVolumes.swift
@@ -35,13 +35,11 @@ struct TestCLIVolumes {
             }
 
             try f.doVolumeCreate(vol)
-            try f.doLongRun(name: c1, image: image, args: ["-v", "\(vol):/data"], autoRemove: false)
-            try await f.waitForContainerRunning(c1)
+            try await f.doLongRun(name: c1, image: image, args: ["-v", "\(vol):/data"], autoRemove: false, waitUntilRunning: true)
             _ = try f.doExec(c1, cmd: ["sh", "-c", "echo 'persistent-data-test' > /data/test.txt"])
             try f.doStop(c1)
             try f.doRemove(c1)
-            try f.doLongRun(name: c2, image: image, args: ["-v", "\(vol):/data"], autoRemove: false)
-            try await f.waitForContainerRunning(c2)
+            try await f.doLongRun(name: c2, image: image, args: ["-v", "\(vol):/data"], autoRemove: false, waitUntilRunning: true)
             let output = try f.doExec(c2, cmd: ["cat", "/data/test.txt"])
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             #expect(output == "persistent-data-test")
@@ -65,8 +63,7 @@ struct TestCLIVolumes {
             }
 
             try f.doVolumeCreate(vol)
-            try f.doLongRun(name: c1, image: image, args: ["-v", "\(vol):/data"], autoRemove: false)
-            try await f.waitForContainerRunning(c1)
+            try await f.doLongRun(name: c1, image: image, args: ["-v", "\(vol):/data"], autoRemove: false, waitUntilRunning: true)
 
             let result = try f.run(["run", "--name", c2, "-v", "\(vol):/data", image, "sleep", "infinity"])
             #expect(result.status != 0, "second container should fail when volume is already in use")
@@ -89,8 +86,7 @@ struct TestCLIVolumes {
             }
 
             try f.doVolumeCreate(vol)
-            try f.doLongRun(name: c, image: image, args: ["-v", "\(vol):/data"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, args: ["-v", "\(vol):/data"], autoRemove: false, waitUntilRunning: true)
 
             #expect(try f.doesVolumeDeleteFail(vol), "volume delete should fail while in use")
 
@@ -245,13 +241,11 @@ struct TestCLIVolumes {
             }
 
             try f.doVolumeCreate(vol, opts: ["journal=ordered"])
-            try f.doLongRun(name: c1, image: image, args: ["-v", "\(vol):/data"], autoRemove: false)
-            try await f.waitForContainerRunning(c1)
+            try await f.doLongRun(name: c1, image: image, args: ["-v", "\(vol):/data"], autoRemove: false, waitUntilRunning: true)
             _ = try f.doExec(c1, cmd: ["sh", "-c", "echo 'journaled-data' > /data/test.txt"])
             try f.doStop(c1)
             try f.doRemove(c1)
-            try f.doLongRun(name: c2, image: image, args: ["-v", "\(vol):/data"], autoRemove: false)
-            try await f.waitForContainerRunning(c2)
+            try await f.doLongRun(name: c2, image: image, args: ["-v", "\(vol):/data"], autoRemove: false, waitUntilRunning: true)
             let output = try f.doExec(c2, cmd: ["cat", "/data/test.txt"])
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             #expect(output == "journaled-data")

--- a/Tests/IntegrationTests/Volumes/TestCLIVolumesSerial.swift
+++ b/Tests/IntegrationTests/Volumes/TestCLIVolumesSerial.swift
@@ -69,8 +69,7 @@ struct TestCLIVolumesSerial {
 
             try f.doVolumeCreate(vInUse)
             try f.doVolumeCreate(vUnused)
-            try f.doLongRun(name: c, image: image, args: ["-v", "\(vInUse):/data"], autoRemove: false)
-            try await f.waitForContainerRunning(c)
+            try await f.doLongRun(name: c, image: image, args: ["-v", "\(vInUse):/data"], autoRemove: false, waitUntilRunning: true)
 
             try f.run(["volume", "prune"]).check()
 


### PR DESCRIPTION
- Closes #1992.
- Coalesce redundant fixture functions
- Extract fixture function for creating valid length socket paths
- Move waitForRunning into doLongRun to eliminate boilerplate
- Remove unnecessary image retags