### PR TITLE
fix(os): close directory watcher descriptors after failed startup

### DIFF
--- a/Sources/ContainerOS/DirectoryWatcher.swift
+++ b/Sources/ContainerOS/DirectoryWatcher.swift
@@ -105,11 +105,11 @@ public actor DirectoryWatcher {
         }
     }
 
-    private func _startWatching(
-        handler: @escaping ([FilePath]) throws -> Void
+    func _startWatching(
+        handler: @Sendable @escaping ([FilePath]) throws -> Void
     ) throws {
         let descriptor = open(directoryPath.string, O_EVTONLY)
-        guard descriptor > 0 else {
+        guard descriptor >= 0 else {
             throw ContainerizationError(.internalError, message: "cannot open \(directoryPath.string), descriptor=\(descriptor)")
         }
 
@@ -117,6 +117,7 @@ public actor DirectoryWatcher {
             let files = try FileManager.default.contentsOfDirectory(atPath: directoryPath.string)
             try handler(files.map { directoryPath.appending($0) })
         } catch {
+            close(descriptor)
             throw ContainerizationError(.internalError, message: "failed to run handler for \(directoryPath.string)")
         }
 

--- a/Tests/ContainerOSTests/DirectoryWatcherTest.swift
+++ b/Tests/ContainerOSTests/DirectoryWatcherTest.swift
@@ -14,12 +14,15 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import ContainerOS
 import ContainerizationError
 import DNSServer
+import Darwin
 import Foundation
+import Synchronization
 import SystemPackage
 import Testing
+
+@testable import ContainerOS
 
 struct DirectoryWatcherTest {
     let testUUID = UUID().uuidString
@@ -150,6 +153,33 @@ struct DirectoryWatcherTest {
         }
     }
 
+    @Test func testFailingHandlerDoesNotLeakDescriptors() async throws {
+        try await withTempDir { tempPath in
+            let watcher = DirectoryWatcher(directoryPath: tempPath, log: nil)
+            let baseline = try openDescriptorCount(for: tempPath)
+            let handlerCalls = Mutex(0)
+
+            for _ in 0..<32 {
+                do {
+                    try await watcher._startWatching { _ in
+                        handlerCalls.withLock { $0 += 1 }
+                        throw ContainerizationError(.internalError, message: "intentional test failure")
+                    }
+                    Issue.record("expected the failing watch handler to throw")
+                } catch is ContainerizationError {
+                    // Expected.
+                }
+            }
+
+            let afterFailures = try openDescriptorCount(for: tempPath)
+            #expect(handlerCalls.withLock { $0 } == 32)
+            #expect(
+                afterFailures == baseline,
+                "failing handlers leaked descriptors: before=\(baseline), after=\(afterFailures)"
+            )
+        }
+    }
+
     @Test func testWatchingRecreatedDirectory() async throws {
         try await withTempDir { tempPath in
             let dirPath = tempPath.appending(UUID().uuidString)
@@ -192,5 +222,25 @@ struct DirectoryWatcherTest {
             #expect(
                 Set(createdPaths.paths.compactMap { $0.lastComponent?.string }) == Set([beforeDelete, afterDelete]))
         }
+    }
+
+    private func openDescriptorCount(for path: FilePath) throws -> Int {
+        var expectedBuffer = [CChar](repeating: 0, count: Int(MAXPATHLEN))
+        guard realpath(path.string, &expectedBuffer) != nil else {
+            throw ContainerizationError(.internalError, message: "failed to resolve test directory: \(path)")
+        }
+        let expectedPath = String(decoding: expectedBuffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }, as: UTF8.self)
+
+        return try FileManager.default.contentsOfDirectory(atPath: "/dev/fd")
+            .compactMap(Int.init)
+            .filter { descriptor in
+                var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN))
+                guard fcntl(CInt(descriptor), F_GETPATH, &buffer) == 0 else {
+                    return false
+                }
+                let resolvedPath = String(decoding: buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }, as: UTF8.self)
+                return resolvedPath == expectedPath
+            }
+            .count
     }
 }


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Closes #2034.

The initial watch path opens the directory before enumerating it and invoking the handler, but only transfers descriptor ownership to a dispatch source afterward. Close the descriptor when either initial operation fails, and accept descriptor 0 as a successful open result.

This supersedes the earlier closed #2036 with the same focused fix rebased onto current `main`.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

Negative control on current `main`: 32 failing starts leaked 32 descriptors for the exact watched path.

- DirectoryWatcher focused suite: 5/5 passed
- Leak regression repeated 10 times: passed
- Full non-integration suite: 757 tests passed
- `make fmt`, `make check`, and `git diff --check`: passed
- Commit signature: verified