### PR TITLE
Surface a clear error when system start cannot write app-root

### DIFF
--- a/Sources/ContainerCommands/System/SystemStart.swift
+++ b/Sources/ContainerCommands/System/SystemStart.swift
@@ -73,7 +73,15 @@ extension Application {
         public init() {}
 
         public func run() async throws {
-            try ConfigurationLoader.copyConfigurationToReadOnly(to: appRoot)
+            do {
+                try ConfigurationLoader.copyConfigurationToReadOnly(to: appRoot)
+            } catch {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message:
+                        "cannot prepare configuration under app-root \(appRoot): path must be writable (\(error.localizedDescription))"
+                )
+            }
             // Pass appRoot before installRoot: ConfigurationLoader uses first-match-wins
             // precedence, so user-provided config in appRoot overrides the defaults
             // shipped under installRoot. Both layers are passed explicitly because
@@ -103,8 +111,7 @@ extension Application {
             }
 
             let apiServerDataPath = appRoot.appending(FilePath.Component("apiserver"))
-            let apiServerDataURL = URL(fileURLWithPath: apiServerDataPath.string)
-            try FileManager.default.createDirectory(at: apiServerDataURL, withIntermediateDirectories: true)
+            try Self.ensureWritableDirectory(at: apiServerDataPath)
 
             var env = PluginLoader.filterEnvironment()
             env[ApplicationRoot.environmentName] = appRoot.string
@@ -124,7 +131,15 @@ extension Application {
             let plistPath = apiServerDataPath.appending(FilePath.Component("apiserver.plist"))
             let plistURL = URL(fileURLWithPath: plistPath.string)
             let data = try plist.encode()
-            try data.write(to: plistURL)
+            do {
+                try data.write(to: plistURL)
+            } catch {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message:
+                        "cannot write apiserver launchd plist at \(plistPath): app-root must be writable (\(error.localizedDescription))"
+                )
+            }
 
             log.info("Launching container-apiserver...")
             try ServiceManager.register(plistPath: plistURL.path)
@@ -220,6 +235,23 @@ extension Application {
                 return true
             } catch {
                 return false
+            }
+        }
+
+        /// Create `path` if needed, surfacing a clear error when the app-root is not writable.
+        ///
+        /// Prefer this over a bare `FileManager` call so permission failures become a normal
+        /// CLI error instead of an opaque Cocoa error (see apple/container#1802).
+        static func ensureWritableDirectory(at path: FilePath) throws {
+            let url = URL(fileURLWithPath: path.string)
+            do {
+                try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+            } catch {
+                throw ContainerizationError(
+                    .invalidArgument,
+                    message:
+                        "cannot create application data directory at \(path): app-root must be writable (\(error.localizedDescription))"
+                )
             }
         }
     }

--- a/Tests/ContainerCommandsTests/SystemStartAppRootTests.swift
+++ b/Tests/ContainerCommandsTests/SystemStartAppRootTests.swift
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2025-2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerizationError
+import Foundation
+import SystemPackage
+import Testing
+
+@testable import ContainerCommands
+
+struct SystemStartAppRootTests {
+    @Test
+    func ensureWritableDirectorySucceedsForWritableParent() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("container-approot-ok-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let child = FilePath(root.path).appending("apiserver")
+        try Application.SystemStart.ensureWritableDirectory(at: child)
+        #expect(FileManager.default.fileExists(atPath: child.string))
+    }
+
+    @Test
+    func ensureWritableDirectoryThrowsClearErrorForReadOnlyParent() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("container-approot-ro-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: root.path)
+            try? FileManager.default.removeItem(at: root)
+        }
+        try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: root.path)
+
+        let child = FilePath(root.path).appending("apiserver")
+        do {
+            try Application.SystemStart.ensureWritableDirectory(at: child)
+            Issue.record("expected ensureWritableDirectory to throw for a read-only app-root")
+        } catch let error as ContainerizationError {
+            let message = error.description
+            #expect(message.contains("app-root must be writable"))
+            #expect(message.contains(child.string) || message.contains("apiserver"))
+        } catch {
+            Issue.record("expected ContainerizationError, got \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Wrap app-root directory creation and apiserver plist writes so a non-writable `--app-root` fails with a clear `ContainerizationError` instead of an opaque Cocoa / fatal path.
- Note: the original `try!` crash was already fixed in #1785; this finishes the user-facing side of #1802 with actionable messaging and regression coverage.

Closes #1802

## Test plan
### Tested
- [x] `swift test --filter SystemStartAppRootTests` (2/2 passed)
  - writable parent creates the directory
  - read-only parent throws a message containing `app-root must be writable`
- [x] CLI repro with a build of this branch:
  ```sh
  ROOT=$(mktemp -d /tmp/container-approot-ro.XXXXXX)
  chmod 555 "$ROOT"
  bin/container system start --app-root "$ROOT" --disable-kernel-install
  ```
  - Exit code `1` (not `133`)
  - No `Fatal error` / `try!`
  - Error: `cannot create application data directory ... app-root must be writable`

### Not tested
- [ ] GitHub Actions PR build on apple/container

