### PR TITLE
Fix empty build context for symlinked context paths

### DIFF
--- a/Sources/ContainerBuild/BuildFSSync.swift
+++ b/Sources/ContainerBuild/BuildFSSync.swift
@@ -272,11 +272,12 @@ actor BuildFSSync: BuildPipelineHandler {
             destination: tarURL,
             writerConfiguration: writerCfg
         ) { url in
-            guard let rel = try? url.relativeChildPath(to: contextDir) else {
+            let resolvedURL = url.resolvingSymlinksInPath()
+            guard let rel = try? resolvedURL.relativeChildPath(to: self.contextDir) else {
                 return nil
             }
 
-            guard let parent = try? url.deletingLastPathComponent().relativeChildPath(to: self.contextDir) else {
+            guard let parent = try? resolvedURL.deletingLastPathComponent().relativeChildPath(to: self.contextDir) else {
                 return nil
             }
 

--- a/Tests/ContainerBuildTests/BuildFSSyncTests.swift
+++ b/Tests/ContainerBuildTests/BuildFSSyncTests.swift
@@ -394,4 +394,58 @@ import Testing
         let secretLeak = infos.first { $0.name.hasSuffix("secret.txt") }
         #expect(secretLeak == nil, "no entry for the external file should appear in walk() results: \(infos.map { $0.name })")
     }
+
+    // MARK: - walk(): tar mode symlinked contextDir prefix regression test (#2037)
+
+    @Test func testWalkTarIncludesFilesWhenContextDirUsesSymlinkedPrefix() async throws {
+        // Create context directory using a symlinked path prefix (e.g. /tmp on macOS -> /private/tmp)
+        let symlinkBase = URL(fileURLWithPath: "/tmp/" + UUID().uuidString)
+        try fm.createDirectory(at: symlinkBase, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: symlinkBase) }
+
+        let sampleFile = symlinkBase.appendingPathComponent("staged-run.sh")
+        try write("#!/bin/sh\n", to: sampleFile)
+
+        let fssync = try BuildFSSync(symlinkBase)
+
+        var continuation: AsyncStream<ClientStream>.Continuation!
+        let stream = AsyncStream<ClientStream> { continuation = $0 }
+
+        var packet = BuildTransfer()
+        packet.id = UUID().uuidString
+        packet.source = "."
+        packet.metadata = [
+            "followpaths": "staged-run.sh",
+            "mode": "tar",
+        ]
+
+        try await fssync.walk(continuation, packet, "build-repro")
+        continuation.finish()
+
+        var receivedData = Data()
+        for await resp in stream {
+            if !resp.buildTransfer.data.isEmpty {
+                receivedData.append(resp.buildTransfer.data)
+            }
+        }
+
+        #expect(!receivedData.isEmpty, "tar archive data should not be empty for context under symlinked prefix")
+
+        // Unpack tar to temporary directory and verify staged-run.sh is explicitly present inside the archive
+        let unpackDir = URL.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let archiveFile = URL.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".tar")
+        try receivedData.write(to: archiveFile)
+        defer {
+            try? fm.removeItem(at: unpackDir)
+            try? fm.removeItem(at: archiveFile)
+        }
+
+        let archiveReader = try ArchiveReader(url: archiveFile)
+        var entryPaths = [String]()
+        for entry in try archiveReader.readEntries() {
+            entryPaths.append(entry.path)
+        }
+
+        #expect(entryPaths.contains("staged-run.sh"), "staged-run.sh must be explicitly present in tar archive entries: \(entryPaths)")
+    }
 }

--- a/Tests/IntegrationTests/Build/TestCLIBuilder.swift
+++ b/Tests/IntegrationTests/Build/TestCLIBuilder.swift
@@ -1030,4 +1030,33 @@ struct TestCLIBuilder {
             try f.assertImageBuilt(image)
         }
     }
+
+    /// Regression test for issue #2037: `container build` with single file COPY and no `.dockerignore`.
+    /// Verifies context files under symlinked parent paths (like /tmp on macOS) are transferred properly.
+    @Test func testBuildContextSingleFileCOPY() async throws {
+        try await ContainerFixture.with { f in
+            let dir = try f.createTempDir()
+            let dockerfile = """
+                FROM ghcr.io/linuxcontainers/alpine:3.20
+                COPY staged-run.sh /run.sh
+                RUN cat /run.sh
+                """
+            try f.createContext(
+                dir: dir,
+                dockerfile: dockerfile,
+                context: [
+                    .file("staged-run.sh", content: .data(Data("#!/bin/sh\necho hello\n".utf8)))
+                ])
+
+            let image = "registry.local/build-context-single-file:\(UUID().uuidString)"
+            try f.build(tag: image, contextDir: dir)
+            try f.assertImageBuilt(image)
+
+            let containerName = "test-repro-2037-\(UUID().uuidString)"
+            try f.run(["run", "-d", "--name", containerName, image, "sleep", "60"]).check()
+            defer { try? f.run(["rm", "-f", containerName]) }
+
+            try f.assertContainerHasFile(containerName, at: "/run.sh", "/run.sh should exist in image")
+        }
+    }
 }


### PR DESCRIPTION
### Description

Fixes #2037.

When `container build` is run on macOS from a context path located under a
symlinked directory such as `/tmp`, `BuildFSSync` canonicalizes the context
root to enforce containment.

However, `Archiver.compress` enumerates files using the unresolved physical
path prefix. This caused the existing containment check to reject valid
context files, resulting in an empty build context being transferred to
BuildKit and causing `COPY` operations to fail.

This change canonicalizes URLs returned by the archive walk before checking
them against the canonicalized context root, while preserving the existing
containment and security boundary.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Motivation and Context

The context root and the paths returned by the archive walk could represent
the same filesystem location using different path prefixes on macOS.

For example:

`/tmp/context` -> `/private/tmp/context`

The canonicalized context root was therefore compared against an
unresolved archive path, causing `relativeChildPath()` to reject valid
files.

Canonicalizing the enumerated URL before the existing containment check
makes both paths comparable without weakening the containment boundary.

### Testing

- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

Production build:
`swift build --target ContainerBuild` completed successfully.

Formatting & linting:
`make fmt` and `git diff --check` completed successfully.

Unit tests:
`make test` passed locally with Xcode 26.6: 757 tests in 81 suites passed.

Regression tests:
Added `testWalkTarIncludesFilesWhenContextDirUsesSymlinkedPrefix` in `BuildFSSyncTests.swift`; it passed successfully.

Integration tests:
Executed `make APP_ROOT=test-data container integration`.

The new end-to-end `testBuildContextSingleFileCOPY` regression test passed successfully, including building the image, running a container from the image, and verifying `/run.sh` exists in the container.

The integration suite completed with 273/276 tests passing. The 3 unrelated failures were caused by temporary HTTP mirror timeouts while Alpine attempted to fetch packages from `dl-cdn.alpinelinux.org`; the #2037 regression test passed.