### PR TITLE
Keep the trailing equals sign out of parsed key names

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/Utility.swift
+++ b/Sources/Services/ContainerAPIService/Client/Utility.swift
@@ -356,7 +356,7 @@ public struct Utility {
     public static func parseKeyValuePairs(_ pairs: [String]) -> [String: String] {
         var result: [String: String] = Dictionary(minimumCapacity: pairs.count)
         for pair in pairs {
-            let components = pair.split(separator: "=", maxSplits: 1)
+            let components = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
             if components.count == 2 {
                 result[String(components[0])] = String(components[1])
             } else {

--- a/Tests/ContainerAPIClientTests/UtilityTests.swift
+++ b/Tests/ContainerAPIClientTests/UtilityTests.swift
@@ -38,6 +38,14 @@ struct UtilityTests {
         #expect(result["standalone"] == "")
     }
 
+    @Test("Parse key with an explicitly empty value")
+    func testKeyWithEmptyValue() {
+        let result = Utility.parseKeyValuePairs(["owner="])
+
+        #expect(result["owner"] == "")
+        #expect(result["owner="] == nil)
+    }
+
     @Test("Parse empty input")
     func testEmptyInput() {
         let result = Utility.parseKeyValuePairs([])


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Fixes #2013.

`Utility.parseKeyValuePairs` splits each argument on the first equals sign. `String.split` omits empty subsequences by default, so an argument ending in `=` produces a single component:

```swift
"owner=".split(separator: "=", maxSplits: 1)
// ["owner"]
```

The count is 1 rather than 2, so the standalone-key branch runs and stores the whole unsplit argument as the key. `--label owner=` therefore creates the key `owner=` instead of `owner` with an empty value.

The doc comment on the function states that a standalone key is treated as `key=`, which implies `owner` and `owner=` should produce the same key. Keeping empty subsequences makes the two spellings agree.

This affects `--label` and `--opt` on `container volume create` and `container network create`.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

`testKeyWithEmptyValue` asserts that `owner=` yields the key `owner` and that the key `owner=` is absent. The existing `parseKeyValuePairs` tests for standalone keys, empty input, and mixed formats continue to pass, so the bare-key behaviour is unchanged.