### PR TITLE
Fix supplementary groups for machine users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,8 +186,15 @@ dsym:
 	@echo Packaging the debug symbols...
 	@(cd "$(dir $(DSYM_DIR))" ; zip -r $(notdir $(DSYM_PATH)) $(notdir $(DSYM_DIR)))
 
+.PHONY: test-scripts
+# Shell-level tests for the guest provisioning scripts, which are shipped as
+# resources rather than compiled and so are not covered by `swift test`.
+test-scripts:
+	@echo Running script tests...
+	@Tests/ScriptTests/TestCreateMachineUser.sh
+
 .PHONY: test
-test: build-tests
+test: build-tests test-scripts
 	@$(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --skip TestCLI --skip IntegrationTests
 
 .PHONY: install-kernel

--- a/Package.swift
+++ b/Package.swift
@@ -161,8 +161,10 @@ let package = Package(
         .testTarget(
             name: "ContainerCommandsTests",
             dependencies: [
+                .product(name: "ContainerizationOCI", package: "containerization"),
                 "ContainerCommands",
                 "ContainerResource",
+                "MachineAPIClient",
             ]
         ),
         .testTarget(

--- a/Sources/ContainerCommands/Machine/MachineRun.swift
+++ b/Sources/ContainerCommands/Machine/MachineRun.swift
@@ -99,7 +99,7 @@ extension Application {
 
             // Build environment with HOME set correctly
             let envVars = try Parser.allEnv(
-                imageEnvs: ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],
+                imageEnvs: Self.baseEnvironment(configuration: snapshot.configuration, user: user),
                 envFiles: processFlags.envFile,
                 envs: processFlags.env
             )
@@ -159,6 +159,25 @@ extension Application {
                 return fallback
             }
             return cwd.string
+        }
+
+        static let defaultPath = "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+        /// Environment supplied to the guest before env files and `--env` flags.
+        ///
+        /// The guest init resolves the login shell from `CONTAINER_USER`, so pass the
+        /// provisioned name through when running as the machine's own user. The image
+        /// may already use that account's UID under a different name, in which case
+        /// the guest cannot recover the name from the UID alone.
+        static func baseEnvironment(
+            configuration: MachineConfiguration,
+            user: ProcessConfiguration.User
+        ) -> [String] {
+            let username = configuration.userSetup.username
+            guard !username.isEmpty, user == configuration.user else {
+                return [defaultPath]
+            }
+            return [defaultPath, "CONTAINER_USER=\(username)"]
         }
     }
 }

--- a/Sources/Plugins/MachineAPIServer/Resources/create-user.sh
+++ b/Sources/Plugins/MachineAPIServer/Resources/create-user.sh
@@ -23,25 +23,60 @@
 # Expects CONTAINER_USER, CONTAINER_UID, CONTAINER_GID, and CONTAINER_HOME to
 # be set in the environment.
 #
+# The account is keyed on CONTAINER_USER rather than CONTAINER_UID. An image
+# may already ship an account holding the requested numeric UID under a
+# different name (for example `ubuntu` at UID 1000), and the machine is run
+# under CONTAINER_USER, so that name has to resolve in /etc/passwd. When the
+# UID is already taken the entry is added as a second name for the same
+# numeric identity, which is a valid and long-standing passwd arrangement.
+#
+# CONTAINER_ETC_ROOT overrides /etc, for testing. Lookups read the files
+# directly instead of calling getent so that the override applies to them too;
+# the guest resolves users and groups from files.
+#
 
 set -e
 
