### PR TITLE
Increase testExecDetachProcessRunning sleep margin to avoid CI flake

### DIFF
--- a/Tests/IntegrationTests/Containers/TestCLIExecCommand.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIExecCommand.swift
@@ -77,14 +77,15 @@ struct TestCLIExecCommand {
             try f.doStart(name)
             try await f.waitForContainerRunning(name)
 
-            let output = try f.doExec(name, cmd: ["sleep", "10"], detach: true)
+            // Generous duration: ContainersService's host-wide lock can queue this exec's start behind other containers' multi-second VM boots.
+            let output = try f.doExec(name, cmd: ["sleep", "60"], detach: true)
             try #require(
                 output.trimmingCharacters(in: .whitespacesAndNewlines) == name,
                 "exec --detach should print the container name")
 
             let ps = try f.doExec(name, cmd: ["ps", "aux"])
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-            try #require(ps.contains("sleep 10"), "detached 'sleep 10' should appear in ps output")
+            try #require(ps.contains("sleep 60"), "detached 'sleep 60' should appear in ps output")
 
             try f.doStop(name)
         }


### PR DESCRIPTION
ContainersService serializes exec starts on a single host-wide lock shared with container bootstrap (VM boot), so under concurrent test load a detached exec can queue for 10+ seconds before it even runs. sleep 10 could fully exit before the assertion ran; bump to sleep 60 for margin.