### PR TITLE
Add missing dependencies to new ContainerTestSupport package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -574,12 +574,18 @@ let package = Package(
             name: "ContainerTestSupport",
             dependencies: [
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
+                .product(name: "Containerization", package: "containerization"),
+                .product(name: "ContainerizationArchive", package: "containerization"),
                 .product(name: "ContainerizationExtras", package: "containerization"),
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOHTTP1", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "SystemPackage", package: "swift-system"),
                 .product(name: "TOML", package: "swift-toml"),
                 "ContainerLog",
                 "ContainerPersistence",
+                "ContainerPlugin",
                 "ContainerResource",
             ]
         ),


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context
Add missing dependencies to new ContainerTestSupport package. Without this change, other projects are not able to import the ContainerTestSupport package without an error. 

## Testing
- [x] Tested locally
