### PR TITLE
fix(persistence): preserve unloadable container bundles

### DIFF
--- a/Sources/ContainerResource/Container/Bundle.swift
+++ b/Sources/ContainerResource/Container/Bundle.swift
@@ -137,7 +137,7 @@ extension Bundle {
 
     public func setContainerRootFs(fs: Filesystem) throws {
         let fsData = try JSONEncoder().encode(fs)
-        try fsData.write(to: self.containerRootfsConfig)
+        try fsData.write(to: self.containerRootfsConfig, options: .atomic)
     }
 
     public func cloneContainerRootFs(cloning fs: Filesystem, readonly: Bool = false) throws {
@@ -160,7 +160,7 @@ extension Bundle {
 
     private static func write(_ path: URL, value: Encodable) throws {
         let data = try JSONEncoder().encode(value)
-        try data.write(to: path)
+        try data.write(to: path, options: .atomic)
     }
 
     public func load<T>(filename: String) throws -> T where T: Decodable {

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -132,6 +132,12 @@ public actor ContainersService {
                     continue
                 }
 
+                guard runtimePlugins.first(where: { $0.name == config.runtimeHandler }) != nil else {
+                    throw ContainerizationError(
+                        .internalError,
+                        message: "failed to find runtime plugin \(config.runtimeHandler)"
+                    )
+                }
                 let state = ContainerState(
                     snapshot: .init(
                         configuration: config,
@@ -141,16 +147,9 @@ public actor ContainersService {
                     ),
                 )
                 results[config.id] = state
-                guard runtimePlugins.first(where: { $0.name == config.runtimeHandler }) != nil else {
-                    throw ContainerizationError(
-                        .internalError,
-                        message: "failed to find runtime plugin \(config.runtimeHandler)"
-                    )
-                }
             } catch {
-                try? FileManager.default.removeItem(at: dir)
                 log.warning(
-                    "failed to load container",
+                    "failed to load container; leaving bundle on disk",
                     metadata: [
                         "path": "\(dir.path)",
                         "error": "\(error)",

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -148,9 +148,8 @@ public actor ContainersService {
                     )
                 }
             } catch {
-                try? FileManager.default.removeItem(at: dir)
                 log.warning(
-                    "failed to load container",
+                    "failed to load container; leaving bundle on disk",
                     metadata: [
                         "path": "\(dir.path)",
                         "error": "\(error)",
@@ -429,8 +428,14 @@ public actor ContainersService {
             }
 
             do {
+                guard let runtimePlugin = self.runtimePlugins.first(where: { $0.name == config.runtimeHandler }) else {
+                    throw ContainerizationError(
+                        .internalError,
+                        message: "failed to find runtime plugin \(config.runtimeHandler)"
+                    )
+                }
                 try Self.registerService(
-                    plugin: self.runtimePlugins.first { $0.name == config.runtimeHandler }!,
+                    plugin: runtimePlugin,
                     loader: self.pluginLoader,
                     configuration: config,
                     path: path,

--- a/Tests/ContainerAPIServiceTests/ContainerLoadAtBootTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLoadAtBootTests.swift
@@ -1,0 +1,114 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerResource
+import Containerization
+import Foundation
+import Logging
+import Testing
+
+@testable import ContainerAPIService
+@testable import ContainerPlugin
+
+struct ContainerLoadAtBootTests {
+    @Test
+    func malformedConfigurationFilesRemainOnDisk() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        let bundlePath = fixture.containers.appendingPathComponent("malformed")
+        try FileManager.default.createDirectory(at: bundlePath, withIntermediateDirectories: true)
+        try Data("{".utf8).write(to: bundlePath.appendingPathComponent("config.json"))
+        try Data("{".utf8).write(to: bundlePath.appendingPathComponent("runtime-configuration.json"))
+
+        let states = try ContainersService.loadAtBoot(
+            root: fixture.containers,
+            loader: fixture.loader,
+            log: fixture.log
+        )
+
+        #expect(states.isEmpty)
+        #expect(FileManager.default.fileExists(atPath: bundlePath.path))
+    }
+
+    @Test
+    func missingRuntimeBundleRemainsOnDiskButIsNotLoaded() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        let bundlePath = fixture.containers.appendingPathComponent("missing-runtime")
+        try FileManager.default.createDirectory(at: bundlePath, withIntermediateDirectories: true)
+        let bundle = ContainerResource.Bundle(path: bundlePath)
+        try bundle.set(configuration: testConfiguration(id: "missing-runtime"))
+
+        let states = try ContainersService.loadAtBoot(
+            root: fixture.containers,
+            loader: fixture.loader,
+            log: fixture.log
+        )
+
+        #expect(states.isEmpty)
+        #expect(FileManager.default.fileExists(atPath: bundlePath.path))
+        let recovered: ContainerConfiguration = try bundle.load(filename: "config.json")
+        #expect(recovered.id == "missing-runtime")
+    }
+
+    private func testConfiguration(id: String) -> ContainerConfiguration {
+        let image = ImageDescription(
+            reference: "docker.io/library/alpine:latest",
+            descriptor: .init(
+                mediaType: "application/vnd.oci.image.manifest.v1+json",
+                digest: "sha256:" + String(repeating: "0", count: 64),
+                size: 0
+            )
+        )
+        let process = ProcessConfiguration(
+            executable: "/bin/sh",
+            arguments: [],
+            environment: [],
+            workingDirectory: "/",
+            terminal: false,
+            user: .id(uid: 0, gid: 0),
+            supplementalGroups: [],
+            rlimits: []
+        )
+        return ContainerConfiguration(id: id, image: image, process: process)
+    }
+}
+
+private struct Fixture {
+    let root: URL
+    let containers: URL
+    let loader: PluginLoader
+    let log = Logger(label: "ContainerLoadAtBootTests")
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        containers = root.appendingPathComponent("containers")
+        try FileManager.default.createDirectory(at: containers, withIntermediateDirectories: true)
+        loader = try PluginLoader(
+            appRoot: root,
+            installRoot: root,
+            logRoot: nil,
+            pluginDirectories: [],
+            pluginFactories: []
+        )
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: root)
+    }
+}

--- a/Tests/ContainerAPIServiceTests/ContainerLoadAtBootTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainerLoadAtBootTests.swift
@@ -1,0 +1,133 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerPersistence
+import ContainerResource
+import Containerization
+import ContainerizationError
+import Foundation
+import Logging
+import Testing
+
+@testable import ContainerAPIService
+@testable import ContainerPlugin
+
+struct ContainerLoadAtBootTests {
+    @Test
+    func malformedConfigurationFilesRemainOnDisk() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        let bundlePath = fixture.containers.appendingPathComponent("malformed")
+        try FileManager.default.createDirectory(at: bundlePath, withIntermediateDirectories: true)
+        try Data("{".utf8).write(to: bundlePath.appendingPathComponent("config.json"))
+        try Data("{".utf8).write(to: bundlePath.appendingPathComponent("runtime-configuration.json"))
+
+        let states = try ContainersService.loadAtBoot(
+            root: fixture.containers,
+            loader: fixture.loader,
+            log: fixture.log
+        )
+
+        #expect(states.isEmpty)
+        #expect(FileManager.default.fileExists(atPath: bundlePath.path))
+    }
+
+    @Test
+    func missingRuntimeBundleRemainsOnDiskAndIsListedAsStopped() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        let bundlePath = fixture.containers.appendingPathComponent("missing-runtime")
+        try FileManager.default.createDirectory(at: bundlePath, withIntermediateDirectories: true)
+        let bundle = ContainerResource.Bundle(path: bundlePath)
+        try bundle.set(configuration: testConfiguration(id: "missing-runtime"))
+
+        let states = try ContainersService.loadAtBoot(
+            root: fixture.containers,
+            loader: fixture.loader,
+            log: fixture.log
+        )
+
+        #expect(states.count == 1)
+        #expect(states["missing-runtime"]?.snapshot.id == "missing-runtime")
+        #expect(states["missing-runtime"]?.snapshot.status == .stopped)
+        #expect(FileManager.default.fileExists(atPath: bundlePath.path))
+        let recovered: ContainerConfiguration = try bundle.load(filename: "config.json")
+        #expect(recovered.id == "missing-runtime")
+
+        let service = try fixture.makeService()
+        let error = await #expect(throws: ContainerizationError.self) {
+            try await service.bootstrap(id: "missing-runtime", stdio: [], dynamicEnv: [:])
+        }
+        #expect(error?.code == .internalError)
+    }
+
+    private func testConfiguration(id: String) -> ContainerConfiguration {
+        let image = ImageDescription(
+            reference: "docker.io/library/alpine:latest",
+            descriptor: .init(
+                mediaType: "application/vnd.oci.image.manifest.v1+json",
+                digest: "sha256:" + String(repeating: "0", count: 64),
+                size: 0
+            )
+        )
+        let process = ProcessConfiguration(
+            executable: "/bin/sh",
+            arguments: [],
+            environment: [],
+            workingDirectory: "/",
+            terminal: false,
+            user: .id(uid: 0, gid: 0),
+            supplementalGroups: [],
+            rlimits: []
+        )
+        return ContainerConfiguration(id: id, image: image, process: process)
+    }
+}
+
+private struct Fixture {
+    let root: URL
+    let containers: URL
+    let loader: PluginLoader
+    let log = Logger(label: "ContainerLoadAtBootTests")
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        containers = root.appendingPathComponent("containers")
+        try FileManager.default.createDirectory(at: containers, withIntermediateDirectories: true)
+        loader = try PluginLoader(
+            appRoot: root,
+            installRoot: root,
+            logRoot: nil,
+            pluginDirectories: [],
+            pluginFactories: []
+        )
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    func makeService() throws -> ContainersService {
+        try ContainersService(
+            appRoot: root,
+            pluginLoader: loader,
+            containerSystemConfig: ContainerSystemConfig(),
+            log: log
+        )
+    }
+}


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Closes #2033.

Preserve malformed or temporarily unloadable container bundles instead of deleting user state during startup. Validate runtime availability before publishing in-memory state, and atomically replace bundle metadata to avoid exposing interrupted JSON writes.

This supersedes the earlier closed #2035 with strengthened malformed-current-and-legacy configuration coverage, rebased onto current `main`.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

Negative control on current `main`: malformed bundles were deleted and missing-runtime state was returned before its bundle was deleted.

- Focused startup persistence regressions: 2/2 passed
- Full non-integration suite: 758 tests passed
- `make fmt`, `make check`, and `git diff --check`: passed
- Commit signature: verified