### PR TITLE
Close a UDP proxy backend that becomes active after eviction

### DIFF
--- a/Sources/SocketForwarder/UDPForwarder.swift
+++ b/Sources/SocketForwarder/UDPForwarder.swift
@@ -22,7 +22,7 @@ import NIOFoundationCompat
 import Synchronization
 
 // Proxy backend for a single client address (clientIP, clientPort).
-private final class UDPProxyBackend: ChannelInboundHandler {
+final class UDPProxyBackend: ChannelInboundHandler {
     typealias InboundIn = AddressedEnvelope<ByteBuffer>
     typealias OutboundOut = AddressedEnvelope<ByteBuffer>
 
@@ -35,6 +35,7 @@ private final class UDPProxyBackend: ChannelInboundHandler {
     private struct State {
         var queuedPayloads: Deque<ByteBuffer>
         var channel: (any Channel)?
+        var closed: Bool
     }
 
     private let clientAddress: SocketAddress
@@ -48,7 +49,7 @@ private final class UDPProxyBackend: ChannelInboundHandler {
         self.serverAddress = serverAddress
         self.frontendChannel = frontendChannel
         self.log = log
-        let initialState = State(queuedPayloads: Deque(), channel: nil)
+        let initialState = State(queuedPayloads: Deque(), channel: nil, closed: false)
         self.state = initialState
     }
 
@@ -61,6 +62,16 @@ private final class UDPProxyBackend: ChannelInboundHandler {
     }
 
     func channelActive(context: ChannelHandlerContext) {
+        guard !state.closed else {
+            // close() ran while this channel was still binding, so there was no channel to
+            // close at the time. Close it now rather than adopting it: the backend has
+            // already been evicted from the proxy cache, so no reference remains that could
+            // close it later.
+            self.log?.trace("backend - closing channel that became active after close")
+            state.queuedPayloads.removeAll()
+            context.channel.close(promise: nil)
+            return
+        }
         if !state.queuedPayloads.isEmpty {
             self.log?.trace("backend - writing \(state.queuedPayloads.count) queued datagrams to server")
             while let queuedData = state.queuedPayloads.popFirst() {
@@ -88,8 +99,9 @@ private final class UDPProxyBackend: ChannelInboundHandler {
     }
 
     func close() {
+        state.closed = true
         guard let channel = state.channel else {
-            self.log?.warning("backend - close on inactive channel")
+            self.log?.trace("backend - close requested before the channel became active")
             return
         }
         _ = channel.close()

--- a/Tests/SocketForwarderTests/UDPForwarderTest.swift
+++ b/Tests/SocketForwarderTests/UDPForwarderTest.swift
@@ -23,6 +23,33 @@ import Testing
 struct UDPForwarderTest {
     let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 
+    /// A backend evicted from the proxy cache before its channel finished binding used to
+    /// have no channel to close, and nothing closed the socket once it became active.
+    @Test
+    func testBackendClosedBeforeChannelActiveClosesTheChannel() throws {
+        let clientAddress = try SocketAddress(ipAddress: "127.0.0.1", port: 12345)
+        let serverAddress = try SocketAddress(ipAddress: "127.0.0.1", port: 54321)
+        let frontendChannel = EmbeddedChannel()
+
+        let backend = UDPProxyBackend(
+            clientAddress: clientAddress,
+            serverAddress: serverAddress,
+            frontendChannel: frontendChannel,
+            log: nil
+        )
+
+        // Evicted while the backend channel is still binding, so there is no channel yet.
+        backend.close()
+
+        // The bind then completes and the channel becomes active.
+        let backendChannel = EmbeddedChannel(handler: backend)
+        try backendChannel.connect(to: serverAddress).wait()
+
+        #expect(!backendChannel.isActive)
+        _ = try? backendChannel.finish()
+        _ = try? frontendChannel.finish()
+    }
+
     @Test
     func testUDPForwarder() async throws {
         let requestCount = 100


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Fixes #2015.

`UDPProxyFrontend` keeps at most 256 backends in an LRU cache and closes whichever one is evicted. `UDPProxyBackend.close()` returned early when the backend channel had not finished binding:

```swift
func close() {
    guard let channel = state.channel else {
        self.log?.warning("backend - close on inactive channel")
        return
    }
    _ = channel.close()
}
```

`state.channel` is nil from construction until `channelActive` runs, which happens after `bind` completes. A backend evicted inside that window is never closed. `channelActive` then adopts the channel, and because the `ProxyContext` has already been dropped from the cache, no reference remains that could close it. The socket stays open for the lifetime of the process.

The existing warning shows the case was anticipated, but the early return leaves the socket open rather than deferring the close.

This change records the close request in the backend state and has `channelActive` honour it, closing the channel instead of adopting it and discarding any queued payloads. Both paths run on the event loop the backend is bootstrapped on, since `DatagramBootstrap(group: context.eventLoop)` and `NIOLoopBound(proxy, eventLoop: context.eventLoop)` bind them to that loop, so the flag needs no further synchronisation.

`UDPProxyBackend` changes from file-private to internal so the test can drive the ordering directly. Nothing outside the module references it.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

`testBackendClosedBeforeChannelActiveClosesTheChannel` calls `close()` before the channel becomes active, then activates it through an `EmbeddedChannel` and asserts the channel is no longer active. The test fails against the current code and passes with this change. `testUDPForwarder` and `testLRUCache` continue to pass.