### PR TITLE
Fix tmpfs mount source field left empty for --mount type=tmpfs

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/Parser.swift
+++ b/Sources/Services/ContainerAPIService/Client/Parser.swift
@@ -433,6 +433,7 @@ public struct Parser {
                     fs.type = Filesystem.FSType.virtiofs
                 case "tmpfs":
                     fs.type = Filesystem.FSType.tmpfs
+                    fs.source = "tmpfs"
                 case "volume":
                     isVolume = true
                 default:

--- a/Tests/ContainerAPIClientTests/ParserTest.swift
+++ b/Tests/ContainerAPIClientTests/ParserTest.swift
@@ -459,6 +459,40 @@ struct ParserTest {
     }
 
     @Test
+    func testMountTmpfsWithMode() throws {
+        let result = try Parser.mount("type=tmpfs,dst=/foo,size=64m,mode=1777")
+
+        switch result {
+        case .filesystem(let fs):
+            #expect(fs.destination == "/foo")
+            #expect(fs.options.contains("mode=1777"))
+        case .volume:
+            #expect(Bool(false), "Expected filesystem mount, got volume")
+        }
+    }
+
+    @Test
+    func testMountTmpfsSource() throws {
+        let result = try Parser.mount("type=tmpfs,target=/tmpfsmount1,size=512M")
+        switch result {
+        case .filesystem(let fs):
+            #expect(fs.type == .tmpfs)
+            #expect(fs.source == "tmpfs")
+            #expect(fs.destination == "/tmpfsmount1")
+            #expect(fs.options.contains("size=536870912"))
+        case .volume:
+            #expect(Bool(false), "Expected filesystem mount, got volume")
+        }
+    }
+
+    @Test
+    func testMountTmpfsSourceRejection() throws {
+        #expect(throws: ContainerizationError.self) {
+            _ = try Parser.mount("type=tmpfs,source=tmpfs,target=/tmpfsmount1")
+        }
+    }
+
+    @Test
     func testMountVolumeValidName() throws {
         let result = try Parser.mount("type=volume,src=myvolume,dst=/data")
 

--- a/Tests/IntegrationTests/Run/TestCLIRunCommand.swift
+++ b/Tests/IntegrationTests/Run/TestCLIRunCommand.swift
@@ -295,6 +295,32 @@ struct TestCLIRunCommand {
         }
     }
 
+    @Test func testRunCommandMountTmpfs() async throws {
+        try await ContainerFixture.with { f in
+            let image = alpine.rawValue
+            let c = "\(f.testID)-c"
+            try await f.doLongRun(
+                name: c, image: image,
+                args: ["--mount", "type=tmpfs,target=/tmp/testtmpfs,size=64m"],
+                autoRemove: false, waitUntilRunning: true)
+            f.addCleanup {
+                try? f.doStop(c)
+                try? f.doRemove(c)
+            }
+
+            let output = try f.doExec(c, cmd: ["df", "/tmp/testtmpfs"])
+            let lines = output.split(separator: "\n")
+            #expect(lines.count == 2)
+            let words = lines[1].split(separator: " ")
+            #expect(words[0].lowercased() == "tmpfs")
+
+            let mounts = try f.doExec(c, cmd: ["cat", "/proc/mounts"])
+            let mountLine = mounts.split(separator: "\n").first { $0.contains(" /tmp/testtmpfs ") }
+            #expect(mountLine != nil)
+            #expect(mountLine?.hasPrefix("tmpfs ") == true)
+        }
+    }
+
     @Test func testRunCommandShmSize() async throws {
         try await ContainerFixture.with { f in
             let image = alpine.rawValue


### PR DESCRIPTION
> [!IMPORTANT]
> All commits must be signed and verified. Pull requests containing unsigned or unverified commits cannot be built or merged. See the [GitHub documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#about-commit-signature-verification) for instructions.
>
> For all but trivial fixes, make sure to first create a GitHub issue that concisely describes the bug or desired enhancement as justification for the change. Large PRs with no justifying issue will be closed.

## Type of Change
- [X] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Fixes #2109.

`Filesystem.source` is left empty when a tmpfs mount is created via `--mount type=tmpfs,...`, which corrupts its entry in
`/proc/mounts` and breaks `df` (`df: tmpfs: No such file or directory`) and `mount`, both of which parse that line positionally.

`Parser.mount()` sets `Filesystem.type` for `type=tmpfs` but never sets `Filesystem.source`. The `--tmpfs` flag doesn't have this problem because it builds its `Filesystem` via `Filesystem.tmpfs()`, which already hardcodes `source: "tmpfs"`.

This sets `source` the same way in `Parser.mount()`, so both paths agree.

## Testing
- [X] Tested locally
- [X] Added/updated tests
- [ ] Added/updated docs

### Before / after
Added `testRunCommandMountTmpfs`, which runs a real container with `--mount type=tmpfs,...` and checks `df` and `/proc/mounts`.

**Before the fix:**
<img width="1249" height="78" alt="image" src="https://github.com/user-attachments/assets/5cfc71db-6224-40c0-b527-577091a244bd" />
✘ Test testRunCommandMountTmpfs() failed after 2.168 seconds with 1 issue.

**After the fix:**
<img width="1249" height="78" alt="image" src="https://github.com/user-attachments/assets/6f73716c-8dec-44f7-9f0e-5a6dacc7fc0b" />
✔ Test testRunCommandMountTmpfs() passed after 2.124 seconds.

Also ran the full targeted suites on the final diff:
- `swift test --filter ParserTest` — 138/138 passed
- `CONTAINER_CLI_PATH=$(pwd)/bin/container swift test --filter TestCLIRunCommand` — 33/33 passed
