### PR TITLE
Send `container machine run` forced-exit diagnostic to stderr

### DIFF
--- a/Sources/ContainerCommands/Machine/MachineRun.swift
+++ b/Sources/ContainerCommands/Machine/MachineRun.swift
@@ -128,8 +128,9 @@ extension Application {
 
             if !tty {
                 var handler = SignalThreshold(threshold: 3, signals: [SIGINT, SIGTERM])
+                let log = self.log
                 handler.start {
-                    print("Received 3 SIGINT/SIGTERM's, forcefully exiting.")
+                    log.warning("Received 3 SIGINT/SIGTERM's, forcefully exiting.")
                     Darwin.exit(1)
                 }
             }


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Part of #642.

`container machine run` installs a `SignalThreshold` handler to report the forced exit after three SIGINT/SIGTERMs, but emits that diagnostic with [`print()`](https://github.com/apple/container/blob/ddaf2ca5ac5629d0555e4a5e04e491de665fd958/Sources/ContainerCommands/Machine/MachineRun.swift#L132), so it goes to stdout.

The identical handler in the sibling commands uses `log.warning()`, which the CLI routes to stderr through `StderrLogHandler`:

- [`ContainerRun.swift#L167`](https://github.com/apple/container/blob/ddaf2ca5ac5629d0555e4a5e04e491de665fd958/Sources/ContainerCommands/Container/ContainerRun.swift#L167)
- [`ContainerExec.swift#L105`](https://github.com/apple/container/blob/ddaf2ca5ac5629d0555e4a5e04e491de665fd958/Sources/ContainerCommands/Container/ContainerExec.swift#L105)

The handler is only installed when `!tty` — precisely when stdout is likely a pipe or a file — so the diagnostic is interleaved into the machine process's redirected output rather than kept on the terminal.

This routes the message to stderr, matching the sibling commands. `let log = self.log` is bound before the closure for the same reason it is in those two: `SignalThreshold.start` takes a `@Sendable @escaping` closure.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

- `swift build -c debug -Xswiftc -warnings-as-errors -Xswiftc -enable-testing` — clean
- `make test` — 613 tests in 71 suites passed
- `swift format lint --strict --configuration .swift-format-nolint` on the changed file — clean
- Confirmed the stream routing with the built binary: logger output goes to stderr (`container image load -i /nonexistent` writes only to stderr) and `print()` output goes to stdout (`container --version`).

I did not exercise the three-signal path end to end, as that needs a booted container machine; the change is a like-for-like swap to the logger the sibling commands already use on that same code path.
