### PR TITLE
Fix --publish-socket rejecting host paths that contain a colon

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/Parser.swift
+++ b/Sources/Services/ContainerAPIService/Client/Parser.swift
@@ -772,14 +772,15 @@ public struct Parser {
 
     // Parse a single `--publish-socket`` argument into a `PublishSocket`.
     public static func publishSocket(_ socketText: String) throws -> PublishSocket {
-        // Split by colon to two parts: [host_path, container_path]
-        let parts = socketText.split(separator: ":")
-
-        switch parts.count {
-        case 2:
+        // The host path may itself contain ':' (e.g. a timestamped filename),
+        // so split on the LAST ':' rather than requiring exactly one. The
+        // container path is always a simple absolute path and is validated
+        // as such below, mirroring the approach used for `container cp` path
+        // references.
+        if let colon = socketText.lastIndex(of: ":") {
             // Extract host and container paths
-            let hostPath = String(parts[0])
-            let containerPath = String(parts[1])
+            let hostPath = String(socketText[..<colon])
+            let containerPath = String(socketText[socketText.index(after: colon)...])
 
             if hostPath.isEmpty {
                 throw ContainerizationError(
@@ -788,6 +789,10 @@ public struct Parser {
             if containerPath.isEmpty {
                 throw ContainerizationError(
                     .invalidArgument, message: "container socket path cannot be empty")
+            }
+            guard FilePath(containerPath).isAbsolute else {
+                throw ContainerizationError(
+                    .invalidArgument, message: "containerPath must be absolute: \(containerPath)")
             }
 
             let absoluteHostPath = FilePathOps.absolutePath(FilePath(hostPath))
@@ -820,13 +825,12 @@ public struct Parser {
                 hostPath: absoluteHostPath,
                 permissions: nil
             )
-
-        default:
-            throw ContainerizationError(
-                .invalidArgument,
-                message:
-                    "invalid publish-socket format \(socketText). Expected: host_path:container_path")
         }
+
+        throw ContainerizationError(
+            .invalidArgument,
+            message:
+                "invalid publish-socket format \(socketText). Expected: host_path:container_path")
     }
 
     // MARK: Networks

--- a/Tests/ContainerAPIClientTests/ParserTest.swift
+++ b/Tests/ContainerAPIClientTests/ParserTest.swift
@@ -331,6 +331,83 @@ struct ParserTest {
     }
 
     @Test
+    func testPublishSocketBasic() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("test-publish-socket-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let hostPath = tempDir.appendingPathComponent("app.sock").path
+
+        let result = try Parser.publishSocket("\(hostPath):/var/run/app.sock")
+        #expect(result.hostPath.string == hostPath)
+        #expect(result.containerPath.string == "/var/run/app.sock")
+    }
+
+    @Test
+    func testPublishSocketHostPathWithColon() throws {
+        // Regression: a host path containing ':' (e.g. a timestamped filename)
+        // was rejected because the argument was split on every ':' instead of
+        // only the last one, mirroring the fix for `container cp` path refs.
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("test-publish-socket-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let hostPath = tempDir.appendingPathComponent("backup-2026-08-18T10:30:00.sock").path
+
+        let result = try Parser.publishSocket("\(hostPath):/var/run/app.sock")
+        #expect(result.hostPath.string == hostPath)
+        #expect(result.containerPath.string == "/var/run/app.sock")
+    }
+
+    @Test
+    func testPublishSocketEmptyHostPath() throws {
+        #expect {
+            _ = try Parser.publishSocket(":/var/run/app.sock")
+        } throws: { error in
+            guard let error = error as? ContainerizationError else {
+                return false
+            }
+            return error.description.contains("host socket path cannot be empty")
+        }
+    }
+
+    @Test
+    func testPublishSocketEmptyContainerPath() throws {
+        #expect {
+            _ = try Parser.publishSocket("/tmp/app.sock:")
+        } throws: { error in
+            guard let error = error as? ContainerizationError else {
+                return false
+            }
+            return error.description.contains("container socket path cannot be empty")
+        }
+    }
+
+    @Test
+    func testPublishSocketNoColon() throws {
+        #expect {
+            _ = try Parser.publishSocket("/tmp/app.sock")
+        } throws: { error in
+            guard let error = error as? ContainerizationError else {
+                return false
+            }
+            return error.description.contains("invalid publish-socket format")
+        }
+    }
+
+    @Test
+    func testPublishSocketNonAbsoluteContainerPath() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("test-publish-socket-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let hostPath = tempDir.appendingPathComponent("app.sock").path
+
+        #expect {
+            _ = try Parser.publishSocket("\(hostPath):relative/app.sock")
+        } throws: { error in
+            guard let error = error as? ContainerizationError else {
+                return false
+            }
+            return error.description.contains("containerPath must be absolute")
+        }
+    }
+
+    @Test
     func testRelativePaths() throws {
         // Test bind mount with relative path "."
         do {


### PR DESCRIPTION
> [!IMPORTANT]
> All commits must be signed and verified. Pull requests containing unsigned or unverified commits cannot be built or merged. See the [GitHub documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#about-commit-signature-verification) for instructions.
>
> For all but trivial fixes, make sure to first create a GitHub issue that concisely describes the bug or desired enhancement as justification for the change. Large PRs with no justifying issue will be closed.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

`--publish-socket` takes `host_path:container_path`. The parser split the
argument on every `:` and required exactly 2 parts, so a host path with a
colon in it (for example a timestamped filename) was rejected as an
"invalid publish-socket format" even though it's a perfectly valid path.

This is the same class of bug already fixed for `container cp` in #1970,
just not applied to `--publish-socket`.

Splits on the last colon instead, since the host path can legitimately
contain a colon while the container path is always a plain absolute path.

Also validates that the container path is absolute before touching the
filesystem, instead of after a potential file removal. That ordering bug
predates this change, but this fix widens the set of inputs that reach
that code, so it's closed in the same PR rather than left half-fixed.

Fixes #2133

## Testing
- [x] Tested locally
- [x] Added/updated tests

Added tests to `Tests/ContainerAPIClientTests/ParserTest.swift`: a normal
host:container pair, a host path containing a colon (the regression case),
empty host path, empty container path, no colon at all, and a non-absolute
container path.

`swift format lint --strict --configuration .swift-format-nolint` on the
changed files reports no findings. Couldn't run `swift test` locally
(Testing module isn't available without full Xcode in this environment,
same as #2052), so the split logic was hand-verified in a standalone
script and the library target builds clean. CI should run the real suite.