### PR TITLE
Add --masked-path and --read-only-path to container machine create

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -160,8 +160,11 @@ let package = Package(
         .testTarget(
             name: "ContainerCommandsTests",
             dependencies: [
+                .product(name: "Containerization", package: "containerization"),
+                .product(name: "ContainerizationOCI", package: "containerization"),
                 "ContainerCommands",
                 "ContainerResource",
+                "MachineAPIClient",
             ]
         ),
         .testTarget(

--- a/Sources/ContainerCommands/Machine/MachineInspect.swift
+++ b/Sources/ContainerCommands/Machine/MachineInspect.swift
@@ -66,6 +66,8 @@ private struct InspectOutput: Codable {
     let homeMount: MachineConfig.HomeMountOption
     let diskSize: UInt64?
     let ipAddress: String?
+    let maskedPaths: [String]?
+    let readonlyPaths: [String]?
 
     init(_ snapshot: MachineSnapshot) {
         self.id = snapshot.id
@@ -81,5 +83,7 @@ private struct InspectOutput: Codable {
         self.homeMount = snapshot.bootConfig.homeMount
         self.diskSize = snapshot.diskSize
         self.ipAddress = snapshot.ipAddress
+        self.maskedPaths = snapshot.configuration.maskedPaths
+        self.readonlyPaths = snapshot.configuration.readonlyPaths
     }
 }

--- a/Sources/ContainerTestSupport/ContainerFixture+MachineHelpers.swift
+++ b/Sources/ContainerTestSupport/ContainerFixture+MachineHelpers.swift
@@ -43,6 +43,8 @@ public struct MachineInspectOutput: Codable {
     public let homeMount: String?
     public let diskSize: UInt64?
     public let ipAddress: String?
+    public let maskedPaths: [String]?
+    public let readonlyPaths: [String]?
 
     public struct ImageDescription: Codable {
         public let reference: String

--- a/Sources/Services/MachineAPIService/Client/Flags.swift
+++ b/Sources/Services/MachineAPIService/Client/Flags.swift
@@ -29,5 +29,25 @@ extension Flags {
 
         @Option(name: .long, help: "Platform for the image if it's multi-platform. This takes precedence over --os and --arch")
         public var platform: String?
+
+        /// EXPERIMENTAL: The flag is subject to change.
+        @Option(
+            name: .customLong("masked-path"),
+            help: .init(
+                "[EXPERIMENTAL] Hide a path inside the container machine, in addition to the runtime defaults (or NONE to clear prior values and the defaults)",
+                valueName: "path"
+            )
+        )
+        public var maskedPaths: [String] = []
+
+        /// EXPERIMENTAL: The flag is subject to change.
+        @Option(
+            name: .customLong("read-only-path"),
+            help: .init(
+                "[EXPERIMENTAL] Mark a path inside the container machine read-only, in addition to the runtime defaults (or NONE to clear prior values and the defaults)",
+                valueName: "path"
+            )
+        )
+        public var readonlyPaths: [String] = []
     }
 }

--- a/Sources/Services/MachineAPIService/Client/MachineClient.swift
+++ b/Sources/Services/MachineAPIService/Client/MachineClient.swift
@@ -77,7 +77,9 @@ public struct MachineClient: Sendable {
             id: id,
             image: img.description,
             platform: requestedPlatform,
-            userSetup: userSetup)
+            userSetup: userSetup,
+            maskedPaths: try Parser.maskedPaths(management.maskedPaths),
+            readonlyPaths: try Parser.readonlyPaths(management.readonlyPaths))
 
         let resources = try? await Self.fetchMachineArtifact(
             reference: img.reference, platform: requestedPlatform, scheme: scheme)

--- a/Sources/Services/MachineAPIService/Client/MachineConfiguration.swift
+++ b/Sources/Services/MachineAPIService/Client/MachineConfiguration.swift
@@ -55,6 +55,12 @@ public struct MachineConfiguration: Sendable, Codable {
     public var platform: ContainerizationOCI.Platform
     /// User setup from first boot. Nil means provisioning has not run yet.
     public var userSetup: UserSetup
+    /// Paths hidden inside the machine, in addition to the runtime defaults.
+    /// Nil means the runtime defaults apply.
+    public var maskedPaths: [String]?
+    /// Paths marked read-only inside the machine, in addition to the runtime defaults.
+    /// Nil means the runtime defaults apply.
+    public var readonlyPaths: [String]?
 
     public var user: ProcessConfiguration.User {
         userSetup.user
@@ -88,14 +94,27 @@ public struct MachineConfiguration: Sendable, Codable {
         id: String,
         image: ImageDescription,
         platform: ContainerizationOCI.Platform,
-        userSetup: UserSetup
+        userSetup: UserSetup,
+        maskedPaths: [String]? = nil,
+        readonlyPaths: [String]? = nil
     ) throws {
         self.id = id
         self.image = image
         self.platform = platform
         self.userSetup = userSetup
+        self.maskedPaths = maskedPaths
+        self.readonlyPaths = readonlyPaths
 
         try self.validate()
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case image
+        case platform
+        case userSetup
+        case maskedPaths
+        case readonlyPaths
     }
 
     public init(from decoder: Decoder) throws {
@@ -106,8 +125,21 @@ public struct MachineConfiguration: Sendable, Codable {
         self.platform = try container.decode(ContainerizationOCI.Platform.self, forKey: .platform)
         // DEPRECATED 0.11.0.0 - `decodeIfPresent` used for down-revision compatibility, remove in 0.13.0.0
         self.userSetup = try container.decodeIfPresent(UserSetup.self, forKey: .userSetup) ?? UserSetup(username: NSUserName(), uid: getuid(), gid: getgid())
+        self.maskedPaths = try container.decodeIfPresent([String].self, forKey: .maskedPaths)
+        self.readonlyPaths = try container.decodeIfPresent([String].self, forKey: .readonlyPaths)
 
         try self.validate()
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(id, forKey: .id)
+        try container.encode(image, forKey: .image)
+        try container.encode(platform, forKey: .platform)
+        try container.encode(userSetup, forKey: .userSetup)
+        try container.encodeIfPresent(maskedPaths, forKey: .maskedPaths)
+        try container.encodeIfPresent(readonlyPaths, forKey: .readonlyPaths)
     }
 
     private func validate() throws {

--- a/Sources/Services/MachineAPIService/Server/MachinesService.swift
+++ b/Sources/Services/MachineAPIService/Server/MachinesService.swift
@@ -697,6 +697,8 @@ extension MachineConfiguration {
         config.capAdd = ["ALL"]
         config.ssh = true
         config.virtualization = virtualization
+        config.maskedPaths = maskedPaths
+        config.readonlyPaths = readonlyPaths
 
         config.rosetta = platform.architecture == "amd64" && Arch.hostArchitecture() == .arm64
 

--- a/Tests/ContainerCommandsTests/MachineConfigurationTests.swift
+++ b/Tests/ContainerCommandsTests/MachineConfigurationTests.swift
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerResource
+import Containerization
+import ContainerizationOCI
+import Foundation
+import MachineAPIClient
+import Testing
+
+struct MachineConfigurationTests {
+    private func makeConfig(
+        maskedPaths: [String]? = nil,
+        readonlyPaths: [String]? = nil
+    ) throws -> MachineConfiguration {
+        try MachineConfiguration(
+            id: "test-machine",
+            image: ImageDescription(
+                reference: "ghcr.io/linuxcontainers/alpine:3.20",
+                descriptor: Descriptor(
+                    mediaType: "application/vnd.oci.image.manifest.v1+json",
+                    digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                    size: 64
+                )
+            ),
+            platform: Platform(arch: "arm64", os: "linux"),
+            userSetup: UserSetup(username: "tester", uid: 501, gid: 20),
+            maskedPaths: maskedPaths,
+            readonlyPaths: readonlyPaths
+        )
+    }
+
+    @Test func testCodableRoundTripWithoutPaths() throws {
+        let original = try makeConfig()
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(MachineConfiguration.self, from: data)
+
+        #expect(decoded.id == original.id)
+        #expect(decoded.maskedPaths == nil)
+        #expect(decoded.readonlyPaths == nil)
+    }
+
+    @Test func testCodableRoundTripWithPaths() throws {
+        let original = try makeConfig(
+            maskedPaths: ["/run/secrets", "/proc/kcore"],
+            readonlyPaths: ["/etc/config"]
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(MachineConfiguration.self, from: data)
+
+        #expect(decoded.maskedPaths == ["/run/secrets", "/proc/kcore"])
+        #expect(decoded.readonlyPaths == ["/etc/config"])
+    }
+
+    @Test func testDecodeDownRevisionWithoutKeys() throws {
+        // A config.json written by an older version of `container` has no
+        // maskedPaths/readonlyPaths keys; decoding must not fail.
+        let json = """
+            {
+                "id": "test-machine",
+                "image": {
+                    "reference": "ghcr.io/linuxcontainers/alpine:3.20",
+                    "descriptor": {
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                        "size": 64
+                    }
+                },
+                "platform": { "architecture": "arm64", "os": "linux" },
+                "userSetup": { "username": "tester", "uid": 501, "gid": 20 }
+            }
+            """
+        let decoded = try JSONDecoder().decode(
+            MachineConfiguration.self,
+            from: Data(json.utf8)
+        )
+
+        #expect(decoded.id == "test-machine")
+        #expect(decoded.maskedPaths == nil)
+        #expect(decoded.readonlyPaths == nil)
+    }
+}

--- a/Tests/IntegrationTests/Machine/TestCLIMachineSecurityPaths.swift
+++ b/Tests/IntegrationTests/Machine/TestCLIMachineSecurityPaths.swift
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerTestSupport
+import Containerization
+import Foundation
+import Testing
+
+@Suite
+struct TestCLIMachineSecurityPaths {
+    private let machineImage = WarmupImage.alpine320.rawValue
+
+    /// Mount points inside the machine. A masked path is a bind mount of
+    /// /dev/null (files) or an empty tmpfs (directories), and a read-only path
+    /// is a bind mount of itself, so every applied path appears in /proc/mounts.
+    private func mountPoints(_ f: ContainerFixture, _ name: String) throws -> Set<String> {
+        let mounts = try f.doMachineRun(name: name, root: true, command: ["cat", "/proc/mounts"])
+        return Set(
+            mounts.split(separator: "\n").compactMap { line in
+                let fields = line.split(separator: " ")
+                return fields.count > 1 ? String(fields[1]) : nil
+            })
+    }
+
+    private func trimmed(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // MARK: - Invalid paths
+
+    @Test func testMachineCreateRejectsRelativePaths() async throws {
+        try await ContainerFixture.with { f in
+            let masked = try f.runMachine(["create", "--no-boot", "--name", "rel-masked", "--masked-path", "proc/kcore", machineImage])
+            #expect(masked.status != 0)
+            #expect(masked.error.contains("proc/kcore"))
+
+            let readonly = try f.runMachine(["create", "--no-boot", "--name", "rel-readonly", "--read-only-path", "proc/sys", machineImage])
+            #expect(readonly.status != 0)
+            #expect(readonly.error.contains("proc/sys"))
+        }
+    }
+
+    // MARK: - Paths added on top of the defaults
+
+    @Test func testMachineCreateAppliesMaskedAndReadOnlyPaths() async throws {
+        try await ContainerFixture.with { f in
+            let name = "\(f.testID)-machine"
+            f.addCleanup { f.cleanupMachine(name) }
+
+            try f.doMachineCreate(
+                name: name,
+                image: machineImage,
+                extraArgs: ["--masked-path", "/etc/alpine-release", "--read-only-path", "/bin"]
+            )
+
+            // The persisted machine configuration captures the paths, and they
+            // are applied on top of the runtime defaults.
+            let inspect = try f.doMachineInspect(name: name)
+            #expect(inspect.maskedPaths == LinuxContainer.defaultMaskedPaths() + ["/etc/alpine-release"])
+            #expect(inspect.readonlyPaths == LinuxContainer.defaultReadonlyPaths() + ["/bin"])
+
+            // Boot the machine (doMachineRun auto-boots it) and verify the paths
+            // are active inside the guest.
+            let mounted = try mountPoints(f, name)
+            #expect(mounted.contains("/etc/alpine-release"))
+            #expect(mounted.contains("/bin"))
+
+            // A masked file is replaced with /dev/null, so it reads as empty.
+            let size = try f.doMachineRun(
+                name: name, root: true, command: ["sh", "-c", "wc -c < /etc/alpine-release"])
+            #expect(trimmed(size) == "0")
+        }
+    }
+
+    // MARK: - NONE sentinel
+
+    @Test func testMachineCreateNoneClearsDefaults() async throws {
+        try await ContainerFixture.with { f in
+            let name = "\(f.testID)-machine-none"
+            f.addCleanup { f.cleanupMachine(name) }
+
+            try f.doMachineCreate(
+                name: name,
+                image: machineImage,
+                extraArgs: ["--masked-path", "NONE", "--read-only-path", "NONE"]
+            )
+
+            let inspect = try f.doMachineInspect(name: name)
+            #expect(inspect.maskedPaths == [])
+            #expect(inspect.readonlyPaths == [])
+        }
+    }
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1089,6 +1089,8 @@ container machine create [<options>] <image>
 *   `--cpus <cpus>`: Number of virtual CPUs
 *   `--memory <memory>`: Memory allocation (e.g., 2G, 8G). Default: half of system memory
 *   `--home-mount <home-mount>`: User's home directory mount option (ro, rw, none). Default: rw
+*   `--masked-path <path>`: **Experimental.** Hide a path inside the container machine, in addition to the runtime defaults (or `NONE` to clear prior values and the defaults)
+*   `--read-only-path <path>`: **Experimental.** Mark a path inside the container machine read-only, in addition to the runtime defaults (or `NONE` to clear prior values and the defaults)
 *   `--virtualization`: Enable nested virtualization. Requires Apple Silicon M3+ and macOS 15+ and kernel with CONFIG_KVM=y.
 *   `--kernel <path>`: Path to a custom kernel binary (e.g. `vmlinux`).
 
@@ -1124,6 +1126,9 @@ container machine create --no-boot alpine:3.22
 
 # enable nested virtualization with a custom kernel built with CONFIG_KVM=y
 container machine create --virtualization --kernel ./vmlinux-kvm alpine:3.22
+
+# mask and protect paths inside the container machine
+container machine create --masked-path /run/secrets --read-only-path /opt alpine:3.22
 ```
 
 ### `container machine run`

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -527,12 +527,13 @@ Read-only by default:
 
 `/proc/bus`, `/proc/fs`, `/proc/irq`, `/proc/sys`, `/proc/sysrq-trigger`
 
-You can extend either set using `--masked-path` and `--read-only-path` with `container run` or `container create`. Both flags can be repeated, take absolute paths, and add to the defaults rather than replacing them:
+You can extend either set using `--masked-path` and `--read-only-path` with `container run`, `container create`, or `container machine create`. Both flags can be repeated, take absolute paths, and add to the defaults rather than replacing them:
 
 ```console
 % container run --masked-path /etc/alpine-release alpine cat /etc/alpine-release
 % container run --read-only-path /tmp alpine touch /tmp/file
 touch: /tmp/file: Read-only file system
+% container machine create --masked-path /etc/alpine-release --read-only-path /opt alpine:3.22
 ```
 
 To opt out of the defaults entirely, pass the `NONE` sentinel. It clears every path accumulated so far for that flag, including the defaults:
@@ -547,7 +548,7 @@ Because values are processed in order, `NONE` can be followed by a custom set th
 container run --masked-path NONE --masked-path /run/secrets alpine sh
 ```
 
-The two flags are independent, so clearing the masked paths leaves the read-only defaults in place. The paths that a container was created with are visible in `container inspect` under `configuration.maskedPaths` and `configuration.readonlyPaths`; when neither flag is used, both are absent and the runtime defaults apply.
+The two flags are independent, so clearing the masked paths leaves the read-only defaults in place. The paths that a container was created with are visible in `container inspect` under `configuration.maskedPaths` and `configuration.readonlyPaths`; when neither flag is used, both are absent and the runtime defaults apply. For container machines, the paths are fixed when the machine is created and are visible in `container machine inspect` as `maskedPaths` and `readonlyPaths`.
 
 
 ## Expose virtualization capabilities to a container


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Fixes: #2077 

`container run`/`container create` already support `--masked-path` and `--read-only-path` (PR #2069) to hide or protect sensitive paths inside a container. Container machines did not expose the same controls, so users had no way to mask or protect paths inside a machine's backing container.

This PR adds `--masked-path` and `--read-only-path` to `container machine create`. The paths are persisted in the machine's `MachineConfiguration` (create-time only, matching how the machine's platform is fixed) and applied to the backing container at boot. When not specified, the runtime OCI defaults apply; the `NONE` sentinel clears the defaults as it does for `container run`/`create`. The effective paths are surfaced in `container machine inspect` under `maskedPaths` and `readonlyPaths`.

`MachineConfiguration` uses `decodeIfPresent`/`encodeIfPresent` with explicit `CodingKeys` so existing machines from earlier revisions still decode, and new machines are readable by older revisions.