### PR TITLE
Remove `auto` registry scheme.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,11 +296,11 @@ define RUN_INTEGRATION
 		CLITEST_LOG_ROOT=$(LOG_ROOT) && export CLITEST_LOG_ROOT ; \
 		CLITEST_SCRATCH_ROOT=$(SCRATCH_ROOT) && export CLITEST_SCRATCH_ROOT ; \
 		CONTAINER_CLI_PATH=$(ROOT_DIR)/bin/container && export CONTAINER_CLI_PATH ; \
-		echo "==> Warmup pass" && \
+		echo "==> Starting warmup tests" && \
 		$(SWIFT) test $(INTEGRATION_SWIFT_EXTRA) -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter "$(WARMUP_FILTER)" && \
-		echo "==> Concurrent pass (width=$(PARALLEL_WIDTH))" && \
+		echo "==> Starting $(words $(CONCURRENT_TEST_SUITES)) test suites concurrently (width=$(PARALLEL_WIDTH))" && \
 		$(SWIFT) test $(INTEGRATION_SWIFT_EXTRA) -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) $(CONCURRENT_EVENT_STREAM_OPTS) --experimental-maximum-parallelization-width $(PARALLEL_WIDTH) --filter "$(CONCURRENT_FILTER)" && \
-		echo "==> Global pass (serial)" && \
+		echo "==> Starting $(words $(SERIAL_TEST_SUITES)) test suites serially" && \
 		$(SWIFT) test $(INTEGRATION_SWIFT_EXTRA) -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) $(GLOBAL_EVENT_STREAM_OPTS) --experimental-maximum-parallelization-width 1 --filter "$(SERIAL_FILTER)" ; \
 		exit_code=$$? ; \
 		$(INTEGRATION_POST_TEST) \

--- a/Sources/ContainerK8s/K8sHelper.swift
+++ b/Sources/ContainerK8s/K8sHelper.swift
@@ -183,7 +183,7 @@ struct K8sHelper {
         _ = try await ClientImage.fetch(
             reference: nodeImage,
             platform: platform,
-            scheme: .auto,
+            scheme: .https,
             containerSystemConfig: containerSystemConfig,
             progressUpdate: nil)
     }

