### PR TITLE
Add --sysctl and --privileged flags to run/create

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/Flags.swift
+++ b/Sources/Services/ContainerAPIService/Client/Flags.swift
@@ -191,6 +191,8 @@ public struct Flags {
             runtime: String?,
             ssh: Bool,
             shmSize: String?,
+            sysctl: [String] = [],
+            privileged: Bool = false,
             tmpFs: [String],
             useInit: Bool,
             virtualization: Bool,
@@ -221,6 +223,8 @@ public struct Flags {
             self.runtime = runtime
             self.ssh = ssh
             self.shmSize = shmSize
+            self.sysctl = sysctl
+            self.privileged = privileged
             self.tmpFs = tmpFs
             self.useInit = useInit
             self.virtualization = virtualization
@@ -344,6 +348,15 @@ public struct Flags {
 
         @Option(name: .customLong("shm-size"), help: "Size of /dev/shm (e.g. 64M, 1G)")
         public var shmSize: String?
+
+        @Option(
+            name: .long,
+            help: .init("Set a sysctl in the container (format: key=value, repeatable)", valueName: "key=value")
+        )
+        public var sysctl: [String] = []
+
+        @Flag(name: .long, help: "Give the container the full capability set and disable the default masked and read-only paths")
+        public var privileged = false
 
         @Option(name: .customLong("tmpfs"), help: "Add a tmpfs mount to the container at the given path")
         public var tmpFs: [String] = []

--- a/Sources/Services/ContainerAPIService/Client/Parser.swift
+++ b/Sources/Services/ContainerAPIService/Client/Parser.swift
@@ -1024,6 +1024,18 @@ public struct Parser {
 
     /// Parse and validate --cap-add / --cap-drop arguments.
     /// Returns normalized uppercase CAP_* strings.
+    public static func sysctls(_ rawSysctls: [String]) throws -> [String: String] {
+        var result: [String: String] = Dictionary(minimumCapacity: rawSysctls.count)
+        for item in rawSysctls {
+            let parts = item.split(separator: "=", maxSplits: 2)
+            guard parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty else {
+                throw ContainerizationError(.invalidArgument, message: "invalid sysctl format \(item) — expected key=value")
+            }
+            result[String(parts[0])] = String(parts[1])
+        }
+        return result
+    }
+
     public static func capabilities(capAdd: [String], capDrop: [String]) throws -> (capAdd: [String], capDrop: [String]) {
         var normalizedAdd: [String] = []
         normalizedAdd.reserveCapacity(capAdd.count)

--- a/Sources/Services/ContainerAPIService/Client/Utility.swift
+++ b/Sources/Services/ContainerAPIService/Client/Utility.swift
@@ -257,6 +257,18 @@ public struct Utility {
         config.capDrop = caps.capDrop
         config.stopSignal = imageConfig?.stopSignal
 
+        config.sysctls = try Parser.sysctls(management.sysctl)
+
+        if management.privileged {
+            // Docker-compatible privileged mode: the full capability set and
+            // none of the default masked/read-only paths. Proportionate here
+            // because every guest is its own VM with its own kernel.
+            config.capAdd = ["ALL"]
+            config.capDrop = []
+            config.maskedPaths = []
+            config.readonlyPaths = []
+        }
+
         if let runtime = management.runtime {
             config.runtimeHandler = runtime
         }

--- a/Tests/ContainerAPIClientTests/ParserTest.swift
+++ b/Tests/ContainerAPIClientTests/ParserTest.swift
@@ -1391,6 +1391,21 @@ struct ParserTest {
         #expect(result.capAdd.first == "ALL")
     }
 
+    @Test("sysctls parses key=value pairs")
+    func testSysctls() throws {
+        let result = try Parser.sysctls(["net.ipv4.ip_forward=1", "vm.max_map_count=262144"])
+        #expect(result["net.ipv4.ip_forward"] == "1")
+        #expect(result["vm.max_map_count"] == "262144")
+        #expect(result.count == 2)
+    }
+
+    @Test("sysctls rejects malformed input")
+    func testSysctlsRejectsMalformed() throws {
+        #expect(throws: ContainerizationError.self) { try Parser.sysctls(["no-equals-sign"]) }
+        #expect(throws: ContainerizationError.self) { try Parser.sysctls(["=1"]) }
+        #expect(throws: ContainerizationError.self) { try Parser.sysctls(["net.ipv4.ip_forward="]) }
+    }
+
     @Test("rlimits with large input")
     func testRlimitsLargeInput() throws {
         let result = try Parser.rlimits(["nofile=1024:2048", "nproc=100:200", "memlock=65536:65536"])


### PR DESCRIPTION
Fixes #2041.

## Problem

container 1.2.0 picked up containerization's secure-by-default changes (default `readonlyPaths` includes `/proc/sys`, restricted capability set) with no CLI opt-out. Guests can no longer write sysctls or remount mounts, so Kubernetes node images (`kindest/node`, `rancher/k3s`) and docker-in-docker engines like dagger fail to boot.

## Change

Two Docker-compatible flags on `run`/`create`:

- `--sysctl key=value` (repeatable): sets guest sysctls at creation. vminitd applies them before the read-only remount, so they compose with the default readonly paths.
- `--privileged`: grants the full capability set and clears the default masked/readonly paths. Every container is its own VM with its own kernel, so an explicit opt-in escape hatch is proportionate and matches Docker's UX.

The API plumbing (`sysctls`, `readonlyPaths`, `maskedPaths` on `ContainerConfiguration`) already existed — this exposes it.

## Verification (against 1.2.0 services)

- `--sysctl net.ipv4.ip_forward=1`: value lands in the guest (`cat` = 1)
- `--privileged` ubuntu: `sysctl -w` succeeds, `mount -o remount,ro /sys` succeeds
- `--privileged` kindest/node:v1.36.1: boots cleanly (containerd active, kubelet starts) — fails hard without the flag
- Added `Parser.sysctls` unit tests (note: `swift test` needs full Xcode; I only had CLT locally, so tests are unrun locally — CI should cover)

Defaults are unchanged: without the flags, behavior is exactly 1.2.0.