### PR TITLE
Close directory watcher descriptors after failed startup

### DIFF
--- a/Sources/ContainerOS/DirectoryWatcher.swift
+++ b/Sources/ContainerOS/DirectoryWatcher.swift
@@ -82,7 +82,7 @@ public actor DirectoryWatcher {
         }
     }
 
-    private func _startWatching(
+    func _startWatching(
         handler: @escaping ([FilePath]) throws -> Void
     ) throws {
         let descriptor = open(directoryPath.string, O_EVTONLY)
@@ -94,6 +94,7 @@ public actor DirectoryWatcher {
             let files = try FileManager.default.contentsOfDirectory(atPath: directoryPath.string)
             try handler(files.map { directoryPath.appending($0) })
         } catch {
+            close(descriptor)
             throw ContainerizationError(.internalError, message: "failed to run handler for \(directoryPath.string)")
         }
 

--- a/Sources/ContainerOS/DirectoryWatcher.swift
+++ b/Sources/ContainerOS/DirectoryWatcher.swift
@@ -46,6 +46,10 @@ public actor DirectoryWatcher {
 
     private let log: Logger?
 
+    var isWatching: Bool {
+        source.withLock { $0 != nil }
+    }
+
     /// Creates a new `DirectoryWatcher` for the given directory path.
     ///
     /// - Parameters:

--- a/Sources/ContainerOS/DirectoryWatcher.swift
+++ b/Sources/ContainerOS/DirectoryWatcher.swift
@@ -83,7 +83,7 @@ public actor DirectoryWatcher {
     }
 
     func _startWatching(
-        handler: @escaping ([FilePath]) throws -> Void
+        handler: @Sendable @escaping ([FilePath]) throws -> Void
     ) throws {
         let descriptor = open(directoryPath.string, O_EVTONLY)
         guard descriptor >= 0 else {

--- a/Sources/ContainerOS/DirectoryWatcher.swift
+++ b/Sources/ContainerOS/DirectoryWatcher.swift
@@ -86,7 +86,7 @@ public actor DirectoryWatcher {
         handler: @escaping ([FilePath]) throws -> Void
     ) throws {
         let descriptor = open(directoryPath.string, O_EVTONLY)
-        guard descriptor > 0 else {
+        guard descriptor >= 0 else {
             throw ContainerizationError(.internalError, message: "cannot open \(directoryPath.string), descriptor=\(descriptor)")
         }
 

--- a/Tests/ContainerOSTests/DirectoryWatcherTest.swift
+++ b/Tests/ContainerOSTests/DirectoryWatcherTest.swift
@@ -14,12 +14,13 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import ContainerOS
 import ContainerizationError
 import DNSServer
 import Foundation
 import SystemPackage
 import Testing
+
+@testable import ContainerOS
 
 struct DirectoryWatcherTest {
     let testUUID = UUID().uuidString
@@ -133,6 +134,30 @@ struct DirectoryWatcherTest {
         }
     }
 
+    @Test func testFailingHandlerDoesNotLeakDescriptors() async throws {
+        try await withTempDir { tempPath in
+            let watcher = DirectoryWatcher(directoryPath: tempPath, log: nil)
+            let baseline = try openDescriptorCount()
+
+            for _ in 0..<32 {
+                do {
+                    try await watcher._startWatching { _ in
+                        throw ContainerizationError(.internalError, message: "intentional test failure")
+                    }
+                    Issue.record("expected the failing watch handler to throw")
+                } catch is ContainerizationError {
+                    // Expected.
+                }
+            }
+
+            let afterFailures = try openDescriptorCount()
+            #expect(
+                afterFailures <= baseline + 2,
+                "failing handlers leaked descriptors: before=\(baseline), after=\(afterFailures)"
+            )
+        }
+    }
+
     @Test func testWatchingRecreatedDirectory() async throws {
         try await withTempDir { tempPath in
             let dirPath = tempPath.appending(UUID().uuidString)
@@ -170,5 +195,11 @@ struct DirectoryWatcherTest {
                 Set(createdPaths.paths.compactMap { $0.lastComponent?.string }) == Set([beforeDelete, afterDelete]))
         }
 
+    }
+
+    private func openDescriptorCount() throws -> Int {
+        try FileManager.default.contentsOfDirectory(atPath: "/dev/fd")
+            .compactMap(Int.init)
+            .count
     }
 }

--- a/Tests/ContainerOSTests/DirectoryWatcherTest.swift
+++ b/Tests/ContainerOSTests/DirectoryWatcherTest.swift
@@ -16,6 +16,7 @@
 
 import ContainerizationError
 import DNSServer
+import Darwin
 import Foundation
 import SystemPackage
 import Testing
@@ -137,11 +138,13 @@ struct DirectoryWatcherTest {
     @Test func testFailingHandlerDoesNotLeakDescriptors() async throws {
         try await withTempDir { tempPath in
             let watcher = DirectoryWatcher(directoryPath: tempPath, log: nil)
-            let baseline = try openDescriptorCount()
+            let baseline = try openDescriptorCount(for: tempPath)
+            var handlerCalls = 0
 
             for _ in 0..<32 {
                 do {
                     try await watcher._startWatching { _ in
+                        handlerCalls += 1
                         throw ContainerizationError(.internalError, message: "intentional test failure")
                     }
                     Issue.record("expected the failing watch handler to throw")
@@ -150,9 +153,10 @@ struct DirectoryWatcherTest {
                 }
             }
 
-            let afterFailures = try openDescriptorCount()
+            let afterFailures = try openDescriptorCount(for: tempPath)
+            #expect(handlerCalls == 32)
             #expect(
-                afterFailures <= baseline + 2,
+                afterFailures == baseline,
                 "failing handlers leaked descriptors: before=\(baseline), after=\(afterFailures)"
             )
         }
@@ -197,9 +201,25 @@ struct DirectoryWatcherTest {
 
     }
 
-    private func openDescriptorCount() throws -> Int {
-        try FileManager.default.contentsOfDirectory(atPath: "/dev/fd")
+    private func openDescriptorCount(for path: FilePath) throws -> Int {
+        var expectedBuffer = [CChar](repeating: 0, count: Int(MAXPATHLEN))
+        guard realpath(path.string, &expectedBuffer) != nil else {
+            throw ContainerizationError(.internalError, message: "failed to resolve test directory: \(path)")
+        }
+        let expectedBytes = expectedBuffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+        let expectedPath = String(decoding: expectedBytes, as: UTF8.self)
+        let descriptors = try FileManager.default.contentsOfDirectory(atPath: "/dev/fd")
+        return
+            descriptors
             .compactMap(Int.init)
+            .filter { descriptor in
+                var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN))
+                guard fcntl(CInt(descriptor), F_GETPATH, &buffer) == 0 else {
+                    return false
+                }
+                let pathBytes = buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+                return String(decoding: pathBytes, as: UTF8.self) == expectedPath
+            }
             .count
     }
 }

--- a/Tests/ContainerOSTests/DirectoryWatcherTest.swift
+++ b/Tests/ContainerOSTests/DirectoryWatcherTest.swift
@@ -25,16 +25,6 @@ import Testing
 @testable import ContainerOS
 
 struct DirectoryWatcherTest {
-    let testUUID = UUID().uuidString
-
-    private var testDir: FilePath {
-        let tempURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-            .appendingPathComponent(".clitests")
-            .appendingPathComponent(testUUID)
-        try! FileManager.default.createDirectory(at: tempURL, withIntermediateDirectories: true)
-        return FilePath(tempURL.path)
-    }
-
     private func withTempDir<T>(_ body: (FilePath) async throws -> T) async throws -> T {
         let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tempURL, withIntermediateDirectories: true)

--- a/Tests/ContainerOSTests/DirectoryWatcherTest.swift
+++ b/Tests/ContainerOSTests/DirectoryWatcherTest.swift
@@ -18,6 +18,7 @@ import ContainerizationError
 import DNSServer
 import Darwin
 import Foundation
+import Synchronization
 import SystemPackage
 import Testing
 
@@ -46,12 +47,37 @@ struct DirectoryWatcherTest {
         return try await body(tempPath)
     }
 
-    private actor CreatedPaths {
-        nonisolated(unsafe) public var paths: [FilePath]
+    private final class CreatedPaths: Sendable {
+        private let paths = Mutex<[FilePath]>([])
 
-        public init() {
-            self.paths = []
+        func append(_ path: FilePath) {
+            paths.withLock { $0.append(path) }
         }
+
+        func contains(_ expectedNames: Set<String>) -> Bool {
+            paths.withLock { paths in
+                let names = Set(paths.compactMap { $0.lastComponent?.string })
+                return names.isSuperset(of: expectedNames)
+            }
+        }
+    }
+
+    private func waitForPaths(
+        _ expectedNames: Set<String>,
+        in createdPaths: CreatedPaths,
+        timeout: Duration = .seconds(5)
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+
+        while clock.now < deadline {
+            if createdPaths.contains(expectedNames) {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+
+        return createdPaths.contains(expectedNames)
     }
 
     @Test func testWatchingExistingDirectory() async throws {
@@ -63,17 +89,17 @@ struct DirectoryWatcherTest {
 
             await watcher.startWatching { [createdPaths] paths in
                 for path in paths where path.lastComponent?.string == name {
-                    createdPaths.paths.append(path)
+                    createdPaths.append(path)
                 }
             }
 
-            try await Task.sleep(for: .milliseconds(100))
             let newFile = tempPath.appending(name)
             FileManager.default.createFile(atPath: newFile.string, contents: nil)
-            try await Task.sleep(for: .milliseconds(500))
 
-            #expect(!createdPaths.paths.isEmpty, "directory watcher failed to detect new file")
-            #expect(createdPaths.paths.first!.lastComponent?.string == name)
+            #expect(
+                await waitForPaths([name], in: createdPaths),
+                "directory watcher failed to detect new file"
+            )
         }
     }
 
@@ -88,20 +114,18 @@ struct DirectoryWatcherTest {
 
             await watcher.startWatching { [createdPaths] paths in
                 for path in paths where path.lastComponent?.string == name {
-                    createdPaths.paths.append(path)
+                    createdPaths.append(path)
                 }
             }
 
-            try await Task.sleep(for: .milliseconds(100))
             try FileManager.default.createDirectory(atPath: childPath.string, withIntermediateDirectories: true)
-
-            try await Task.sleep(for: DirectoryWatcher.watchPeriod)
             let newFile = childPath.appending(name)
             FileManager.default.createFile(atPath: newFile.string, contents: nil)
-            try await Task.sleep(for: .milliseconds(500))
 
-            #expect(!createdPaths.paths.isEmpty, "directory watcher failed to detect parent directory")
-            #expect(createdPaths.paths.first!.lastComponent?.string == name)
+            #expect(
+                await waitForPaths([name], in: createdPaths),
+                "directory watcher failed to detect directory"
+            )
         }
     }
 
@@ -117,21 +141,19 @@ struct DirectoryWatcherTest {
 
             await watcher.startWatching { paths in
                 for path in paths where path.lastComponent?.string == name {
-                    createdPaths.paths.append(path)
+                    createdPaths.append(path)
                 }
             }
 
-            try await Task.sleep(for: .milliseconds(100))
             try FileManager.default.createDirectory(atPath: childPath.string, withIntermediateDirectories: true)
-
-            try await Task.sleep(for: DirectoryWatcher.watchPeriod)
 
             let newFile = childPath.appending(name)
             FileManager.default.createFile(atPath: newFile.string, contents: nil)
-            try await Task.sleep(for: .milliseconds(500))
 
-            #expect(!createdPaths.paths.isEmpty, "directory watcher failed to detect parent directory")
-            #expect(createdPaths.paths.first!.lastComponent?.string == name)
+            #expect(
+                await waitForPaths([name], in: createdPaths),
+                "directory watcher failed to detect parent directory"
+            )
         }
     }
 
@@ -139,12 +161,12 @@ struct DirectoryWatcherTest {
         try await withTempDir { tempPath in
             let watcher = DirectoryWatcher(directoryPath: tempPath, log: nil)
             let baseline = try openDescriptorCount(for: tempPath)
-            var handlerCalls = 0
+            let handlerCalls = Mutex(0)
 
             for _ in 0..<32 {
                 do {
                     try await watcher._startWatching { _ in
-                        handlerCalls += 1
+                        handlerCalls.withLock { $0 += 1 }
                         throw ContainerizationError(.internalError, message: "intentional test failure")
                     }
                     Issue.record("expected the failing watch handler to throw")
@@ -154,7 +176,7 @@ struct DirectoryWatcherTest {
             }
 
             let afterFailures = try openDescriptorCount(for: tempPath)
-            #expect(handlerCalls == 32)
+            #expect(handlerCalls.withLock { $0 } == 32)
             #expect(
                 afterFailures == baseline,
                 "failing handlers leaked descriptors: before=\(baseline), after=\(afterFailures)"
@@ -175,28 +197,27 @@ struct DirectoryWatcherTest {
             await watcher.startWatching { [createdPaths] paths in
                 for path in paths
                 where path.lastComponent?.string == beforeDelete || path.lastComponent?.string == afterDelete {
-                    createdPaths.paths.append(path)
+                    createdPaths.append(path)
                 }
             }
 
-            try await Task.sleep(for: .milliseconds(100))
             let file1 = dirPath.appending(beforeDelete)
             FileManager.default.createFile(atPath: file1.string, contents: nil)
-            try await Task.sleep(for: .milliseconds(100))
+            #expect(
+                await waitForPaths([beforeDelete], in: createdPaths),
+                "directory watcher failed to detect file before directory recreation"
+            )
 
             try FileManager.default.removeItem(atPath: dirPath.string)
-            try await Task.sleep(for: .milliseconds(100))
             try FileManager.default.createDirectory(atPath: dirPath.string, withIntermediateDirectories: true)
-            try await Task.sleep(for: DirectoryWatcher.watchPeriod)
 
             let file2 = dirPath.appending(afterDelete)
             FileManager.default.createFile(atPath: file2.string, contents: nil)
 
-            try await Task.sleep(for: .milliseconds(500))
-
-            #expect(!createdPaths.paths.isEmpty, "directory watcher failed to detect new file")
             #expect(
-                Set(createdPaths.paths.compactMap { $0.lastComponent?.string }) == Set([beforeDelete, afterDelete]))
+                await waitForPaths([beforeDelete, afterDelete], in: createdPaths),
+                "directory watcher failed to detect file after directory recreation"
+            )
         }
 
     }

--- a/Tests/ContainerOSTests/DirectoryWatcherTest.swift
+++ b/Tests/ContainerOSTests/DirectoryWatcherTest.swift
@@ -50,8 +50,8 @@ struct DirectoryWatcherTest {
     private final class CreatedPaths: Sendable {
         private let paths = Mutex<[FilePath]>([])
 
-        func append(_ path: FilePath) {
-            paths.withLock { $0.append(path) }
+        func record(_ paths: [FilePath]) {
+            self.paths.withLock { $0.append(contentsOf: paths) }
         }
 
         func contains(_ expectedNames: Set<String>) -> Bool {
@@ -62,22 +62,39 @@ struct DirectoryWatcherTest {
         }
     }
 
-    private func waitForPaths(
-        _ expectedNames: Set<String>,
-        in createdPaths: CreatedPaths,
-        timeout: Duration = .seconds(5)
+    private func waitUntil(
+        timeout: Duration = .seconds(5),
+        _ condition: () async -> Bool
     ) async -> Bool {
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: timeout)
 
         while clock.now < deadline {
-            if createdPaths.contains(expectedNames) {
+            if await condition() {
                 return true
             }
             try? await Task.sleep(for: .milliseconds(25))
         }
 
-        return createdPaths.contains(expectedNames)
+        return await condition()
+    }
+
+    private func waitForPaths(
+        _ expectedNames: Set<String>,
+        in createdPaths: CreatedPaths
+    ) async -> Bool {
+        await waitUntil {
+            createdPaths.contains(expectedNames)
+        }
+    }
+
+    private func waitForWatcher(
+        _ watcher: DirectoryWatcher,
+        toBeWatching expected: Bool = true
+    ) async -> Bool {
+        await waitUntil {
+            await watcher.isWatching == expected
+        }
     }
 
     @Test func testWatchingExistingDirectory() async throws {
@@ -88,11 +105,10 @@ struct DirectoryWatcherTest {
             let name = "newFile"
 
             await watcher.startWatching { [createdPaths] paths in
-                for path in paths where path.lastComponent?.string == name {
-                    createdPaths.append(path)
-                }
+                createdPaths.record(paths)
             }
 
+            try #require(await waitForWatcher(watcher), "directory watcher did not initialise")
             let newFile = tempPath.appending(name)
             FileManager.default.createFile(atPath: newFile.string, contents: nil)
 
@@ -113,12 +129,11 @@ struct DirectoryWatcherTest {
             let name = "newFile"
 
             await watcher.startWatching { [createdPaths] paths in
-                for path in paths where path.lastComponent?.string == name {
-                    createdPaths.append(path)
-                }
+                createdPaths.record(paths)
             }
 
             try FileManager.default.createDirectory(atPath: childPath.string, withIntermediateDirectories: true)
+            try #require(await waitForWatcher(watcher), "directory watcher did not initialise")
             let newFile = childPath.appending(name)
             FileManager.default.createFile(atPath: newFile.string, contents: nil)
 
@@ -140,12 +155,11 @@ struct DirectoryWatcherTest {
             let name = "newFile"
 
             await watcher.startWatching { paths in
-                for path in paths where path.lastComponent?.string == name {
-                    createdPaths.append(path)
-                }
+                createdPaths.record(paths)
             }
 
             try FileManager.default.createDirectory(atPath: childPath.string, withIntermediateDirectories: true)
+            try #require(await waitForWatcher(watcher), "directory watcher did not initialise")
 
             let newFile = childPath.appending(name)
             FileManager.default.createFile(atPath: newFile.string, contents: nil)
@@ -195,21 +209,27 @@ struct DirectoryWatcherTest {
             let afterDelete = "afterDelete"
 
             await watcher.startWatching { [createdPaths] paths in
-                for path in paths
-                where path.lastComponent?.string == beforeDelete || path.lastComponent?.string == afterDelete {
-                    createdPaths.append(path)
-                }
+                createdPaths.record(paths)
             }
 
+            try #require(await waitForWatcher(watcher), "directory watcher did not initialise")
             let file1 = dirPath.appending(beforeDelete)
             FileManager.default.createFile(atPath: file1.string, contents: nil)
-            #expect(
+            try #require(
                 await waitForPaths([beforeDelete], in: createdPaths),
                 "directory watcher failed to detect file before directory recreation"
             )
 
             try FileManager.default.removeItem(atPath: dirPath.string)
+            try #require(
+                await waitForWatcher(watcher, toBeWatching: false),
+                "directory watcher did not stop after directory removal"
+            )
             try FileManager.default.createDirectory(atPath: dirPath.string, withIntermediateDirectories: true)
+            try #require(
+                await waitForWatcher(watcher),
+                "directory watcher did not resume after directory recreation"
+            )
 
             let file2 = dirPath.appending(afterDelete)
             FileManager.default.createFile(atPath: file2.string, contents: nil)


### PR DESCRIPTION
> [!IMPORTANT]
> All commits are signed and verified.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
During testing of my Container Compose plugin, I found and fixed a path-specific file-descriptor leak in `DirectoryWatcher`. `_startWatching` opens an `O_EVTONLY` descriptor before it lists the directory and calls the handler. If either operation throws, the dispatch source that normally owns and closes the descriptor is never created. The retry loop can therefore leak one descriptor on every failed startup.

This submission retains the correct production fix from #1773 and credits its author, @muk2. It supersedes that proposal with deterministic regression coverage: the test identifies only descriptors whose `F_GETPATH` resolves to the watched directory, verifies the failing handler ran exactly 32 times, and requires the path-specific count to return to its exact baseline. It also accepts valid descriptor zero, makes the internal escaping handler contract `@Sendable`, and replaces fixed-sleep test races with explicit watcher readiness and restart synchronisation, bounded condition polling, and locked snapshots.

This PR deliberately does not close #1097. That issue reproduces descriptor growth from guest filesystem traversal through virtiofs, while `DirectoryWatcher` is used by the host DNS resolver configuration watcher. The available evidence does not establish that this code path causes #1097.

Fixes #2034

### Reproduction on stock Apple `main`

Base tested: `48145ac7fb177d9fb14e015a0bdea4c642b36729`. A test-only visibility and `@Sendable` annotation were applied to the stock method so the regression test could invoke it; the stock descriptor guard and missing error-path `close` were left unchanged.

```console
/usr/bin/swift test --skip-build -c debug \
  -Xswiftc -warnings-as-errors -Xswiftc -enable-testing \
  --filter testFailingHandlerDoesNotLeakDescriptors
```

Actual stock result: the single test fails in 0.010 seconds with `baseline=0` and `afterFailures=32`.

Expected result: after 32 intentional handler failures, the number of descriptors resolving to the watched path equals the baseline.

### Changes

- Close the opened descriptor when directory enumeration or the initial handler throws.
- Treat descriptor zero as a successful `open` result.
- Require the stored handler to be `@Sendable`, matching the public API and dispatch-source use.
- Replace the process-wide descriptor threshold with exact path-specific leak detection.
- Verify all 32 handler invocations occurred.
- Replace fixed sleeps and force unwraps in existing watcher tests with explicit watcher-state synchronisation, locked snapshots, bounded condition polling, and phase-gating requirements.
- Remove the obsolete watcher fixture and its unnecessary force unwrap.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

- `make check`: passed in 4.84 seconds wall time.
- `swift test --filter DirectoryWatcherTest`: 5 tests in 1 suite passed in 1.081 seconds on the final head; 5.84 seconds wall time including the incremental build.
- Stability run: 10 consecutive `swift test --filter DirectoryWatcherTest` attempts passed, 50 tests total; suite times remained between 1.062 and 1.092 seconds, with cached wall times between 1.89 and 1.97 seconds after the first build refresh.
- `make test`: 590 tests in 71 suites passed in 1.266 seconds on the final head; 114.91 seconds wall time including the 105.82-second full rebuild.
- Stock negative control: the targeted test failed as expected in 0.010 seconds, reporting exactly 32 leaked descriptors for the watched path; 0.63 seconds wall time.
- `git diff --check`: passed.
- All seven commits verified with the configured signing key.