### PR TITLE
docs: note Time Machine exclusion for Application Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ To retain your user data so that it is available should you reinstall later, run
 - Learn how to [use various `container` features](./docs/how-to.md).
 - Read a brief description and [technical overview](./docs/technical-overview.md) of `container`.
 - Browse the [full command reference](./docs/command-reference.md).
+- See answers to [common questions](./docs/faq.md), including Time Machine and sparse disk images.
 - [Build and run](./BUILDING.md) `container` on your own development system.
 - View the project [API documentation](https://apple.github.io/container/documentation/).
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,29 @@
+# FAQ
+
+> [!IMPORTANT]
+> This file contains documentation for the CURRENT BRANCH. To find documentation for official releases, find the target release on the [Release Page](https://github.com/apple/container/releases) and click the tag corresponding to your release version.
+>
+> Example: [release 0.4.1 tag](https://github.com/apple/container/tree/0.4.1)
+
+## Why do files under Application Support look enormous?
+
+`container` keeps Linux disk images (including builder `initfs`/`rootfs` and snapshot files) under `~/Library/Application Support/com.apple.container`. Those images are sparse files: Finder and some tools report the apparent size (often hundreds of gigabytes or more), not the much smaller amount of space actually allocated on disk.
+
+To inspect on-disk usage, use:
+
+```bash
+du -h ~/Library/Application\ Support/com.apple.container
+ls -lhs ~/Library/Application\ Support/com.apple.container
+```
+
+## Time Machine backups hang or grow unexpectedly
+
+Some Time Machine destinations have trouble with these sparse files. Backups may stall for a long time, or the files may expand toward their full apparent size on the backup volume (this is especially common with HFS+ destinations, and has also been reported with some APFS and network backups).
+
+If Time Machine gets stuck on `container` data, exclude the application support directory:
+
+```bash
+sudo tmutil addexclusion -p ~/Library/Application\ Support/com.apple.container
+```
+
+That directory is recreated as needed when missing, so excluding it from Time Machine is a safe workaround. If you need durable copies of images, use `container image save` instead of relying on Time Machine for this path.


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context
`container` stores sparse disk images under `~/Library/Application Support/com.apple.container`. Their apparent size can look enormous in Finder and can stall or inflate Time Machine backups. Maintainers asked for FAQ / known-issue docs covering the sparse-file explanation and excluding that directory from Time Machine.

Fixes #497

## Testing
- [ ] Tested locally
- [ ] Added/updated tests
- [x] Added/updated docs

Docs-only change: added `docs/faq.md` and linked it from the README.