### PR TITLE
Preserve unloadable bundles and write metadata atomically

### DIFF
--- a/Sources/ContainerResource/Container/Bundle.swift
+++ b/Sources/ContainerResource/Container/Bundle.swift
@@ -137,7 +137,7 @@ extension Bundle {
 
     public func setContainerRootFs(fs: Filesystem) throws {
         let fsData = try JSONEncoder().encode(fs)
-        try fsData.write(to: self.containerRootfsConfig)
+        try fsData.write(to: self.containerRootfsConfig, options: .atomic)
     }
 
     public func cloneContainerRootFs(cloning fs: Filesystem, readonly: Bool = false) throws {
@@ -160,7 +160,7 @@ extension Bundle {
 
     private static func write(_ path: URL, value: Encodable) throws {
         let data = try JSONEncoder().encode(value)
-        try data.write(to: path)
+        try data.write(to: path, options: .atomic)
     }
 
     public func load<T>(filename: String) throws -> T where T: Decodable {

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -132,6 +132,12 @@ public actor ContainersService {
                     continue
                 }
 
+                guard runtimePlugins.first(where: { $0.name == config.runtimeHandler }) != nil else {
+                    throw ContainerizationError(
+                        .internalError,
+                        message: "failed to find runtime plugin \(config.runtimeHandler)"
+                    )
+                }
                 let state = ContainerState(
                     snapshot: .init(
                         configuration: config,
@@ -141,16 +147,9 @@ public actor ContainersService {
                     ),
                 )
                 results[config.id] = state
-                guard runtimePlugins.first(where: { $0.name == config.runtimeHandler }) != nil else {
-                    throw ContainerizationError(
-                        .internalError,
-                        message: "failed to find runtime plugin \(config.runtimeHandler)"
-                    )
-                }
             } catch {
-                try? FileManager.default.removeItem(at: dir)
                 log.warning(
-                    "failed to load container",
+                    "failed to load container; leaving bundle on disk",
                     metadata: [
                         "path": "\(dir.path)",
                         "error": "\(error)",

--- a/Tests/ContainerAPIServiceTests/ContainerLoadAtBootTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLoadAtBootTests.swift
@@ -25,13 +25,14 @@ import Testing
 
 struct ContainerLoadAtBootTests {
     @Test
-    func malformedBundleRemainsOnDisk() throws {
+    func malformedConfigurationFilesRemainOnDisk() throws {
         let fixture = try Fixture()
         defer { fixture.remove() }
 
         let bundlePath = fixture.containers.appendingPathComponent("malformed")
         try FileManager.default.createDirectory(at: bundlePath, withIntermediateDirectories: true)
         try Data("{".utf8).write(to: bundlePath.appendingPathComponent("config.json"))
+        try Data("{".utf8).write(to: bundlePath.appendingPathComponent("runtime-configuration.json"))
 
         let states = try ContainersService.loadAtBoot(
             root: fixture.containers,

--- a/Tests/ContainerAPIServiceTests/ContainerLoadAtBootTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLoadAtBootTests.swift
@@ -1,0 +1,113 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerResource
+import Containerization
+import Foundation
+import Logging
+import Testing
+
+@testable import ContainerAPIService
+@testable import ContainerPlugin
+
+struct ContainerLoadAtBootTests {
+    @Test
+    func malformedBundleRemainsOnDisk() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        let bundlePath = fixture.containers.appendingPathComponent("malformed")
+        try FileManager.default.createDirectory(at: bundlePath, withIntermediateDirectories: true)
+        try Data("{".utf8).write(to: bundlePath.appendingPathComponent("config.json"))
+
+        let states = try ContainersService.loadAtBoot(
+            root: fixture.containers,
+            loader: fixture.loader,
+            log: fixture.log
+        )
+
+        #expect(states.isEmpty)
+        #expect(FileManager.default.fileExists(atPath: bundlePath.path))
+    }
+
+    @Test
+    func missingRuntimeBundleRemainsOnDiskButIsNotLoaded() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        let bundlePath = fixture.containers.appendingPathComponent("missing-runtime")
+        try FileManager.default.createDirectory(at: bundlePath, withIntermediateDirectories: true)
+        let bundle = ContainerResource.Bundle(path: bundlePath)
+        try bundle.set(configuration: testConfiguration(id: "missing-runtime"))
+
+        let states = try ContainersService.loadAtBoot(
+            root: fixture.containers,
+            loader: fixture.loader,
+            log: fixture.log
+        )
+
+        #expect(states.isEmpty)
+        #expect(FileManager.default.fileExists(atPath: bundlePath.path))
+        let recovered: ContainerConfiguration = try bundle.load(filename: "config.json")
+        #expect(recovered.id == "missing-runtime")
+    }
+
+    private func testConfiguration(id: String) -> ContainerConfiguration {
+        let image = ImageDescription(
+            reference: "docker.io/library/alpine:latest",
+            descriptor: .init(
+                mediaType: "application/vnd.oci.image.manifest.v1+json",
+                digest: "sha256:" + String(repeating: "0", count: 64),
+                size: 0
+            )
+        )
+        let process = ProcessConfiguration(
+            executable: "/bin/sh",
+            arguments: [],
+            environment: [],
+            workingDirectory: "/",
+            terminal: false,
+            user: .id(uid: 0, gid: 0),
+            supplementalGroups: [],
+            rlimits: []
+        )
+        return ContainerConfiguration(id: id, image: image, process: process)
+    }
+}
+
+private struct Fixture {
+    let root: URL
+    let containers: URL
+    let loader: PluginLoader
+    let log = Logger(label: "ContainerLoadAtBootTests")
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        containers = root.appendingPathComponent("containers")
+        try FileManager.default.createDirectory(at: containers, withIntermediateDirectories: true)
+        loader = try PluginLoader(
+            appRoot: root,
+            installRoot: root,
+            logRoot: nil,
+            pluginDirectories: [],
+            pluginFactories: []
+        )
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: root)
+    }
+}


### PR DESCRIPTION
During testing of my Container Compose plugin, I found that startup load failures can delete complete container bundles and, when a runtime plugin is missing, still publish an unusable in-memory state for the deleted bundle.

This supersedes and credits @radheradhe01's work in #1859. That PR correctly preserves failed bundles and makes the generic bundle writer atomic. This version retains those fixes and strengthens them by:

- validating runtime availability before inserting `ContainerState`;
- making `rootfs.json` writes atomic as well as metadata written through the generic bundle writer; and
- adding corrected regressions that exercise both malformed current and legacy configuration files.

Fixes #2033.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

`ContainersService.loadAtBoot` currently removes a bundle directory for every load error. Some failures are transient, such as a runtime plugin not being registered when startup loading runs, while malformed metadata should remain available for diagnosis or recovery.

The missing-runtime path also constructs and inserts a stopped `ContainerState` before checking for the plugin. The subsequent error deletes the bundle, but the returned dictionary still exposes the state as a usable container.

Bundle JSON is currently written directly to its destination. An interrupted write can therefore expose truncated metadata on the next startup, which then reaches the destructive load-error path. `rootfs.json` uses a separate writer and must receive the same atomic replacement semantics.

### Reproduction on stock `main`

Tested at `48145ac7fb177d9fb14e015a0bdea4c642b36729`.

1. Put malformed JSON in both `config.json` and the legacy fallback `runtime-configuration.json`.
2. Call `ContainersService.loadAtBoot`.
3. Observe that the bundle directory is deleted.
4. Separately, create a valid bundle whose configured runtime plugin is unavailable.
5. Call `loadAtBoot` again.
6. Observe that the bundle is deleted while the returned state dictionary still contains the container.

The corrected regression suite fails on stock `main` with four issues:

- the malformed bundle no longer exists;
- the missing-runtime state dictionary is not empty;
- the missing-runtime bundle no longer exists; and
- reloading its deleted `config.json` fails with `NSCocoaErrorDomain Code=260`.

### Expected behaviour

Failed bundles remain on disk, no state is inserted until runtime availability is validated, and all bundle metadata files are replaced atomically.

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

- `make check`: passed
- `swift test --filter ContainerLoadAtBootTests`: 2 tests in 1 suite passed in 0.006 seconds, 201.58 seconds including the initial dependency build
- `make test`: 591 tests in 72 suites passed in 2.011 seconds, 119.33 seconds including the Apple test build
- Strict-review focused rerun: `swift test --filter ContainerLoadAtBootTests` passed 2 tests in 1 suite in 0.006 seconds, 95.93 seconds including a clean rebuild
- Two fresh strict-review full-suite retries passed the persistence coverage, then stopped on the unrelated stock `DirectoryWatcherTest` readiness races corrected by #2036 (`testWatchingNonExistingDirectory`, then `testWatchingNonExistingParent`)
- Stock `main` negative control: the same 2 tests failed with the four expected issues in 0.016 seconds, 94.56 seconds including rebuild
- `git diff --check`: passed

All commits are signed and verified.