### PR TITLE
Start default machine shell as a login shell

### DIFF
--- a/Sources/Plugins/MachineAPIServer/Resources/init
+++ b/Sources/Plugins/MachineAPIServer/Resources/init
@@ -51,7 +51,7 @@ if [ "$1" = "-s" ]; then
     if [ $# -gt 0 ]; then
         exec "${USER_SHELL:-${SHELL}}" -c "$*"
     else
-        exec "${USER_SHELL:-${SHELL}}"
+        exec "${USER_SHELL:-${SHELL}}" -l
     fi
 elif [ "$1" = "-u" ]; then
     # DEPRECATED 0.11.0.0 - use `id` instead of checking `${MACHINE_INITIALIZED}` for backward compatibility, remove in 0.13.0.0

--- a/Tests/IntegrationTests/Machine/TestCLIMachineRuntimeSerial.swift
+++ b/Tests/IntegrationTests/Machine/TestCLIMachineRuntimeSerial.swift
@@ -148,6 +148,33 @@ struct TestCLIMachineRuntimeSerial {
         }
     }
 
+    @Test func testDefaultRunStartsLoginShell() async throws {
+        try await ContainerFixture.with { f in
+            let name = "\(f.testID)-machine"
+            f.addCleanup { f.cleanupMachine(name) }
+            try f.doMachineCreate(name: name, image: machineImage)
+            try f.doMachineBoot(name: name)
+            try await f.waitForMachineStatus(name, status: "running")
+
+            let sentinel = "login-shell-\(UUID().uuidString)"
+            let marker = "/tmp/\(sentinel)"
+            _ = try f.doMachineRun(
+                name: name,
+                command: ["printf", "'touch \(marker)\\n'", ">", "$HOME/.profile"]
+            )
+
+            try f.runMachine(["run", "--detach", "-n", name]).check(
+                "default machine run should start a login shell")
+            try await Task.sleep(for: .seconds(1))
+            let result = try f.runMachine(["run", "-n", name, "test", "-f", marker])
+
+            #expect(
+                result.status == 0,
+                "default machine shell did not source ~/.profile"
+            )
+        }
+    }
+
     @Test func testRunAsRoot() async throws {
         try await ContainerFixture.with { f in
             let name = "\(f.testID)-machine"


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

`container machine run` documents its default behavior as starting a login shell, but the machine init helper invoked the resolved shell without its login option. As a result, startup files such as `~/.profile` were not sourced.

Invoke the default shell with `-l` while leaving the explicit command path unchanged.

Fixes #1991.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

Added a focused integration regression that verifies the default shell sources `~/.profile`. Confirmed it failed before the change and passed afterward.

`make check` passes.