### PR TITLE
Persist container exit codes and surface them on ContainerSnapshot

### DIFF
--- a/Sources/ContainerResource/Container/Bundle.swift
+++ b/Sources/ContainerResource/Container/Bundle.swift
@@ -26,6 +26,10 @@ public struct Bundle: Sendable {
     private static let containerRootFsFilename = "rootfs.json"
 
     static let containerConfigFilename = "config.json"
+    /// Why the container last stopped. Persisted beside the configuration so the
+    /// answer survives an apiserver restart — in memory only, every stopped
+    /// container looks alike after a restart.
+    public static let exitStatusFilename = "exit.json"
 
     /// The path to the bundle.
     public let path: URL
@@ -152,6 +156,16 @@ extension Bundle {
     /// Delete the bundle and all of the resources contained inside.
     public func delete() throws {
         try FileManager.default.removeItem(at: self.path)
+    }
+
+    /// The recorded exit of the container's initial process, if it has stopped at least
+    /// once. Absent for one that has never run.
+    public var exitStatus: ExitRecord? {
+        try? load(filename: Self.exitStatusFilename)
+    }
+
+    public func setExitStatus(_ record: ExitRecord) throws {
+        try write(filename: Self.exitStatusFilename, value: record)
     }
 
     public func write(filename: String, value: Encodable) throws {

--- a/Sources/ContainerResource/Container/ContainerSnapshot.swift
+++ b/Sources/ContainerResource/Container/ContainerSnapshot.swift
@@ -39,16 +39,29 @@ public struct ContainerSnapshot: Codable, Sendable {
     public var networks: [Attachment]
     /// When the container was started.
     public var startedDate: Date?
+    /// The exit code of the container's initial process, once it has exited.
+    ///
+    /// The engine already knew this — the runtime reports it and ExitMonitor
+    /// acts on it — but it was dropped on the floor, so a stopped container was
+    /// indistinguishable from one that had failed. `nil` while running, and for
+    /// containers that were already stopped before the apiserver started.
+    public var exitCode: Int32?
+    /// When the container's initial process exited.
+    public var exitedAt: Date?
 
     public init(
         configuration: ContainerConfiguration,
         status: RuntimeStatus,
         networks: [Attachment],
-        startedDate: Date? = nil
+        startedDate: Date? = nil,
+        exitCode: Int32? = nil,
+        exitedAt: Date? = nil
     ) {
         self.configuration = configuration
         self.status = status
         self.networks = networks
         self.startedDate = startedDate
+        self.exitCode = exitCode
+        self.exitedAt = exitedAt
     }
 }

--- a/Sources/ContainerResource/Container/ContainerStatus.swift
+++ b/Sources/ContainerResource/Container/ContainerStatus.swift
@@ -25,10 +25,24 @@ public struct ContainerStatus: Codable, Sendable {
     public let networks: [Attachment]
     /// When the container was started, if it has been.
     public let startedDate: Date?
+    /// The exit code of the container's initial process, once it has exited.
+    /// `nil` while running, and for containers stopped by an engine that
+    /// predates the recorded exit status.
+    public let exitCode: Int32?
+    /// When the container's initial process exited.
+    public let exitedAt: Date?
 
-    public init(state: RuntimeStatus, networks: [Attachment], startedDate: Date? = nil) {
+    public init(
+        state: RuntimeStatus,
+        networks: [Attachment],
+        startedDate: Date? = nil,
+        exitCode: Int32? = nil,
+        exitedAt: Date? = nil
+    ) {
         self.state = state
         self.networks = networks
         self.startedDate = startedDate
+        self.exitCode = exitCode
+        self.exitedAt = exitedAt
     }
 }

--- a/Sources/ContainerResource/Container/ExitRecord.swift
+++ b/Sources/ContainerResource/Container/ExitRecord.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// How a container's initial process last exited.
+///
+/// Written to the container's bundle when it stops, so the reason outlives the apiserver.
+/// Kept in memory alone, a restart erased it and every stopped container looked identical
+/// — including the one that had crashed.
+public struct ExitRecord: Codable, Sendable, Equatable {
+    public let exitCode: Int32
+    public let exitedAt: Date
+
+    public init(exitCode: Int32, exitedAt: Date) {
+        self.exitCode = exitCode
+        self.exitedAt = exitedAt
+    }
+}

--- a/Sources/ContainerResource/Container/ManagedContainer.swift
+++ b/Sources/ContainerResource/Container/ManagedContainer.swift
@@ -62,7 +62,9 @@ public struct ManagedContainer: ManagedResource {
         self.status = ContainerStatus(
             state: snapshot.status,
             networks: snapshot.networks,
-            startedDate: snapshot.startedDate
+            startedDate: snapshot.startedDate,
+            exitCode: snapshot.exitCode,
+            exitedAt: snapshot.exitedAt
         )
     }
 }

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -992,6 +992,11 @@ public actor ContainersService {
 
         state.snapshot.status = .stopped
         state.snapshot.networks = []
+        // Keep why it stopped, not just that it did.
+        if let code {
+            state.snapshot.exitCode = code.exitCode
+            state.snapshot.exitedAt = code.exitedAt
+        }
         state.client = nil
         await self.setContainerState(id, state, context: context)
 

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -132,12 +132,15 @@ public actor ContainersService {
                     continue
                 }
 
+                let exit = ContainerResource.Bundle(path: dir).exitStatus
                 let state = ContainerState(
                     snapshot: .init(
                         configuration: config,
                         status: .stopped,
                         networks: [],
-                        startedDate: nil
+                        startedDate: nil,
+                        exitCode: exit?.exitCode,
+                        exitedAt: exit?.exitedAt
                     ),
                 )
                 results[config.id] = state
@@ -992,10 +995,19 @@ public actor ContainersService {
 
         state.snapshot.status = .stopped
         state.snapshot.networks = []
-        // Keep why it stopped, not just that it did.
+        // Keep why it stopped, not just that it did — in memory for this apiserver, and
+        // on disk so the answer survives a restart.
         if let code {
             state.snapshot.exitCode = code.exitCode
             state.snapshot.exitedAt = code.exitedAt
+            do {
+                try bundle.setExitStatus(
+                    ExitRecord(exitCode: code.exitCode, exitedAt: code.exitedAt))
+            } catch {
+                self.log.warning(
+                    "failed to record exit status",
+                    metadata: ["id": "\(id)", "error": "\(error)"])
+            }
         }
         state.client = nil
         await self.setContainerState(id, state, context: context)


### PR DESCRIPTION
Companion issue: #1501. Overlaps with draft #1503 — see the comparison below.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

`ContainerSnapshot` exposes `RuntimeStatus.stopped` but not the exit code, so an orchestrator implementing `depends_on: condition: service_completed_successfully` cannot distinguish clean exit from failure — the motivation laid out in #1501.

This implementation surfaces the code and also **persists it in the container bundle**, restoring it at bootstrap. That second half matters because the API server does not run forever: it is restarted by upgrades, crashes, and reboots, and an in-memory-only exit code reads as `nil` afterwards — precisely when an orchestrator polling a one-shot container needs the answer most.

## Description

Two commits, reviewable independently:

1. **Keep the exit code when a container stops** — `ContainerSnapshot` gains `exitCode: Int32?` and `exitedDate: Date?`, populated from the existing `ExitMonitor` callback at the stop transition, and carried through `ContainerStatus` so `container inspect` shows them.
2. **Remember why a container stopped across an apiserver restart** — the exit record is written to the container's bundle (`exit.json`, atomic write) when the container stops, loaded during bootstrap for containers found stopped, and removed on delete with the bundle.

Relationship to draft #1503: same goal and compatible shape for the snapshot field; that draft is snapshot-only, so the code is lost whenever the API server restarts. If the author or maintainers prefer to land #1503 first, the persistence half here rebases cleanly on top of it — either path gets orchestrators a durable answer, which is the property worth having.

We run both commits in production in a GUI embedder of this engine, where the app relaunching the engine is an everyday event rather than an edge case.

## Testing

- `swift test --filter "ContainerResourceTests|ContainerAPIServiceTests"` — 83 tests pass on this branch at abff418.
- Exercised end to end in our release suite: a container that exits is reported with its code by `container inspect`, the engine is restarted, and the same code is still reported.