### PR TITLE
Hide infrastructure images by repository, not exact reference

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/Utility.swift
+++ b/Sources/Services/ContainerAPIService/Client/Utility.swift
@@ -44,8 +44,33 @@ public struct Utility {
             if name == infraImage {
                 return true
             }
+            // Same repository, different tag: still infrastructure. The exact match above
+            // only recognizes the version this build would pull, so the vminit left behind
+            // by the previous engine version surfaced in every image list after an upgrade,
+            // looking like something the user pulled and forgot. Nobody pulls an init or
+            // builder image on purpose; any tag of a configured infra repository is infra.
+            if repository(of: name) == repository(of: infraImage) {
+                return true
+            }
         }
         return false
+    }
+
+    /// The image reference without its tag or digest.
+    ///
+    /// The tag colon is only a colon after the last path separator — splitting on the first
+    /// colon would truncate a registry with a port (`registry.local:5000/repo`) at the port.
+    private static func repository(of reference: String) -> String {
+        var name = reference
+        if let at = name.firstIndex(of: "@") {
+            name = String(name[..<at])
+        }
+        if let colon = name.lastIndex(of: ":"),
+            !name[name.index(after: colon)...].contains("/")
+        {
+            name = String(name[..<colon])
+        }
+        return name
     }
 
     public static func trimDigest(digest: String) -> String {

--- a/Tests/ContainerAPIClientTests/UtilityTests.swift
+++ b/Tests/ContainerAPIClientTests/UtilityTests.swift
@@ -131,4 +131,62 @@ struct UtilityTests {
         #expect(ports[1].proto == .udp)
         #expect(ports[1].count == 100)
     }
+
+    @Test("Infra images are recognized at the configured reference exactly")
+    func testInfraImageExactMatch() {
+        #expect(
+            Utility.isInfraImage(
+                name: "ghcr.io/apple/containerization/vminit:1.0.0",
+                builderImage: "ghcr.io/apple/container-builder-shim/builder:0.5.0",
+                initImage: "ghcr.io/apple/containerization/vminit:1.0.0"))
+    }
+
+    @Test("Infra images are recognized at other tags of the configured repository")
+    func testInfraImageOtherTag() {
+        // The copy left behind by a previous release: same repository, older tag.
+        #expect(
+            Utility.isInfraImage(
+                name: "ghcr.io/apple/containerization/vminit:0.9.0",
+                builderImage: "ghcr.io/apple/container-builder-shim/builder:0.5.0",
+                initImage: "ghcr.io/apple/containerization/vminit:1.0.0"))
+    }
+
+    @Test("Infra images are recognized by digest reference")
+    func testInfraImageDigestReference() {
+        #expect(
+            Utility.isInfraImage(
+                name: "ghcr.io/apple/containerization/vminit@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                builderImage: "ghcr.io/apple/container-builder-shim/builder:0.5.0",
+                initImage: "ghcr.io/apple/containerization/vminit:1.0.0"))
+    }
+
+    @Test("A registry port is not mistaken for a tag")
+    func testInfraImageRegistryPort() {
+        // The tag colon is the one after the last path separator; a bare colon
+        // in the registry host must not truncate the reference at the port.
+        #expect(
+            Utility.isInfraImage(
+                name: "registry.local:5000/infra/vminit:2.0.0",
+                builderImage: "registry.local:5000/infra/vminit:1.0.0",
+                initImage: "ghcr.io/apple/containerization/vminit:1.0.0"))
+        #expect(
+            !Utility.isInfraImage(
+                name: "registry.local:5000/infra/other:1.0.0",
+                builderImage: "registry.local:5000/infra/vminit:1.0.0",
+                initImage: "ghcr.io/apple/containerization/vminit:1.0.0"))
+    }
+
+    @Test("User images sharing only a name suffix are not infra")
+    func testUserImageNotInfra() {
+        #expect(
+            !Utility.isInfraImage(
+                name: "docker.io/library/vminit:1.0.0",
+                builderImage: "ghcr.io/apple/container-builder-shim/builder:0.5.0",
+                initImage: "ghcr.io/apple/containerization/vminit:1.0.0"))
+        #expect(
+            !Utility.isInfraImage(
+                name: "docker.io/library/nginx:alpine",
+                builderImage: "ghcr.io/apple/container-builder-shim/builder:0.5.0",
+                initImage: "ghcr.io/apple/containerization/vminit:1.0.0"))
+    }
 }


### PR DESCRIPTION
Fixes #2088.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

`Utility.isInfraImage` compares full references, so it only recognizes the vminit and builder images at the exact version the running build would pull. After any upgrade that bumps the containerization dependency, the previous version's vminit — same repository, older tag — appears in `container image ls` looking like something the user pulled and forgot. Every user who lives through such an upgrade ends up with one (evidence in #2088).

## Description

Nobody pulls an init or builder image deliberately: any tag of a configured infrastructure repository is infrastructure. The filter keeps the exact-reference match and additionally compares the reference with its tag or digest removed. The tag colon is located after the last path separator, so a registry with a port (`registry.local:5000/repo`) is not truncated at the port; `@digest` suffixes are stripped first.

## Testing

- Five new unit tests in `UtilityTests` cover the exact match, the stale-tag case from #2088, digest references, the registry-port edge, and user images that merely share a name suffix. `swift test --filter UtilityTests`: 17 tests pass on this branch at abff418.
- Verified against a live store that had lived through a containerization 0.35.0 → 0.40.1 upgrade: the leftover `vminit:0.35.0` disappears from `container image ls` with this change and remains reachable via the infra-inclusive listing.