### PR TITLE
Split mount directives on the first equals sign

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/Parser.swift
+++ b/Sources/Services/ContainerAPIService/Client/Parser.swift
@@ -370,7 +370,7 @@ public struct Parser {
         }
         var directives = defaultDirectives
         for part in parts {
-            let keyVal = part.split(separator: "=", maxSplits: 2)
+            let keyVal = part.split(separator: "=", maxSplits: 1)
             var key = String(keyVal[0])
             var skipValue = false
             switch key {

--- a/Tests/ContainerAPIClientTests/ParserTest.swift
+++ b/Tests/ContainerAPIClientTests/ParserTest.swift
@@ -459,6 +459,26 @@ struct ParserTest {
     }
 
     @Test
+    func testMountBindSourceContainingEquals() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("test-bind-eq-\(UUID().uuidString)=v1")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        let result = try Parser.mount("type=bind,src=\(tempDir.path),dst=/foo")
+
+        switch result {
+        case .filesystem(let fs):
+            #expect(fs.source == tempDir.path)
+            #expect(fs.destination == "/foo")
+            #expect(!fs.isVolume)
+        case .volume:
+            #expect(Bool(false), "Expected filesystem mount, got volume")
+        }
+    }
+
+    @Test
     func testMountVolumeValidName() throws {
         let result = try Parser.mount("type=volume,src=myvolume,dst=/data")
 


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Fixes #2012.

`Parser.mount` splits each comma-separated directive with `maxSplits: 2`. In Swift that parameter counts splits rather than resulting elements, so a value that itself contains an equals sign produces three components:

```swift
"src=/tmp/a=b".split(separator: "=", maxSplits: 2)
// ["src", "/tmp/a", "b"]
```

The parser then requires exactly two components and throws `invalid directive format missing value`. Equals signs are legal in POSIX path names, so a bind mount whose source or destination contains one cannot be used today.

Splitting on the first equals sign keeps the remainder as the value. Directives that carry no value, such as `readonly`, still produce a single component and are unaffected.

#1978 and #1999 fix the same defect in `Parser.labels`. Neither changes `Parser.mount`.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

`testMountBindSourceContainingEquals` creates a directory whose name contains an equals sign and mounts it by absolute path. Against the current code the test fails with `invalid directive format missing value`; with this change it passes. The existing mount and publish-port tests continue to pass.