### PR TITLE
fix(image): preserve active and infrastructure aliases

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -159,6 +159,7 @@ let package = Package(
         .testTarget(
             name: "ContainerCommandsTests",
             dependencies: [
+                .product(name: "ContainerizationOCI", package: "containerization"),
                 "ContainerCommands",
                 "ContainerResource",
             ]

--- a/Sources/ContainerCommands/Builder/BuilderStart.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStart.swift
@@ -133,6 +133,10 @@ extension Application {
             )
 
             let client = ContainerClient()
+            let builderImageAliases = try Utility.imageReferenceAliases(
+                builderImage,
+                containerSystemConfig: containerSystemConfig
+            )
             let existingContainer = try? await client.get(id: "buildkit")
             if let existingContainer {
                 let existingImage = existingContainer.configuration.image.reference
@@ -147,7 +151,7 @@ extension Application {
                 let envChanged = existingManagedEnv != targetEnvVars
 
                 // Check if we need to recreate the builder due to different image
-                let imageChanged = existingImage != builderImage
+                let imageChanged = !builderImageAliases.contains(existingImage)
                 let cpuChanged = existingResources.cpus != resources.cpus
                 let memChanged = existingResources.memoryInBytes != resources.memoryInBytes
                 let dnsChanged = {
@@ -223,7 +227,7 @@ extension Application {
             )
 
             let imageDesc = ImageDescription(
-                reference: builderImage,
+                reference: image.reference,
                 descriptor: image.descriptor
             )
 

--- a/Sources/ContainerCommands/Image/ImageDelete.swift
+++ b/Sources/ContainerCommands/Image/ImageDelete.swift
@@ -60,11 +60,10 @@ extension Application {
             var didDeleteAnyImage = false
             for image in found {
                 guard
-                    !Utility.isInfraImage(
+                    !(try Utility.isInfraImage(
                         name: image.reference,
-                        builderImage: containerSystemConfig.build.image,
-                        initImage: containerSystemConfig.vminit.image
-                    )
+                        containerSystemConfig: containerSystemConfig
+                    ))
                 else {
                     continue
                 }

--- a/Sources/ContainerCommands/Image/ImageInspect.swift
+++ b/Sources/ContainerCommands/Image/ImageInspect.swift
@@ -53,11 +53,10 @@ extension Application {
             var printable: [ImageResource] = []
             for image in result.images {
                 guard
-                    !Utility.isInfraImage(
+                    !(try Utility.isInfraImage(
                         name: image.reference,
-                        builderImage: containerSystemConfig.build.image,
-                        initImage: containerSystemConfig.vminit.image
-                    )
+                        containerSystemConfig: containerSystemConfig
+                    ))
                 else { continue }
                 printable.append(
                     try await image.toImageResource(containerSystemConfig: containerSystemConfig)

--- a/Sources/ContainerCommands/Image/ImageList.swift
+++ b/Sources/ContainerCommands/Image/ImageList.swift
@@ -49,7 +49,7 @@ extension Application {
             try Self.validate(quiet: quiet, verbose: verbose)
 
             var images = try await ClientImage.list().filter { img in
-                !Utility.isInfraImage(name: img.reference, builderImage: containerSystemConfig.build.image, initImage: containerSystemConfig.vminit.image)
+                !(try Utility.isInfraImage(name: img.reference, containerSystemConfig: containerSystemConfig))
             }
             images.sort { $0.reference < $1.reference }
 

--- a/Sources/ContainerCommands/Image/ImagePrune.swift
+++ b/Sources/ContainerCommands/Image/ImagePrune.swift
@@ -16,6 +16,8 @@
 
 import ArgumentParser
 import ContainerAPIClient
+import ContainerPersistence
+import ContainerResource
 import ContainerizationOCI
 import Foundation
 
@@ -33,19 +35,22 @@ extension Application {
         var all: Bool = false
 
         public func run() async throws {
-            let allImages = try await ClientImage.list()
+            let containerSystemConfig: ContainerSystemConfig = try await Application.loadContainerSystemConfig()
+            let allImages = try await ClientImage.list().filter { image in
+                !(try Utility.isInfraImage(
+                    name: image.reference,
+                    containerSystemConfig: containerSystemConfig
+                ))
+            }
 
             let imagesToPrune: [ClientImage]
             if all {
                 // Find all images not used by any container
                 let client = ContainerClient()
                 let containers = try await client.list()
-                var imagesInUse = Set<String>()
-                for container in containers {
-                    imagesInUse.insert(container.configuration.image.reference)
-                }
+                let imagesInUse = Set(containers.map { $0.configuration.image.digest })
                 imagesToPrune = allImages.filter { image in
-                    !imagesInUse.contains(image.reference)
+                    Self.isUnusedImage(image.description, usedImageDigests: imagesInUse)
                 }
             } else {
                 // Find dangling images (images with no tag)
@@ -83,6 +88,10 @@ extension Application {
             formatter.countStyle = .file
             let freed = formatter.string(fromByteCount: Int64(size))
             log.info("Reclaimed \(freed) in disk space")
+        }
+
+        static func isUnusedImage(_ image: ImageDescription, usedImageDigests: Set<String>) -> Bool {
+            !usedImageDigests.contains(image.digest)
         }
 
         private func hasTag(_ reference: String) -> Bool {

--- a/Sources/Services/ContainerAPIService/Client/Utility.swift
+++ b/Sources/Services/ContainerAPIService/Client/Utility.swift
@@ -39,9 +39,26 @@ public struct Utility {
         return name
     }
 
+    public static func imageReferenceAliases(
+        _ reference: String,
+        containerSystemConfig: ContainerSystemConfig
+    ) throws -> Set<String> {
+        let localReference = try Reference.parse(reference)
+        localReference.normalize()
+        return [
+            reference,
+            localReference.description,
+            try ClientImage.normalizeReference(reference, containerSystemConfig: containerSystemConfig),
+        ]
+    }
+
     public static func isInfraImage(name: String, builderImage: String, initImage: String) -> Bool {
-        for infraImage in [builderImage, initImage] {
-            if name == infraImage {
+        [builderImage, initImage].contains(name)
+    }
+
+    public static func isInfraImage(name: String, containerSystemConfig: ContainerSystemConfig) throws -> Bool {
+        for infraImage in [containerSystemConfig.build.image, containerSystemConfig.vminit.image] {
+            if try imageReferenceAliases(infraImage, containerSystemConfig: containerSystemConfig).contains(name) {
                 return true
             }
         }

--- a/Tests/ContainerAPIClientTests/UtilityTests.swift
+++ b/Tests/ContainerAPIClientTests/UtilityTests.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerPersistence
 import ContainerResource
 import ContainerizationError
 import Foundation
@@ -111,6 +112,52 @@ struct UtilityTests {
     @Test("Trim digest shorter than 12 chars returns value unchanged")
     func testTrimDigestShort() {
         #expect(Utility.trimDigest(digest: "sha256:abc") == "abc")
+    }
+
+    @Test("Infrastructure image matching normalizes configured references")
+    func infrastructureImageMatchingNormalizesConfiguredReferences() throws {
+        let config = ContainerSystemConfig(
+            build: BuildConfig(image: "custom-builder"),
+            registry: RegistryConfig(domain: "registry.example.com"),
+            vminit: VminitConfig(image: "custom-init")
+        )
+
+        #expect(
+            try Utility.isInfraImage(
+                name: "custom-builder",
+                containerSystemConfig: config
+            )
+        )
+        #expect(
+            try Utility.isInfraImage(
+                name: "custom-builder:latest",
+                containerSystemConfig: config
+            )
+        )
+        #expect(
+            try Utility.isInfraImage(
+                name: "registry.example.com/custom-builder:latest",
+                containerSystemConfig: config
+            )
+        )
+        #expect(
+            try Utility.isInfraImage(
+                name: "custom-init",
+                containerSystemConfig: config
+            )
+        )
+        #expect(
+            try Utility.isInfraImage(
+                name: "custom-init:latest",
+                containerSystemConfig: config
+            )
+        )
+        #expect(
+            try !Utility.isInfraImage(
+                name: "registry.example.com/application:latest",
+                containerSystemConfig: config
+            )
+        )
     }
 
     @Test

--- a/Tests/ContainerCommandsTests/ImagePruneTests.swift
+++ b/Tests/ContainerCommandsTests/ImagePruneTests.swift
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerResource
+import ContainerizationOCI
+import Testing
+
+@testable import ContainerCommands
+
+struct ImagePruneTests {
+    @Test("Active image aliases are matched by OCI digest")
+    func activeImageAliasesAreMatchedByDigest() {
+        let descriptor = Descriptor(
+            mediaType: MediaTypes.index,
+            digest: "sha256:" + String(repeating: "a", count: 64),
+            size: 1
+        )
+        let storedImage = ImageDescription(
+            reference: "registry.example.com/library/builder:latest",
+            descriptor: descriptor
+        )
+        let configuredImage = ImageDescription(
+            reference: "builder",
+            descriptor: descriptor
+        )
+
+        #expect(
+            !Application.ImagePrune.isUnusedImage(
+                storedImage,
+                usedImageDigests: [configuredImage.digest]
+            )
+        )
+    }
+}

--- a/Tests/IntegrationTests/Images/TestCLIImagePruneSerial.swift
+++ b/Tests/IntegrationTests/Images/TestCLIImagePruneSerial.swift
@@ -14,6 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerAPIClient
 import ContainerTestSupport
 import Testing
 
@@ -64,15 +65,18 @@ struct TestCLIImagePruneSerial {
 
             try f.builderStart()
             try await f.waitForBuilderRunning()
-            let builderImage = try f.getSystemConfig().build.image
-            _ = try f.doInspectImages(builderImage)
+            let builder = try f.inspectContainer("buildkit")
+            let builderDigest = builder.configuration.image.digest
+            var storedImages = try await ClientImage.list()
+            #expect(storedImages.contains { $0.digest == builderDigest }, "expected builder image in the image store")
 
             try f.doPull(alpine)
             let result = try f.run(["image", "prune", "-a"]).check()
 
             #expect(result.output.contains(alpine), "should prune unused alpine image")
             #expect(try !f.isImagePresent(alpine), "expected unused alpine image to be removed")
-            _ = try f.doInspectImages(builderImage)
+            storedImages = try await ClientImage.list()
+            #expect(storedImages.contains { $0.digest == builderDigest }, "expected builder image to remain in the image store")
             #expect(try f.getContainerStatus("buildkit") == "running", "builder should remain usable after image prune")
         }
     }

--- a/Tests/IntegrationTests/Images/TestCLIImagePruneSerial.swift
+++ b/Tests/IntegrationTests/Images/TestCLIImagePruneSerial.swift
@@ -53,6 +53,30 @@ struct TestCLIImagePruneSerial {
         }
     }
 
+    @Test func testImagePrunePreservesBuilderImage() async throws {
+        try await ContainerFixture.with { f in
+            _ = try? f.builderDelete(force: true)
+            try? f.doRemoveImages()
+            f.addCleanup {
+                try? f.builderDelete(force: true)
+                try? f.doRemoveImages()
+            }
+
+            try f.builderStart()
+            try await f.waitForBuilderRunning()
+            let builderImage = try f.getSystemConfig().build.image
+            _ = try f.doInspectImages(builderImage)
+
+            try f.doPull(alpine)
+            let result = try f.run(["image", "prune", "-a"]).check()
+
+            #expect(result.output.contains(alpine), "should prune unused alpine image")
+            #expect(try !f.isImagePresent(alpine), "expected unused alpine image to be removed")
+            _ = try f.doInspectImages(builderImage)
+            #expect(try f.getContainerStatus("buildkit") == "running", "builder should remain usable after image prune")
+        }
+    }
+
     @Test func testImagePruneUnusedImages() async throws {
         try await ContainerFixture.with { f in
             _ = try? f.run(["delete", "--all", "--force"])


### PR DESCRIPTION
> [!IMPORTANT]
> All commits in this pull request are signed and verified.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

During testing of my `container-compose` plugin, I found and fixed the following issue: `image prune --all` compared image reference strings to decide whether active containers used an image. Equivalent OCI references can differ after registry and tag normalisation, so prune could treat an active image as unused.

The builder path also stored the configured reference instead of the fetched image reference, and infrastructure-image filters compared configured and stored references literally. Together, these behaviours could expose a normalised builder or init image to list, inspect, delete, or prune operations and could unnecessarily recreate an otherwise matching builder.

Fixes #2030.

### Reproduction

1. Configure the stock builder using the equivalent short reference `apple/container-builder-shim/builder:0.13.0` with `registry.domain = "ghcr.io"`.
2. Start the system and builder.
3. Pull an unrelated image.
4. Run `container image prune --all`.
5. Confirm the prune output does not include the builder image and run `container builder status`.

Before this change, the configured and stored aliases can compare unequal even though they resolve to the same OCI image. The deterministic unit regression models that condition with two references sharing one descriptor digest.

### Changes

- Match images used by active containers by OCI digest rather than reference string.
- Match configured builder and init images using original, OCI-normalised, and registry-normalised aliases.
- Store the fetched builder image reference in container state.
- Reuse an existing builder when its stored image reference is an equivalent alias.
- Add focused unit and CLI integration regressions.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

Documentation is not needed because command syntax and user-facing behaviour are unchanged.

### Validation

Validated on macOS 26.5.1 (25F80), Xcode 26.6 (17F113), and Swift 6.3.3 against `apple/container` `main` at `27e5043165178edb095c901624857b51a2ea8e1a`.

- `HAWKEYE_AUTO_INSTALL=1 make fmt`
- `HAWKEYE_AUTO_INSTALL=1 make check`
- `HAWKEYE_AUTO_INSTALL=1 make test`: 570 tests in 71 suites passed
- `swift test --disable-automatic-resolution -Xswiftc -warnings-as-errors --filter 'ImagePruneTests|UtilityTests'`: 14 tests in 2 suites passed
- Targeted CLI integration:
  - image warm-up: 1 test passed
  - existing image lifecycle suite: 19 tests passed
  - serial image-prune suite: 6 tests passed
  - new `testImagePrunePreservesBuilderImage`: passed in 45.445 seconds
- `git diff --check`

The integration regression starts the builder, records its OCI digest, confirms that digest is present in the unfiltered image service, pulls an ordinary unused image, runs `image prune --all`, verifies the ordinary image is removed, verifies the builder digest remains stored, and verifies the builder remains running.
