### PR TITLE
Fix logs -n N truncating the oldest line at the read-chunk boundary

### DIFF
--- a/Sources/ContainerCommands/Container/ContainerLogs.swift
+++ b/Sources/ContainerCommands/Container/ContainerLogs.swift
@@ -63,27 +63,7 @@ extension Application {
             follow: Bool
         ) async throws {
             if let n {
-                var buffer = Data()
-                let size = try fh.seekToEnd()
-                var offset = size
-                var lines: [String] = []
-
-                while offset > 0, lines.count < n {
-                    let readSize = min(1024, offset)
-                    offset -= readSize
-                    try fh.seek(toOffset: offset)
-
-                    let data = fh.readData(ofLength: Int(readSize))
-                    buffer.insert(contentsOf: data, at: 0)
-
-                    if let chunk = String(data: buffer, encoding: .utf8) {
-                        lines = chunk.components(separatedBy: .newlines)
-                        lines = lines.filter { !$0.isEmpty }
-                    }
-                }
-
-                lines = Array(lines.suffix(n))
-                for line in lines {
+                for line in try Self.lastLines(fh: fh, n: n) {
                     print(line)
                 }
             } else {
@@ -107,6 +87,36 @@ extension Application {
                 setbuf(stdout, nil)
                 try await Self.followFile(fh: fh)
             }
+        }
+
+        /// Returns the last `n` non-empty lines of the file, reading backward in
+        /// 1024-byte chunks.
+        ///
+        /// While `offset > 0` the buffer starts in the middle of a line, so its
+        /// first line is a fragment truncated at the chunk boundary. Keep reading
+        /// until there are *more* than `n` lines (so the first of the `n` kept
+        /// lines is complete) or the start of the file is reached. Stopping at
+        /// `>= n` instead would keep a truncated leading line whenever the last
+        /// `n` lines span more than one chunk.
+        static func lastLines(fh: FileHandle, n: Int) throws -> [String] {
+            var buffer = Data()
+            var offset = try fh.seekToEnd()
+            var lines: [String] = []
+
+            while offset > 0, lines.count <= n {
+                let readSize = min(1024, offset)
+                offset -= readSize
+                try fh.seek(toOffset: offset)
+
+                let data = fh.readData(ofLength: Int(readSize))
+                buffer.insert(contentsOf: data, at: 0)
+
+                if let chunk = String(data: buffer, encoding: .utf8) {
+                    lines = chunk.components(separatedBy: .newlines).filter { !$0.isEmpty }
+                }
+            }
+
+            return Array(lines.suffix(n))
         }
 
         private static func followFile(fh: FileHandle) async throws {

--- a/Tests/ContainerCommandsTests/ContainerLogsTests.swift
+++ b/Tests/ContainerCommandsTests/ContainerLogsTests.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import ContainerCommands
+
+struct ContainerLogsTests {
+    /// Writes `contents` to a temp file and runs `lastLines` against it.
+    private func lastLines(of contents: String, n: Int) throws -> [String] {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("logs-\(UUID().uuidString).log")
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let fh = try FileHandle(forReadingFrom: url)
+        defer { try? fh.close() }
+        return try Application.ContainerLogs.lastLines(fh: fh, n: n)
+    }
+
+    @Test("returns the complete oldest line when it exceeds the 1024-byte chunk")
+    func singleLongLineIsNotTruncated() throws {
+        let line = "START" + String(repeating: "X", count: 3000) + "END"
+        let result = try lastLines(of: line + "\n", n: 1)
+        #expect(result == [line])
+    }
+
+    @Test("does not truncate the oldest of N lines that span multiple chunks")
+    func multipleLinesSpanningChunksAreNotTruncated() throws {
+        let l1 = String(repeating: "A", count: 800)
+        let l2 = String(repeating: "B", count: 800)
+        let l3 = String(repeating: "C", count: 800)
+        let result = try lastLines(of: "\(l1)\n\(l2)\n\(l3)\n", n: 2)
+        #expect(result == [l2, l3])
+    }
+
+    @Test("returns the last N short lines")
+    func lastNShortLines() throws {
+        let result = try lastLines(of: "line1\nline2\nline3\nline4\nline5\n", n: 3)
+        #expect(result == ["line3", "line4", "line5"])
+    }
+
+    @Test("returns all lines when N exceeds the line count")
+    func nLargerThanFile() throws {
+        let result = try lastLines(of: "a\nb\nc\n", n: 10)
+        #expect(result == ["a", "b", "c"])
+    }
+}


### PR DESCRIPTION
## Summary

`container logs -n N` truncated the oldest of the N returned lines whenever those
lines spanned more than one 1024-byte read chunk. For example, a single line
longer than 1024 bytes:

```
$ container logs -n 1 logbug | wc -c
1024        # expected ~3009; output also starts mid-line (leading "START" gone)
```

## Root cause

`Application.ContainerLogs.tail(fh:n:follow:)` reads the file backward in
1024-byte chunks and stopped as soon as `lines.count >= n`. While `offset > 0`
the buffer starts in the middle of a line, so the first line in the buffer is a
fragment truncated at the chunk boundary — and `Array(lines.suffix(n))` kept it.

## Fix

Keep reading until there are **more** than `n` non-empty lines (so the first of
the `n` kept lines is guaranteed complete) or the start of the file is reached.
The backward read is extracted into a testable `lastLines(fh:n:)`; the `follow`
and full-file paths are unchanged.

## Tests

Adds `ContainerLogsTests` covering a single line longer than one chunk, N lines
spanning multiple chunks (the general case), the ordinary short-line case, and
`N` larger than the file. Verified locally: `swift build`,
`swift format lint --strict`, and the new tests all pass.

Fixes #1967

🤖 Generated with [Claude Code](https://claude.com/claude-code)
