### PR TITLE
Report an unreadable build context as permission denied, not a missing Dockerfile

### DIFF
--- a/Sources/ContainerCommands/BuildCommand.swift
+++ b/Sources/ContainerCommands/BuildCommand.swift
@@ -497,6 +497,16 @@ extension Application {
                 break
             case .none:
                 guard let defaultDockerfile = try BuildFile.resolvePath(contextDir: contextDir) else {
+                    // "Not found" and "not allowed to look" arrive here as the same answer,
+                    // because `FileManager.fileExists` returns false for both — so a build
+                    // whose context the process may not read reported a missing Dockerfile
+                    // that was sitting right there, and the message sent people to inspect
+                    // their context. Listing the directory separates the two cases: a
+                    // denial fails, and a directory that simply holds no Dockerfile lists
+                    // fine. Naming the file with -f already surfaces the real error.
+                    guard (try? FileManager.default.contentsOfDirectory(atPath: contextDir)) != nil else {
+                        throw ValidationError("cannot read context dir \(contextDir): permission denied")
+                    }
                     throw ValidationError("dockerfile not found in context dir")
                 }
 


### PR DESCRIPTION
Fixes #2089.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

`FileManager.fileExists` answers `false` both for a file that is absent and for one the process may not look at, and `BuildCommand.validate()` reported the first for both:

```
mkdir ctx && printf 'FROM alpine\n' > ctx/Dockerfile && chmod 000 ctx
container build ctx
Error: dockerfile not found in context dir
```

The message sends the user to inspect a build context that was never the problem — naming the file with `-f` shows the real permission error was available and discarded by the earlier check. Reproduction and details in #2089.

## Description

When default Dockerfile resolution fails, the context directory is listed once: a denial throws `cannot read context dir <path>: permission denied`, while a directory that genuinely holds no Dockerfile lists fine and keeps the existing message. Only the default-resolution path changes; `-f` already surfaces the real error when it opens the file.

## Testing

- `swift build` clean on this branch at abff418.
- The reproduction above now reports `Error: cannot read context dir /tmp/ctxtest: permission denied` — verified against the built CLI from this branch.
- The genuinely-missing-Dockerfile case is unchanged: an empty readable context still reports `dockerfile not found in context dir`.