### PR TITLE
Accept port 1 when validating published port ranges

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/Parser.swift
+++ b/Sources/Services/ContainerAPIService/Client/Parser.swift
@@ -703,13 +703,13 @@ public struct Parser {
             throw ContainerizationError(.invalidArgument, message: "invalid publish container port: \(containerPortText)")
         }
 
-        guard hostPortRangeStart > 1,
+        guard hostPortRangeStart >= 1,
             hostPortRangeStart <= hostPortRangeEnd
         else {
             throw ContainerizationError(.invalidArgument, message: "invalid publish host port range: \(hostPortText)")
         }
 
-        guard containerPortRangeStart > 1,
+        guard containerPortRangeStart >= 1,
             containerPortRangeStart <= containerPortRangeEnd
         else {
             throw ContainerizationError(.invalidArgument, message: "invalid publish container port range: \(containerPortText)")

--- a/Tests/ContainerAPIClientTests/ParserTest.swift
+++ b/Tests/ContainerAPIClientTests/ParserTest.swift
@@ -110,6 +110,15 @@ struct ParserTest {
     }
 
     @Test
+    func testPublishPortOne() throws {
+        let result = try Parser.publishPorts(["127.0.0.1:1:1/tcp"])
+        #expect(result.count == 1)
+        #expect(result[0].hostPort == UInt16(1))
+        #expect(result[0].containerPort == UInt16(1))
+        #expect(result[0].count == 1)
+    }
+
+    @Test
     func testPublishPortInvalidProtocol() throws {
         #expect {
             _ = try Parser.publishPorts(["8080:8000/sctp"])


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Fixes #2014.

`Parser.publishPort` validates the lower bound of a parsed port range with a strict greater-than:

```swift
guard hostPortRangeStart > 1, ...
guard containerPortRangeStart > 1, ...
```

TCP and UDP port numbers start at 1, so `--publish 1:80` and `--publish 8080:1` are both rejected as invalid ranges. The same comparison rejects a range that starts at port 1, such as `--publish 1-100:1-100`.

Port 0 stays rejected under `>= 1`, since it means "any port" rather than a specific one. The existing tests that assert port 0 is refused cover that and still pass.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

`testPublishPortOne` publishes port 1 on both sides and checks the parsed host port, container port, and range length. The existing publish-port tests continue to pass, including `testPublishPortRangeZeroHostPortStart` and `testPublishPortRangeZeroContainerPortStart`, which confirm port 0 is still refused.