### PR TITLE
Fix launchctl bootstrap failures being discarded as XPC errors

### DIFF
--- a/Sources/ContainerPlugin/ServiceManager.swift
+++ b/Sources/ContainerPlugin/ServiceManager.swift
@@ -18,25 +18,45 @@ import ContainerizationError
 import Foundation
 
 public struct ServiceManager {
-    private static func runLaunchctlCommand(args: [String]) throws -> Int32 {
+    private static func runLaunchctlCommand(args: [String]) throws -> (status: Int32, stderr: String) {
         let launchctl = Foundation.Process()
         launchctl.executableURL = URL(fileURLWithPath: "/bin/launchctl")
         launchctl.arguments = args
 
         let null = FileHandle.nullDevice
+        let stderrPipe = Pipe()
         launchctl.standardOutput = null
-        launchctl.standardError = null
+        launchctl.standardError = stderrPipe
 
         try launchctl.run()
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
         launchctl.waitUntilExit()
 
-        return launchctl.terminationStatus
+        let stderr = String(data: stderrData, encoding: .utf8) ?? ""
+        return (launchctl.terminationStatus, stderr)
     }
 
     /// Register a service by providing the path to a plist.
     public static func register(plistPath: String) throws {
         let domain = try Self.getDomainString()
-        _ = try runLaunchctlCommand(args: ["bootstrap", domain, plistPath])
+        let command = "launchctl bootstrap \(domain) \(plistPath)"
+        let (status, stderr) = try runLaunchctlCommand(args: ["bootstrap", domain, plistPath])
+        guard status == 0 else {
+            // `container system start` is idempotent: if the service is already
+            // bootstrapped, launchctl returns non-zero. Treat that as success.
+            // Use try? so a launchctl spawn failure does not replace the bootstrap error.
+            if let label = try? launchdLabel(fromPlistAt: plistPath),
+                (try? isRegistered(fullServiceLabel: label)) == true
+            {
+                return
+            }
+            let detail = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            let message =
+                detail.isEmpty
+                ? "command `\(command)` failed with status \(status)"
+                : "command `\(command)` failed with status \(status), message: \(detail)"
+            throw ContainerizationError(.internalError, message: message)
+        }
     }
 
     /// Deregister a service by a launchd label.
@@ -46,7 +66,7 @@ public struct ServiceManager {
 
     /// Deregister a service and pass return status
     public static func deregister(fullServiceLabel label: String, status: inout Int32) throws {
-        status = try runLaunchctlCommand(args: ["bootout", label])
+        status = try runLaunchctlCommand(args: ["bootout", label]).status
     }
 
     /// Restart a service by a launchd label.
@@ -94,7 +114,7 @@ public struct ServiceManager {
 
     /// Check if a service has been registered or not.
     public static func isRegistered(fullServiceLabel label: String) throws -> Bool {
-        let exitStatus = try runLaunchctlCommand(args: ["list", label])
+        let exitStatus = try runLaunchctlCommand(args: ["list", label]).status
         return exitStatus == 0
     }
 
@@ -122,16 +142,31 @@ public struct ServiceManager {
     }
 
     public static func getDomainString() throws -> String {
-        let currentSessionType = try getLaunchdSessionType()
-        switch currentSessionType {
+        try domainString(sessionType: getLaunchdSessionType(), uid: getuid())
+    }
+
+    /// Compute the launchd domain target for the given session and credentials.
+    static func domainString(sessionType: String, uid: uid_t) throws -> String {
+        switch sessionType {
         case LaunchPlist.Domain.System.rawValue:
             return LaunchPlist.Domain.System.rawValue.lowercased()
         case LaunchPlist.Domain.Background.rawValue:
-            return "user/\(getuid())"
+            return "user/\(uid)"
         case LaunchPlist.Domain.Aqua.rawValue:
-            return "gui/\(getuid())"
+            return "gui/\(uid)"
         default:
-            throw ContainerizationError(.internalError, message: "unsupported session type \(currentSessionType)")
+            throw ContainerizationError(.internalError, message: "unsupported session type \(sessionType)")
         }
+    }
+
+    private static func launchdLabel(fromPlistAt path: String) throws -> String {
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
+        guard let dict = plist as? [String: Any],
+            let label = dict[LaunchPlist.CodingKeys.label.rawValue] as? String
+        else {
+            throw ContainerizationError(.internalError, message: "launchd plist at \(path) is missing Label")
+        }
+        return label
     }
 }

--- a/Tests/ContainerPluginTests/ServiceManagerTests.swift
+++ b/Tests/ContainerPluginTests/ServiceManagerTests.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025-2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Testing
+
+@testable import ContainerPlugin
+
+struct ServiceManagerTests {
+    @Test
+    func domainStringAquaUsesGuiDomain() throws {
+        #expect(try ServiceManager.domainString(sessionType: "Aqua", uid: 501) == "gui/501")
+    }
+
+    @Test
+    func domainStringBackgroundUsesUserDomain() throws {
+        #expect(try ServiceManager.domainString(sessionType: "Background", uid: 501) == "user/501")
+    }
+
+    @Test
+    func domainStringSystemSessionUsesSystemDomain() throws {
+        #expect(try ServiceManager.domainString(sessionType: "System", uid: 0) == "system")
+    }
+
+    @Test
+    func domainStringUnsupportedSessionThrows() {
+        #expect(throws: (any Error).self) {
+            try ServiceManager.domainString(sessionType: "LoginWindow", uid: 501)
+        }
+    }
+
+    @Test
+    func registerSurfacesLaunchctlBootstrapFailure() throws {
+        let missingPlist = "/tmp/container-issue-2008-missing-\(UUID().uuidString).plist"
+        do {
+            try ServiceManager.register(plistPath: missingPlist)
+            Issue.record("expected register to throw for missing plist")
+        } catch {
+            let message = String(describing: error)
+            #expect(message.contains("launchctl bootstrap"))
+            #expect(message.contains(missingPlist))
+            #expect(message.contains("failed with status"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Surface `launchctl bootstrap` exit status and stderr from `ServiceManager.register` instead of continuing into a misleading apiserver XPC error.
- Keep `container system start` idempotent when the service is already registered.
- Add unit tests for domain selection helpers and a real `launchctl` failure path for error surfacing.

The system-domain bootstrap change for root outside Aqua is intentionally left to a follow-up PR so this half can merge on its own evidence.

Fixes #2008

## Test plan
### Tested
- [x] `swift test --filter ServiceManagerTests` (5 tests, all passing after rebase)
- [x] Real `launchctl` failure via `ServiceManager.register` with a missing plist; error includes `launchctl bootstrap` and status
- [x] Local Aqua `system start`: `register()` loaded `com.apple.container.apiserver` and the process started

### Not in this PR
- [ ] Root outside Aqua bootstrapping into the `system` domain (follow-up)
- [ ] Exact GitHub Actions `macos-26` Background / non-login `sudo container system start` reproduction