### PR TITLE
fix(dns): avoid global resolver search domains

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/HostDNSResolver.swift
+++ b/Sources/Services/ContainerAPIService/Client/HostDNSResolver.swift
@@ -66,7 +66,6 @@ public struct HostDNSResolver {
             } ?? ""
         let resolverText = """
             domain \(name)
-            search \(name)
             nameserver 127.0.0.1
             port \(dnsPort)
             \(options)

--- a/Tests/ContainerAPIClientTests/HostDNSResolverTest.swift
+++ b/Tests/ContainerAPIClientTests/HostDNSResolverTest.swift
@@ -42,13 +42,13 @@ struct HostDNSResolverTest {
         let actualText = try String(contentsOfFile: resolverConfigPath.string, encoding: .utf8)
         let expectedText = """
             domain foo.bar
-            search foo.bar
             nameserver 127.0.0.1
             port 2053
 
             """
 
         #expect(actualText == expectedText)
+        #expect(!actualText.split(separator: "\n").contains { $0.hasPrefix("search ") })
 
         try resolver.createDomain(name: try! DNSName("bar.foo"))
         let domains = resolver.listDomains()


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Closes #1917.

Scoped files under `/etc/resolver` only need the domain, nameserver, and port. Removing the `search` directive prevents unrelated single-label hostnames from being expanded through a stopped container DNS server.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

Negative control on current `main`: the resolver fixture contained the global search directive.

- HostDNSResolver focused suite: 5/5 passed
- Full non-integration suite: 756 tests passed
- `make fmt`, `make check`, and `git diff --check`: passed
- Commit signature: verified