### PR TITLE
Fix a compilation error

### DIFF
--- a/Sources/ContainerBuild/Builder.swift
+++ b/Sources/ContainerBuild/Builder.swift
@@ -108,7 +108,7 @@ public struct Builder: Sendable {
         }
 
         if let terminal = config.terminal {
-            Task {
+            _ = Task {
                 let winchHandler = AsyncSignalHandler.create(notify: [SIGWINCH])
                 let setWinch = { (rows: UInt16, cols: UInt16) in
                     var winch = ClientStream()

--- a/Sources/Plugins/NetworkVmnet/NetworkVmnetHelper+Start.swift
+++ b/Sources/Plugins/NetworkVmnet/NetworkVmnetHelper+Start.swift
@@ -26,6 +26,7 @@ import ContainerizationError
 import ContainerizationExtras
 import Foundation
 import Logging
+import SystemPackage
 
 enum Variant: String, ExpressibleByArgument {
     case reserved

--- a/Sources/Plugins/RuntimeLinux/RuntimeLinuxHelper+Start.swift
+++ b/Sources/Plugins/RuntimeLinux/RuntimeLinuxHelper+Start.swift
@@ -24,6 +24,7 @@ import ContainerXPC
 import Foundation
 import Logging
 import NIO
+import SystemPackage
 
 extension RuntimeLinuxHelper {
     struct Start: AsyncParsableCommand {


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context
Fixes a compilation error:
```
error: SwiftCompile normal arm64 .../Sources/ContainerBuild/Builder.swift failed with a nonzero exit code. Command line:     cd ...
    builtin-SwiftPerFileCompile Builder.swift
.../Sources/ContainerBuild/Builder.swift:111:13: error: unstructured throwing task created by 'init(name:priority:operation:)' is not used, which may accidentally ignore errors thrown inside the task [#NoUseUnstructuredThrowingTask]
109 | 
110 |         if let terminal = config.terminal {
111 |             Task {
    |             |- error: unstructured throwing task created by 'init(name:priority:operation:)' is not used, which may accidentally ignore errors thrown inside the task [#NoUseUnstructuredThrowingTask]
    |             `- note: to silence this warning, handle the error inside the task, or store/discard the task value explicitly
112 |                 let winchHandler = AsyncSignalHandler.create(notify: [SIGWINCH])
113 |                 let setWinch = { (rows: UInt16, cols: UInt16) in
```

Also, fixes compilation warnings:
```
.../Sources/Plugins/RuntimeLinux/RuntimeLinuxHelper+Start.swift:46:13: warning: cannot use struct 'FilePath' in a property declaration member of a type not marked '@_implementationOnly'; 'SystemPackage' was not imported by this file
 44 |         var root: String
 45 | 
 46 |         var logRoot = LogRoot.path
    |             `- warning: cannot use struct 'FilePath' in a property declaration member of a type not marked '@_implementationOnly'; 'SystemPackage' was not imported by this file
 47 | 
 48 |         var machServiceLabel: String {

SystemPackage.FilePath:2:15: note: struct declared here
1 | @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
2 | public struct FilePath : Sendable {
  |               `- note: struct declared here
3 |     public init()
4 | }
.../Sources/Plugins/NetworkVmnet/NetworkVmnetHelper+Start.swift:70:13: warning: cannot use struct 'FilePath' in a property declaration member of a type not marked '@_implementationOnly'; 'SystemPackage' was not imported by this file
 68 |         }()
 69 | 
 70 |         var logRoot = LogRoot.path
    |             `- warning: cannot use struct 'FilePath' in a property declaration member of a type not marked '@_implementationOnly'; 'SystemPackage' was not imported by this file
 71 | 
 72 |         func run() async throws {

SystemPackage.FilePath:2:15: note: struct declared here
1 | @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
2 | public struct FilePath : Sendable {
  |               `- note: struct declared here
3 |     public init()
4 | }
```

## Testing
- [x] Tested locally