--- a/Sources/Services/ContainerAPIService/Client/ClientImage.swift
+++ b/Sources/Services/ContainerAPIService/Client/ClientImage.swift
@@ -247,7 +247,7 @@ extension ClientImage {
     public static func pull(
         reference: String,
         platform: Platform? = nil,
-        scheme: RequestScheme = .auto,
+        scheme: RequestScheme = .https,
         containerSystemConfig: ContainerSystemConfig,
         progressUpdate: ProgressUpdateHandler? = nil,
         maxConcurrentDownloads: Int = 3
@@ -354,7 +354,7 @@ extension ClientImage {
     public static func fetch(
         reference: String,
         platform: Platform? = nil,
-        scheme: RequestScheme = .auto,
+        scheme: RequestScheme = .https,
         containerSystemConfig: ContainerSystemConfig,
         progressUpdate: ProgressUpdateHandler? = nil,
         maxConcurrentDownloads: Int = 3

--- a/Sources/Services/ContainerAPIService/Client/Flags.swift
+++ b/Sources/Services/ContainerAPIService/Client/Flags.swift
@@ -158,8 +158,8 @@ public struct Flags {
             self.scheme = scheme
         }
 
-        @Option(help: "Scheme to use when connecting to the container registry. One of (http, https, auto)")
-        public var scheme: String = "auto"
+        @Option(help: "Scheme to use when connecting to the container registry. One of (http, https)")
+        public var scheme: String = "https"
     }
 
     public struct Management: ParsableArguments {

--- a/Sources/Services/ContainerAPIService/Client/RequestScheme.swift
+++ b/Sources/Services/ContainerAPIService/Client/RequestScheme.swift
@@ -24,16 +24,12 @@ public enum RequestScheme: String, Sendable {
     case http = "http"
     case https = "https"
 
-    case auto = "auto"
-
     public init(_ rawValue: String) throws {
         switch rawValue {
         case RequestScheme.http.rawValue:
             self = .http
         case RequestScheme.https.rawValue:
             self = .https
-        case RequestScheme.auto.rawValue:
-            self = .auto
         default:
             throw ContainerizationError(.invalidArgument, message: "unsupported scheme \(rawValue)")
         }
@@ -50,48 +46,6 @@ public enum RequestScheme: String, Sendable {
         switch self {
         case .http, .https:
             return self
-        case .auto:
-            return Self.isInternalHost(host: host, internalDnsDomain: internalDnsDomain) ? .http : .https
         }
-    }
-
-    /// Checks if the given `host` string is a private IP address
-    /// or a domain typically reachable only on the local system.
-    public static func isInternalHost(host: String, internalDnsDomain: String?) -> Bool {
-        // The localhost hostname is private.
-        if host == "localhost" {
-            return true
-        }
-
-        // If hostname uses the provided DNS domain, treat it as private.
-        if let internalDnsDomain {
-            if host.hasSuffix(".\(internalDnsDomain)") {
-                return true
-            }
-        }
-
-        // If it's any other hostname and not an IP address, it's not private access.
-        guard let ipv4Address = try? IPv4Address(host) else {
-            return false
-        }
-
-        let ipv4Value = ipv4Address.value
-
-        // 10.0.0.0/8 and 127.0.0.0/8 are private CIDRs.
-        if (ipv4Value & 0xff00_0000 == 0x0a00_0000) || (ipv4Value & 0xff00_0000 == 0x7f00_0000) {
-            return true
-        }
-
-        // 192.168.0.0/16 is a private CIDR.
-        if ipv4Value & 0xffff_0000 == 0xc0a8_0000 {
-            return true
-        }
-
-        // 172.16.0.0/12 is a private CIDR.
-        if ipv4Value & 0xfff0_0000 == 0xac10_0000 {
-            return true
-        }
-
-        return false
     }
 }

--- a/Tests/ContainerAPIClientTests/RequestSchemeTests.swift
+++ b/Tests/ContainerAPIClientTests/RequestSchemeTests.swift
@@ -31,45 +31,28 @@ struct RequestSchemeTests {
     @Test(arguments: [
         TestArg(scheme: "http", host: "myregistry.io", expected: .http),
         TestArg(scheme: "https", host: "myregistry.io", expected: .https),
-        TestArg(scheme: "auto", host: "myregistry.io", expected: .https),
         TestArg(scheme: "https", host: "localhost", expected: .https),
         TestArg(scheme: "http", host: "localhost", expected: .http),
-        TestArg(scheme: "auto", host: "localhost", expected: .http),
-        TestArg(scheme: "auto", host: "localhost.evil.com", expected: .https),
         TestArg(scheme: "http", host: "127.0.0.1", expected: .http),
         TestArg(scheme: "https", host: "127.0.0.1", expected: .https),
-        TestArg(scheme: "auto", host: "127.0.0.1", expected: .http),
-        TestArg(scheme: "auto", host: "127.255.255.255", expected: .http),
-        TestArg(scheme: "auto", host: "127.0.0.1.evil.com", expected: .https),
         TestArg(scheme: "https", host: "10.3.4.1", expected: .https),
-        TestArg(scheme: "auto", host: "10.3.4.1", expected: .http),
-        TestArg(scheme: "auto", host: "10.255.255.255", expected: .http),
-        TestArg(scheme: "auto", host: "10.0.0.1.evil.com", expected: .https),
-        TestArg(scheme: "auto", host: "192.168.0.1", expected: .http),
-        TestArg(scheme: "auto", host: "192.168.255.255", expected: .http),
-        TestArg(scheme: "auto", host: "192.169.0.1", expected: .https),
-        TestArg(scheme: "auto", host: "192.168.1.1.evil.com", expected: .https),
-        TestArg(scheme: "auto", host: "some-dns-name.io", expected: .https),
-        TestArg(scheme: "auto", host: "172.32.0.1", expected: .https),
-        TestArg(scheme: "auto", host: "172.22.23.61", expected: .http),
-        TestArg(scheme: "auto", host: "172.16.0.0", expected: .http),
-        TestArg(scheme: "auto", host: "172.31.255.255", expected: .http),
     ])
 
     func testIsConnectionSecure(arg: TestArg) throws {
-        let requestScheme = RequestScheme(rawValue: arg.scheme)!
+        let requestScheme = try RequestScheme(arg.scheme)
         #expect(try requestScheme.schemeFor(host: arg.host, internalDnsDomain: Self.defaultDnsDomain) == arg.expected)
     }
 
     @Test func testEmptyHostThrowsError() throws {
         #expect(throws: (any Error).self) {
-            let requestScheme = RequestScheme(rawValue: "https")!
+            let requestScheme = try RequestScheme("https")
             _ = try requestScheme.schemeFor(host: "", internalDnsDomain: Self.defaultDnsDomain)
         }
     }
 
-    @Test func testIsInternalHostWithDefaultDNSDomain() throws {
-        let hostName = "some-dns-name.io.\(Self.defaultDnsDomain)"
-        #expect(RequestScheme.isInternalHost(host: hostName, internalDnsDomain: Self.defaultDnsDomain))
+    @Test func testUnsupportedSchemeThrowsError() throws {
+        #expect(throws: (any Error).self) {
+            _ = try RequestScheme("auto")
+        }
     }
 }


### PR DESCRIPTION
- Closes #2099.
- Removes magic auto-downgrade logic.
- nit: Gets rid of confusing use of the word "pass" in integration test startup messages.