### PR TITLE
feat: add build-context support

### DIFF
--- a/Sources/ContainerBuild/BuildFSSync.swift
+++ b/Sources/ContainerBuild/BuildFSSync.swift
@@ -133,30 +133,34 @@ actor BuildFSSync: BuildPipelineHandler {
         _ buildID: String
     ) async throws {
         let wantsTar = packet.mode() == "tar"
+        // context directory -> coming in as resolved (absolute) path
+        // build-context -> relative path to the current working directory
+        let root = URL(filePath: packet.source)
 
         var entries: [String: Set<DirEntry>] = [:]
         let followPaths: [String] = packet.followPaths() ?? []
 
-        let followPathsWalked = try walk(root: self.contextDir, includePatterns: followPaths)
+        let followPathsWalked = try walk(root: root, includePatterns: followPaths)
+
         for url in followPathsWalked {
-            guard self.contextDir.absoluteURL.cleanPath != url.absoluteURL.cleanPath else {
+            guard root.absoluteURL.cleanPath != url.absoluteURL.cleanPath else {
                 continue
             }
-            guard self.contextDir.parentOf(url) else {
+            guard root.parentOf(url) else {
                 continue
             }
 
-            let relPath = try url.relativeChildPath(to: contextDir)
-            let parentPath = try url.deletingLastPathComponent().relativeChildPath(to: contextDir)
+            let relPath = try url.relativeChildPath(to: root)
+            let parentPath = try url.deletingLastPathComponent().relativeChildPath(to: root)
             let entry = DirEntry(url: url, isDirectory: url.hasDirectoryPath, relativePath: relPath)
             entries[parentPath, default: []].insert(entry)
 
             if url.isSymlink {
                 let target: URL = url.resolvingSymlinksInPath()
-                if self.contextDir.parentOf(target) {
-                    let relPath = try target.relativeChildPath(to: self.contextDir)
+                if root.parentOf(target) {
+                    let relPath = try target.relativeChildPath(to: root)
                     let entry = DirEntry(url: target, isDirectory: target.hasDirectoryPath, relativePath: relPath)
-                    let parentPath: String = try target.deletingLastPathComponent().relativeChildPath(to: self.contextDir)
+                    let parentPath: String = try target.deletingLastPathComponent().relativeChildPath(to: root)
                     entries[parentPath, default: []].insert(entry)
                 }
             }
@@ -167,7 +171,7 @@ actor BuildFSSync: BuildPipelineHandler {
 
         if !wantsTar {
             let fileInfos = try fileOrder.map { rel -> FileInfo in
-                try FileInfo(path: contextDir.appendingPathComponent(rel), contextDir: contextDir)
+                try FileInfo(path: root.appendingPathComponent(rel), contextDir: root)
             }
 
             let data = try JSONEncoder().encode(fileInfos)
@@ -201,15 +205,15 @@ actor BuildFSSync: BuildPipelineHandler {
             filter: .none)
 
         let tarHash = try Archiver.compress(
-            source: contextDir,
+            source: root,
             destination: tarURL,
             writerConfiguration: writerCfg
         ) { url in
-            guard let rel = try? url.relativeChildPath(to: contextDir) else {
+            guard let rel = try? url.relativeChildPath(to: root) else {
                 return nil
             }
 
-            guard let parent = try? url.deletingLastPathComponent().relativeChildPath(to: self.contextDir) else {
+            guard let parent = try? url.deletingLastPathComponent().relativeChildPath(to: root) else {
                 return nil
             }
 

--- a/Sources/ContainerBuild/BuildImageResolver.swift
+++ b/Sources/ContainerBuild/BuildImageResolver.swift
@@ -17,6 +17,7 @@
 import ContainerAPIClient
 import ContainerPersistence
 import Containerization
+import ContainerizationArchive
 import ContainerizationOCI
 import Foundation
 import GRPCCore
@@ -78,6 +79,12 @@ struct BuildImageResolver: BuildPipelineHandler {
             let progress = ProgressBar(config: progressConfig)
             defer { progress.finish() }
             progress.start()
+            if let parsed = parseLocalRef(ref: ref) {
+                guard let image = try await handleLocalUCI(url: parsed.url, digest: parsed.digest) else {
+                    throw Error.imageNotFound
+                }
+                return image
+            }
 
             if self.pull {
                 return try await ClientImage.pull(reference: ref, platform: platform, containerSystemConfig: containerSystemConfig, progressUpdate: progress.handler)
@@ -113,6 +120,79 @@ struct BuildImageResolver: BuildPipelineHandler {
             }
         }
         throw Error.unknownPlatformForImage(platform.description, ref)
+    }
+
+    // handle oci-layout from build-context
+    // Not throwing here so that we can fall back to pull or fetch
+    private func parseLocalRef(ref: String) -> (url: URL, digest: String?)? {
+        guard let range = ref.firstRange(of: "oci-layout://") else {
+            return nil
+        }
+        var ref = ref
+        ref.removeSubrange(range)
+
+        let digest = extractDigest(ref)
+        if let digest, let range = ref.range(of: digest) {
+            ref.removeSubrange(range)
+        }
+        ref = ref.trimmingCharacters(in: ["@"])
+        if !FileManager.default.fileExists(atPath: ref) {
+            return nil
+        }
+        let url = URL(filePath: ref)
+        guard url.isDirectory else {
+            return nil
+        }
+        return (url, digest)
+    }
+
+    private func handleLocalUCI(url: URL, digest: String?) async throws -> ClientImage? {
+        let tarURL = URL.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".tar")
+
+        defer { try? FileManager.default.removeItem(at: tarURL) }
+
+        let writerCfg = ArchiveWriterConfiguration(
+            format: .paxRestricted,
+            filter: .none
+        )
+
+        let root = url
+
+        let _ = try Archiver.compress(
+            source: url,
+            destination: tarURL,
+            writerConfiguration: writerCfg,
+            closure: { url in
+                guard let rel = try? url.relativeChildPath(to: root) else {
+                    return nil
+                }
+                return Archiver.ArchiveEntryInfo(
+                    pathOnHost: url,
+                    pathInArchive: URL(fileURLWithPath: rel)
+                )
+            }
+        )
+
+        let result = try await ClientImage.load(from: tarURL.absolutePath(), force: true)
+        let images = result.images
+        let first = images.first
+        if let digest {
+            return images.first(where: { $0.digest == digest }) ?? first
+        }
+        return first
+    }
+
+    private func extractDigest(_ string: String) -> String? {
+        guard let reg = try? Regex("[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}") else {
+            return nil
+        }
+        let matches = string.matches(of: reg)
+        // digest always comes last when specified
+        guard let last = matches.last else {
+            return nil
+        }
+        return String(string[last.range])
     }
 }
 

--- a/Sources/ContainerBuild/Builder.swift
+++ b/Sources/ContainerBuild/Builder.swift
@@ -267,6 +267,7 @@ public struct Builder: Sendable {
         public let buildID: String
         public let contentStore: ContentStore
         public let buildArgs: [String]
+        public let buildContexts: [String]
         public let secrets: [String: Data]
         public let contextDir: String
         public let dockerfile: Data
@@ -288,6 +289,7 @@ public struct Builder: Sendable {
             buildID: String,
             contentStore: ContentStore,
             buildArgs: [String],
+            buildContexts: [String],
             secrets: [String: Data],
             contextDir: String,
             dockerfile: Data,
@@ -308,6 +310,7 @@ public struct Builder: Sendable {
             self.buildID = buildID
             self.contentStore = contentStore
             self.buildArgs = buildArgs
+            self.buildContexts = buildContexts
             self.secrets = secrets
             self.contextDir = contextDir
             self.dockerfile = dockerfile
@@ -352,6 +355,9 @@ public struct Builder: Sendable {
         }
         for buildArg in config.buildArgs {
             metadata.addString(buildArg, forKey: "build-args")
+        }
+        for buildContext in config.buildContexts {
+            metadata.addString(buildContext, forKey: "build-context")
         }
         for (id, data) in config.secrets {
             metadata.addString(id + "=" + data.base64EncodedString(), forKey: "secrets")

--- a/Sources/ContainerCommands/BuildCommand.swift
+++ b/Sources/ContainerCommands/BuildCommand.swift
@@ -63,6 +63,9 @@ extension Application {
         @Option(name: .long, help: ArgumentHelp("Set build-time variables", valueName: "key=val"))
         var buildArg: [String] = []
 
+        @Option(name: .long, help: ArgumentHelp("Set build-contexts. Relative Paths are resolved based on the current working directory.", valueName: "name=<ref>"))
+        var buildContext: [String] = []
+
         @Option(name: .long, help: ArgumentHelp("Cache imports for the build", valueName: "value", visibility: .hidden))
         var cacheIn: [String] = {
             []
@@ -349,12 +352,14 @@ extension Application {
                     }()
                     group.addTask {
                         [
-                            terminal, buildArg, secretsData, contextDir, ignoreFileData, label, noCache, target, quiet, cacheIn, cacheOut, pull, exports, imageNames, tempURL, log,
+                            terminal, buildArg, buildContext, secretsData, contextDir, ignoreFileData, label, noCache, target, quiet, cacheIn, cacheOut, pull, exports, imageNames,
+                            tempURL, log,
                         ] in
                         let config = Builder.BuildConfig(
                             buildID: buildID,
                             contentStore: RemoteContentStoreClient(),
                             buildArgs: buildArg,
+                            buildContexts: buildContext,
                             secrets: secretsData,
                             contextDir: contextDir,
                             dockerfile: buildFileData,


### PR DESCRIPTION
# Add support for named build contexts, equivalent to Docker/Buildx and Podman --build-context name=value.

## Type of Change
- New feature  


## Motivation and Context
Supporting named build contexts : resolve #1930 

### Supported formats:

- name=/absolute/or/relative/local/path
- name=docker-image://xxx
- name=oci-layout:/path/to/layout (with or without digest)
- URL/Git

## Testing
- Tested locally

1. Check out the container fork for enabling build-context option
2. build the container by running `make all && make install`
3. Check out [builder shim fork](https://github.com/apple/container-builder-shim/pull/88)
4. build the shim image by running `container build -t builder .`
5. update build image in container config at ~/.config/container/config.toml 

```
[build]
image = "builder:latest"
```

6. Use the [BuildContextTest.zip](https://github.com/user-attachments/files/30383639/BuildContextTest.zip) to test out all 4 scenarios above + when a regular build where no named context is specified.

