### PR TITLE
Integration test: fix username/uid flake.

### DIFF
--- a/Tests/IntegrationTests/Run/TestCLIRunLifecycle.swift
+++ b/Tests/IntegrationTests/Run/TestCLIRunLifecycle.swift
@@ -29,7 +29,7 @@ struct TestCLIRunLifecycle {
             // First attempt with an invalid user — must fail.
             let failResult = try f.run([
                 "run", "--rm", "--name", name, "-d",
-                "--user", f.testID,  // f.testID won't exist in /etc/passwd
+                "--user", "u-\(f.testID)",  // non-numeric, guaranteed not to exist in /etc/passwd
                 image, "sleep", "infinity",
             ])
             #expect(failResult.status != 0, "expected run to fail with invalid user")


### PR DESCRIPTION
- `TestCLIRunLifecycle.swift.testRunFailureCleanup()` has a flaw where it uses the testID as a `--user` option value. If that value is numeric, the run succeeds and a container is left behind that collides with the next attempt's name.
- Added a non-numeric prefix for the username.