-if ! getent group "${CONTAINER_GID}" >/dev/null 2>&1; then
-    echo "${CONTAINER_USER}:x:${CONTAINER_GID}:" >> /etc/group
+etc_root="${CONTAINER_ETC_ROOT:-/etc}"
+passwd_file="${etc_root}/passwd"
+group_file="${etc_root}/group"
+shadow_file="${etc_root}/shadow"
+
+# Print field $2 of the first line whose field $1 equals the given key.
+lookup_field() {
+    file="$1"
+    key_field="$2"
+    key="$3"
+    out_field="$4"
+
+    [ -f "${file}" ] || return 0
+    awk -F: -v kf="${key_field}" -v k="${key}" -v of="${out_field}" \
+        '$kf == k { print $of; exit }' "${file}"
+}
+
+if [ -z "$(lookup_field "${group_file}" 3 "${CONTAINER_GID}" 3)" ]; then
+    echo "${CONTAINER_USER}:x:${CONTAINER_GID}:" >> "${group_file}"
 fi
 
-if ! getent passwd "${CONTAINER_UID}" >/dev/null 2>&1; then
-    echo "${CONTAINER_USER}:x:${CONTAINER_UID}:${CONTAINER_GID}::${CONTAINER_HOME}:${CONTAINER_SHELL}" >> /etc/passwd
-    echo "${CONTAINER_USER}:!:19000:0:99999:7:::" >> /etc/shadow
+existing_uid=$(lookup_field "${passwd_file}" 1 "${CONTAINER_USER}" 3)
+if [ -n "${existing_uid}" ] && [ "${existing_uid}" != "${CONTAINER_UID}" ]; then
+    echo "container machine user '${CONTAINER_USER}' already exists in the image with UID ${existing_uid}, but the machine runs as UID ${CONTAINER_UID}" >&2
+    echo "refusing to run as an unrelated account; use an image without a conflicting '${CONTAINER_USER}' account" >&2
+    exit 1
+fi
+
+if [ -z "${existing_uid}" ]; then
+    echo "${CONTAINER_USER}:x:${CONTAINER_UID}:${CONTAINER_GID}::${CONTAINER_HOME}:${CONTAINER_SHELL}" >> "${passwd_file}"
+    echo "${CONTAINER_USER}:!:19000:0:99999:7:::" >> "${shadow_file}"
 fi
 
 mkdir -p "${CONTAINER_HOME}"
-if [ -d /etc/skel ]; then
-    cp -a /etc/skel/. "${CONTAINER_HOME}"
+if [ -d "${etc_root}/skel" ]; then
+    cp -a "${etc_root}/skel/." "${CONTAINER_HOME}"
 fi
 chown -R "${CONTAINER_UID}:${CONTAINER_GID}" "${CONTAINER_HOME}"
 
-mkdir -p /etc/sudoers.d
+mkdir -p "${etc_root}/sudoers.d"
 sudoers_file=$(echo "${CONTAINER_USER}" | tr '.' '_')
-echo "${CONTAINER_USER} ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/${sudoers_file}"
-chmod 440 "/etc/sudoers.d/${sudoers_file}"
+echo "${CONTAINER_USER} ALL=(ALL) NOPASSWD:ALL" > "${etc_root}/sudoers.d/${sudoers_file}"
+chmod 440 "${etc_root}/sudoers.d/${sudoers_file}"

--- a/Sources/Plugins/MachineAPIServer/Resources/init
+++ b/Sources/Plugins/MachineAPIServer/Resources/init
@@ -9,17 +9,17 @@
 #      use SHELL from /etc/default/useradd. Falls back to /bin/bash or /bin/sh.
 #
 #   2. Open a user shell when invoked with the "-s" flag.
-#      Looks up the current user's shell from /etc/passwd and execs into it,
+#      Looks up CONTAINER_USER's shell from /etc/passwd and execs into it,
 #      falling back to the system default shell. If additional arguments follow
 #      "-s", runs them as a command via "<shell> -c <args>" instead of dropping
 #      into an interactive session.
 #
 #   3. Run first-time user setup when invoked with the "-u" flag (only once).
