### PR TITLE
Fix tmpfs mount source for --mount

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/Parser.swift
+++ b/Sources/Services/ContainerAPIService/Client/Parser.swift
@@ -433,6 +433,7 @@ public struct Parser {
                     fs.type = Filesystem.FSType.virtiofs
                 case "tmpfs":
                     fs.type = Filesystem.FSType.tmpfs
+                    fs.source = "tmpfs"
                 case "volume":
                     isVolume = true
                 default:

--- a/Tests/ContainerAPIClientTests/ParserTest.swift
+++ b/Tests/ContainerAPIClientTests/ParserTest.swift
@@ -459,6 +459,27 @@ struct ParserTest {
     }
 
     @Test
+    func testMountTmpfsSource() throws {
+        let result = try Parser.mount("type=tmpfs,target=/tmpfsmount1,size=512M")
+        switch result {
+        case .filesystem(let fs):
+            #expect(fs.type == .tmpfs)
+            #expect(fs.source == "tmpfs")
+            #expect(fs.destination == "/tmpfsmount1")
+            #expect(fs.options.contains("size=536870912"))
+        case .volume:
+            #expect(Bool(false), "Expected filesystem mount, got volume")
+        }
+    }
+
+    @Test
+    func testMountTmpfsSourceRejection() throws {
+        #expect(throws: ContainerizationError.self) {
+            _ = try Parser.mount("type=tmpfs,source=tmpfs,target=/tmpfsmount1")
+        }
+    }
+
+    @Test
     func testMountVolumeValidName() throws {
         let result = try Parser.mount("type=volume,src=myvolume,dst=/data")
 


### PR DESCRIPTION
> [!IMPORTANT]
> All commits must be signed and verified. Pull requests containing unsigned or unverified commits cannot be built or merged. See the [GitHub documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#about-commit-signature-verification) for instructions.
>
> For all but trivial fixes, make sure to first create a GitHub issue that concisely describes the bug or desired enhancement as justification for the change. Large PRs with no justifying issue will be closed.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
`--mount type=tmpfs` did not initialize the filesystem `source` field, unlike `--tmpfs`, resulting in an empty source field for tmpfs mounts.

Set the implicit source to `tmpfs` when parsing `type=tmpfs` and add regression coverage for the generated filesystem configuration and the existing validation that rejects an explicit `source` for tmpfs mounts.

Fixes #2109

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs
