### PR TITLE
Adjust overcommit and max_map_count vm defaults in guest VMs

### DIFF
--- a/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
+++ b/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
@@ -997,9 +997,12 @@ public actor RuntimeService {
         czConfig.cpus = config.resources.cpus
         czConfig.cpuOverhead = config.resources.cpuOverhead
         czConfig.memoryInBytes = config.resources.memoryInBytes
-        czConfig.sysctl = config.sysctls.reduce(into: [String: String]()) {
-            $0[$1.key] = $1.value
-        }
+        // Overcommit memory and allow more memory mappings than the kernel default
+        // so workloads inside swap-less guest VMs hit limits less easily.
+        var sysctls = config.sysctls
+        sysctls["vm.overcommit_memory"] = "1"
+        sysctls["vm.max_map_count"] = "262144"
+        czConfig.sysctl = sysctls
         // If the host doesn't support this, we'll throw on container creation.
         czConfig.virtualization = config.virtualization
         czConfig.useInit = config.useInit


### PR DESCRIPTION
## Type of Change

- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Description

Each container runs in its own guest VM sized to `--memory` with no swap, so the guest kernel's stock `vm` sysctl defaults are hit far too easily:

- `vm.overcommit_memory=0` (heuristic overcommit) rejects an oversized `mmap()` upfront whenever the reservation exceeds the small, swap-less VM's free RAM — even if the memory is never touched — returning `ENOMEM`.
- `vm.max_map_count=65530` caps per-process mapping count, which mapping-heavy applications (e.g. Elasticsearch, many JVMs) legitimately exceed.

Fixes #2053

## Motivation and Context

These stock defaults cause common oversubscribed-`mmap` and many-mapping workloads to fail inside a container even though they work on a typical host. This PR applies container-friendly defaults at container start so these workloads succeed, while actual memory usage remains enforced by the container's existing `--memory` limit (via cgroup memory limit and the OOM killer).

## Implementation

- `Sources/Services/RuntimeLinux/Server/RuntimeService.swift`: set `vm.overcommit_memory=1` and `vm.max_map_count=262144` as defaults when configuring a container's guest sysctls.