### PR TITLE
Remove AsyncParsableCommand conformance from ContainerCLI 

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a823585b0904c85df871f25c3eddb487549c75a613b974e763013761fe5c95dd",
+  "originHash" : "35d1f07a3595a3ebabac1430f46ebb8b4e54d4531874f4ff7df33b64092df5f3",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "7800b4642171561c95b5f55500b19e5dce5acd45",
-        "version" : "0.40.1"
+        "revision" : "5427fd21ded4b84034126caef5b3182900b4776d",
+        "version" : "0.41.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ import PackageDescription
 let releaseVersion = ProcessInfo.processInfo.environment["RELEASE_VERSION"] ?? "0.0.0"
 let gitCommit = ProcessInfo.processInfo.environment["GIT_COMMIT"] ?? "unspecified"
 let builderShimVersion = "0.13.1"
-let scVersion = "0.40.1"
+let scVersion = "0.41.0"
 
 let package = Package(
     name: "container",

--- a/Sources/CLI/ContainerCLI.swift
+++ b/Sources/CLI/ContainerCLI.swift
@@ -14,26 +14,11 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import ArgumentParser
-import ContainerAPIClient
 import ContainerCommands
 
 @main
-public struct ContainerCLI: AsyncParsableCommand {
-    public init() {}
-
-    @Argument(parsing: .captureForPassthrough)
-    var arguments: [String] = []
-
-    public static let configuration = Application.configuration
-
-    public static func main() async throws {
+enum ContainerCLI {
+    static func main() async throws {
         try await Application.main()
-    }
-
-    public func run() async throws {
-        var application = try Application.parse(arguments)
-        try application.validate()
-        try application.run()
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> All commits must be signed and verified. Pull requests containing unsigned or unverified commits cannot be built or merged. See the [GitHub documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#about-commit-signature-verification) for instructions.
>
> For all but trivial fixes, make sure to first create a GitHub issue that concisely describes the bug or desired enhancement as justification for the change. Large PRs with no justifying issue will be closed.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
This removes the AsyncParsableCommand protocol from ContainerCLI since
it does not leverage the features that the protocol provides and the
extension main can cause confusion.

Bump to latest containerization version.

## Testing
- [X] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