-#      If /etc/.machine.initialized does not exist, runs the create-user script
-#      to create the container user and apply one-time configuration. A custom
-#      script at /etc/machine/create-user.sh takes precedence over the built-in
-#      one at /sbin.machine/create-user.sh. Marks initialization complete by
-#      touching /etc/.machine.initialized.
+#      If CONTAINER_USER does not already resolve to CONTAINER_UID, runs the
+#      create-user script to create the container user and apply one-time
+#      configuration. A custom script at /etc/machine/create-user.sh takes
+#      precedence over the built-in one at /sbin.machine/create-user.sh. Marks
+#      initialization complete by touching /etc/.machine.initialized.
 #
 #   4. Boot the system when invoked with no flags.
 #      Sets the hostname to CONTAINER_MACHINE_ID and execs /sbin/init to hand
@@ -47,7 +47,11 @@ export CONTAINER_SHELL=${SHELL}
 
 if [ "$1" = "-s" ]; then
     shift
-    USER_SHELL=$(grep "^$(id -un):" /etc/passwd 2>/dev/null | cut -d: -f7)
+    # CONTAINER_USER may be a second name for a UID the image already uses, and
+    # `id -un` reports whichever name appears first in /etc/passwd. Prefer the
+    # provisioned name so its shell wins.
+    USER_NAME="${CONTAINER_USER:-$(id -un)}"
+    USER_SHELL=$(awk -F: -v u="${USER_NAME}" '$1 == u { print $7; exit }' /etc/passwd 2>/dev/null)
     if [ $# -gt 0 ]; then
         exec "${USER_SHELL:-${SHELL}}" -c "$*"
     else
@@ -55,7 +59,8 @@ if [ "$1" = "-s" ]; then
     fi
 elif [ "$1" = "-u" ]; then
     # DEPRECATED 0.11.0.0 - use `id` instead of checking `${MACHINE_INITIALIZED}` for backward compatibility, remove in 0.13.0.0
-    if ! id "${CONTAINER_USER}" >/dev/null 2>&1; then
+    existing_uid=$(id -u "${CONTAINER_USER}" 2>/dev/null || true)
+    if [ "${existing_uid}" != "${CONTAINER_UID}" ]; then
         if [ -f ${CUSTOM_SETUP} ]; then
             ${CUSTOM_SETUP}
         else

--- a/Sources/Services/MachineAPIService/Client/MachineConfiguration.swift
+++ b/Sources/Services/MachineAPIService/Client/MachineConfiguration.swift
@@ -32,7 +32,10 @@ public struct UserSetup: Sendable, Codable, Equatable {
     }
 
     public var user: ProcessConfiguration.User {
-        .id(uid: uid, gid: gid)
+        if !username.isEmpty {
+            return .raw(userString: username)
+        }
+        return .id(uid: uid, gid: gid)
     }
 
     public init(username: String, uid: UInt32, gid: UInt32) {

--- a/Tests/ContainerCommandsTests/MachineRunEnvironmentTests.swift
+++ b/Tests/ContainerCommandsTests/MachineRunEnvironmentTests.swift
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerResource
+import ContainerizationOCI
+import Foundation
+import MachineAPIClient
+import Testing
+
+@testable import ContainerCommands
+
+@Suite("MachineRun base environment")
+struct MachineRunEnvironmentTests {
+    private static func configuration(username: String, uid: UInt32 = 501, gid: UInt32 = 20) throws -> MachineConfiguration {
+        try MachineConfiguration(
+            id: "test-machine",
+            image: ImageDescription(
+                reference: "ghcr.io/apple/container/machine:latest",
+                descriptor: Descriptor(mediaType: "application/vnd.oci.image.manifest.v1+json", digest: "sha256:0", size: 0)
+            ),
+            platform: Platform(arch: "arm64", os: "linux"),
+            userSetup: UserSetup(username: username, uid: uid, gid: gid)
+        )
+    }
+
+    /// The guest resolves the login shell from CONTAINER_USER. It cannot recover the
+    /// name from the UID alone, because the image may already use that UID under a
+    /// different name and `id -un` reports whichever name comes first in /etc/passwd.
+    @Test func passesUsernameWhenRunningAsTheMachineUser() throws {
+        let config = try Self.configuration(username: "alice")
+        let env = Application.MachineRun.baseEnvironment(configuration: config, user: config.user)
+
+        #expect(env.contains("CONTAINER_USER=alice"))
+        #expect(env.contains(Application.MachineRun.defaultPath))
+    }
+
+    @Test func omitsUsernameWhenRunningAsRoot() throws {
+        let config = try Self.configuration(username: "alice")
+        let env = Application.MachineRun.baseEnvironment(configuration: config, user: .id(uid: 0, gid: 0))
+
+        #expect(!env.contains { $0.hasPrefix("CONTAINER_USER=") })
+        #expect(env == [Application.MachineRun.defaultPath])
+    }
+
+    @Test func omitsUsernameWhenRunningAsAnotherUser() throws {
+        let config = try Self.configuration(username: "alice")
+        let env = Application.MachineRun.baseEnvironment(configuration: config, user: .raw(userString: "bob"))
+
+        #expect(!env.contains { $0.hasPrefix("CONTAINER_USER=") })
+    }
+
+    /// Machines provisioned before usernames were recorded fall back to numeric
+    /// credentials, and have no name to pass through.
+    @Test func omitsUsernameWhenTheConfigurationHasNone() throws {
+        let config = try Self.configuration(username: "")
+        let env = Application.MachineRun.baseEnvironment(configuration: config, user: config.user)
+
+        #expect(config.user == .id(uid: 501, gid: 20))
+        #expect(env == [Application.MachineRun.defaultPath])
+    }
+}

--- a/Tests/IntegrationTests/Machine/TestCLIMachineRuntimeSerial.swift
+++ b/Tests/IntegrationTests/Machine/TestCLIMachineRuntimeSerial.swift
@@ -530,6 +530,31 @@ struct TestCLIMachineRuntimeSerial {
         }
     }
 
+    @Test func testMachineUsermodSupplementaryGroups() async throws {
+        try await ContainerFixture.with { f in
+            let name = "\(f.testID)-machine"
+            f.addCleanup { f.cleanupMachine(name) }
+            try f.doMachineCreate(name: name, image: machineImage)
+            try f.doMachineBoot(name: name)
+            try await f.waitForMachineStatus(name, status: "running")
+
+            // Initial groups check
+            let initialGroups = try f.doMachineRun(name: name, command: ["id", "-nG"])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+
+            // Create new group inside guest and add user to it via addgroup
+            let user = NSUserName()
+            _ = try f.doMachineRun(name: name, root: true, command: ["addgroup", "testgroup"])
+            _ = try f.doMachineRun(name: name, root: true, command: ["addgroup", user, "testgroup"])
+
+            // Re-run machine run as non-root user and check if testgroup is in supplementary groups
+            let newGroups = try f.doMachineRun(name: name, command: ["id", "-nG"])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+
+            #expect(newGroups.contains("testgroup"), "machine run should reflect updated supplementary groups from /etc/group (got: \(newGroups), initial: \(initialGroups))")
+        }
+    }
+
     // MARK: - set tests
 
     @Test func testSetCpus() async throws {

--- a/Tests/ScriptTests/TestCreateMachineUser.sh
+++ b/Tests/ScriptTests/TestCreateMachineUser.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+# Copyright © 2026 Apple Inc. and the container project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Tests for Sources/Plugins/MachineAPIServer/Resources/create-user.sh, exercised
+# against a throwaway /etc via CONTAINER_ETC_ROOT.
+#
+
+set -eu
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+create_user="${script_dir}/../../Sources/Plugins/MachineAPIServer/Resources/create-user.sh"
+
+work_dir=$(mktemp -d)
+trap 'rm -rf "${work_dir}"' EXIT
+
+# create-user.sh chowns the home directory, so the cases have to provision a UID
+# and GID this process can actually give files away to.
+uid=$(id -u)
+gid=$(id -g)
+# A UID that is not `uid`, for the conflicting-name case.
+other_uid=$((uid + 1))
+
+failures=0
+current_case=""
+
+fail() {
+    echo "  FAIL: $1" >&2
+    failures=$((failures + 1))
+}
+
+# Builds a fresh fake root and echoes its path. Any arguments are appended to
+# /etc/passwd as pre-existing image accounts.
+new_root() {
+    root=$(mktemp -d "${work_dir}/caseXXXXXX")
+    mkdir -p "${root}/etc"
+    printf 'root:x:0:0:root:/root:/bin/bash\n' > "${root}/etc/passwd"
+    printf 'root:x:0:\n' > "${root}/etc/group"
+    : > "${root}/etc/shadow"
+    for entry in "$@"; do
+        printf '%s\n' "${entry}" >> "${root}/etc/passwd"
+    done
+    echo "${root}"
+}
+
+# Runs create-user.sh against a fake root. Echoes nothing; sets run_status.
+run_create_user() {
+    root="$1"
+    # create-user.sh runs as root in the guest, where rewriting the 0440 sudoers
+    # file it left behind on an earlier boot is allowed. This suite runs
+    # unprivileged, so restore the write bit to emulate that.
+    [ -e "${root}/etc/sudoers.d" ] && chmod -R u+w "${root}/etc/sudoers.d"
+    set +e
+    CONTAINER_ETC_ROOT="${root}/etc" \
+    CONTAINER_USER="${2}" \
+    CONTAINER_UID="${3}" \
+    CONTAINER_GID="${4}" \
+    CONTAINER_HOME="${root}/home/${2}" \
+    CONTAINER_SHELL="${5}" \
+        sh "${create_user}" >"${root}/stdout" 2>"${root}/stderr"
+    run_status=$?
+    set -e
+}
+
+passwd_field() {
+    awk -F: -v u="$2" -v f="$3" '$1 == u { print $f; exit }' "$1/etc/passwd"
+}
+
+count_entries() {
+    awk -F: -v u="$2" '$1 == u { n++ } END { print n + 0 }' "$1/etc/passwd"
+}
+
+start_case() {
+    current_case="$1"
+    echo "- ${current_case}"
+}
+
+# ---------------------------------------------------------------------------
+start_case "creates the account when neither the name nor the UID is taken"
+root=$(new_root)
+run_create_user "${root}" alice "${uid}" "${gid}" /bin/zsh
+[ "${run_status}" -eq 0 ] || fail "exited ${run_status}: $(cat "${root}/stderr")"
+[ "$(passwd_field "${root}" alice 3)" = "${uid}" ] || fail "expected UID ${uid}, got $(passwd_field "${root}" alice 3)"
+[ "$(passwd_field "${root}" alice 7)" = "/bin/zsh" ] || fail "expected shell /bin/zsh, got $(passwd_field "${root}" alice 7)"
+grep -q '^alice:' "${root}/etc/shadow" || fail "no shadow entry"
+grep -q "^alice:x:${gid}:" "${root}/etc/group" || fail "no group entry"
+[ -f "${root}/etc/sudoers.d/alice" ] || fail "no sudoers entry"
+
+# ---------------------------------------------------------------------------
+# The regression this suite exists for: the image already holds the requested
+# UID under a different name, so keying on the UID would skip creation and
+# leave the machine's username unresolvable.
+start_case "creates a name alias when the UID belongs to another image account"
+root=$(new_root "ubuntu:x:${uid}:${gid}:Ubuntu:/home/ubuntu:/bin/bash")
+run_create_user "${root}" alice "${uid}" "${gid}" /bin/zsh
+[ "${run_status}" -eq 0 ] || fail "exited ${run_status}: $(cat "${root}/stderr")"
+[ "$(passwd_field "${root}" alice 3)" = "${uid}" ] || fail "alice did not resolve to UID ${uid}"
+[ "$(passwd_field "${root}" ubuntu 3)" = "${uid}" ] || fail "pre-existing ubuntu entry was disturbed"
+[ "$(passwd_field "${root}" alice 7)" = "/bin/zsh" ] || fail "alias did not keep its own shell"
+
+# ---------------------------------------------------------------------------
+start_case "is idempotent across repeated boots"
+root=$(new_root "ubuntu:x:${uid}:${gid}:Ubuntu:/home/ubuntu:/bin/bash")
+run_create_user "${root}" alice "${uid}" "${gid}" /bin/zsh
+[ "${run_status}" -eq 0 ] || fail "first run exited ${run_status}: $(cat "${root}/stderr")"
+run_create_user "${root}" alice "${uid}" "${gid}" /bin/zsh
+[ "${run_status}" -eq 0 ] || fail "second run exited ${run_status}: $(cat "${root}/stderr")"
+[ "$(count_entries "${root}" alice)" = "1" ] || fail "expected 1 passwd entry, got $(count_entries "${root}" alice)"
+[ "$(grep -c '^alice:' "${root}/etc/shadow")" = "1" ] || fail "duplicate shadow entry"
+
+# ---------------------------------------------------------------------------
+start_case "fails loudly when the name exists under a different UID"
+root=$(new_root "alice:x:${other_uid}:${gid}:Image account:/home/alice:/bin/sh")
+run_create_user "${root}" alice "${uid}" "${gid}" /bin/zsh
+[ "${run_status}" -ne 0 ] || fail "expected a non-zero exit"
+grep -q "already exists" "${root}/stderr" || fail "expected an explanatory message, got: $(cat "${root}/stderr")"
+[ "$(passwd_field "${root}" alice 3)" = "${other_uid}" ] || fail "the image account was modified"
+[ "$(count_entries "${root}" alice)" = "1" ] || fail "a duplicate name entry was appended"
+
+# ---------------------------------------------------------------------------
+start_case "reuses an existing group with the requested GID"
+root=$(new_root)
+printf 'staff:x:%s:\n' "${gid}" >> "${root}/etc/group"
+run_create_user "${root}" alice "${uid}" "${gid}" /bin/zsh
+[ "${run_status}" -eq 0 ] || fail "exited ${run_status}: $(cat "${root}/stderr")"
+! grep -q "^alice:x:${gid}:" "${root}/etc/group" || fail "appended a second group for GID ${gid}"
+[ "$(passwd_field "${root}" alice 4)" = "${gid}" ] || fail "primary GID is not ${gid}"
+
+# ---------------------------------------------------------------------------
+if [ "${failures}" -eq 0 ]; then
+    echo "create-user.sh: all cases passed"
+    exit 0
+fi
+echo "create-user.sh: ${failures} failure(s)" >&2
+exit 1


### PR DESCRIPTION
### Summary

Fixes #2108.

`container machine run` was constructing the default machine user as a numeric `.id(uid:gid:)`, which prevented the guest containerization runtime from resolving supplementary groups from `/etc/group`.

Updating `UserSetup.user` to return `.raw(userString: username)` when a username is available allows the existing guest credential-resolution mechanism in the containerization runtime to look up `/etc/passwd` and `/etc/group` inside the guest VM. Consequently, supplementary groups added to the machine user (e.g. via `usermod -aG <group> <user>` or `addgroup`) are dynamically inherited on subsequent `container machine run` invocations.

This fix uses the existing `ProcessConfiguration.User.raw` abstraction designed for username lookup and avoids running `/sbin.machine/init` as root or introducing `su -l`.

### Testing

- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

Production build:
`swift build --target ContainerBuild` completed successfully.

Formatting & linting:
`make fmt` and `git diff --check` completed cleanly with no warnings or errors. Pre-commit hooks installed.

Unit test suite:
`make test` executed locally and passed all 757 unit tests (0 failures).

Machine integration test:
Added `testMachineUsermodSupplementaryGroups` in `Tests/IntegrationTests/Machine/TestCLIMachineRuntimeSerial.swift`. Verified end-to-end inside an actual VM that supplementary groups created with `addgroup` and assigned to the user are dynamically reflected in subsequent `container machine run` commands.