### PR TITLE
Do not set default maskedPaths and readonlyPaths for container machines

### DIFF
--- a/Sources/Services/MachineAPIService/Server/MachinesService.swift
+++ b/Sources/Services/MachineAPIService/Server/MachinesService.swift
@@ -697,6 +697,8 @@ extension MachineConfiguration {
         config.capAdd = ["ALL"]
         config.ssh = true
         config.virtualization = virtualization
+        config.readonlyPaths = []
+        config.maskedPaths = []
 
         config.rosetta = platform.architecture == "amd64" && Arch.hostArchitecture() == .arm64
 

--- a/Tests/IntegrationTests/Machine/TestCLIMachineRuntimeSerial.swift
+++ b/Tests/IntegrationTests/Machine/TestCLIMachineRuntimeSerial.swift
@@ -205,6 +205,54 @@ struct TestCLIMachineRuntimeSerial {
         }
     }
 
+    @Test func testReadonlyPathsEmpty() async throws {
+        try await ContainerFixture.with { f in
+            let name = "\(f.testID)-machine"
+            f.addCleanup { f.cleanupMachine(name) }
+            try f.doMachineCreate(name: name, image: machineImage)
+            try f.doMachineBoot(name: name)
+            try await f.waitForMachineStatus(name, status: "running")
+
+            // Verify there are no default readonlyPaths on the container config.
+            let inspect = try f.doMachineInspect(name: name)
+            let containerId = try #require(inspect.containerId, "running machine should have a containerId")
+            let containerInspect = try f.inspectContainer(containerId)
+            #expect(containerInspect.configuration.readonlyPaths == [], "machines should not have any readonly paths by default")
+
+            // /proc/sys is one of the default mount readonly paths. Check that we can write to this path.
+            let write = try f.runMachine([
+                "run", "-n", name, "--root",
+                "sh", "-c", "echo test > /proc/sys/kernel/domainname && echo WROTE",
+            ])
+            #expect(write.status == 0)
+            #expect(write.output.trimmingCharacters(in: .whitespacesAndNewlines) == "WROTE")
+        }
+    }
+
+    @Test func testMaskedPathsEmpty() async throws {
+        try await ContainerFixture.with { f in
+            let name = "\(f.testID)-machine"
+            f.addCleanup { f.cleanupMachine(name) }
+            try f.doMachineCreate(name: name, image: machineImage)
+            try f.doMachineBoot(name: name)
+            try await f.waitForMachineStatus(name, status: "running")
+
+            // Verify there are no default maskedPaths on the container config.
+            let inspect = try f.doMachineInspect(name: name)
+            let containerId = try #require(inspect.containerId, "running machine should have a containerId")
+            let containerInspect = try f.inspectContainer(containerId)
+            #expect(containerInspect.configuration.maskedPaths == [], "machines should not have any masked paths by default")
+
+            // /proc/timer_list is one of the default masked paths. Check that we can read the file and get a response.
+            let byteCount = try f.runMachine([
+                "run", "-n", name, "--root",
+                "cat", "/proc/timer_list",
+            ])
+            #expect(byteCount.status == 0)
+            #expect(!byteCount.output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+    }
+
     @Test func testRunNonExistentMachine() async throws {
         try await ContainerFixture.with { f in
             let name = "nonexistent-\(f.testID)"


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context
Recent changes added to containerization here https://github.com/apple/containerization/pull/795 to bring containerization in line with OCI's masked paths and readonly paths broke container machine scenarios relying on the ability to set `sysctls` or read paths such as `/proc/kcore`. This PR sets the maskedPaths and readonlyPaths on container machines to empty. 

## Testing
- [x] Tested locally
- [x] Added/updated tests