### PR TITLE
Update sudoers file to not include dots

### DIFF
--- a/Sources/Plugins/MachineAPIServer/Resources/create-user.sh
+++ b/Sources/Plugins/MachineAPIServer/Resources/create-user.sh
@@ -42,5 +42,6 @@ fi
 chown -R "${CONTAINER_UID}:${CONTAINER_GID}" "${CONTAINER_HOME}"
 
 mkdir -p /etc/sudoers.d
-echo "${CONTAINER_USER} ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/${CONTAINER_USER}"
-chmod 440 "/etc/sudoers.d/${CONTAINER_USER}"
+sudoers_file=$(echo "${CONTAINER_USER}" | tr '.' '_')
+echo "${CONTAINER_USER} ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/${sudoers_file}"
+chmod 440 "/etc/sudoers.d/${sudoers_file}"


### PR DESCRIPTION
Files under /etc/sudoers.d/ must not contain dots as these will be ignored as "backup-files".

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Many have usernames formated as "first.lastname". These users will currently be ignored by sudoers.

See https://superuser.com/questions/1820104/why-does-sudoers-d-ignore-filenames-with-dots-in-them

## Testing
- [ ] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
