### PR TITLE
Update default kernel to Kata Containers 3.32.0 debug build

### DIFF
--- a/Sources/ContainerPersistence/ContainerSystemConfig.swift
+++ b/Sources/ContainerPersistence/ContainerSystemConfig.swift
@@ -165,10 +165,10 @@ final public class VminitConfig: Codable, Sendable {
 }
 
 final public class KernelConfig: Codable, Sendable {
-    public static let defaultBinaryPath = "opt/kata/share/kata-containers/vmlinux-6.18.15-186"
+    public static let defaultBinaryPath = "opt/kata/share/kata-containers/vmlinux-6.18.35-197-debug"
     public static let defaultURL: URL =
-        URL(string: "https://github.com/kata-containers/kata-containers/releases/download/3.28.0/kata-static-3.28.0-arm64.tar.zst")!
-    public static let defaultDigest = "sha256:f63d54507d1f18635d94475077e4c2330de4d8e05cedf25f7c38f063b0e66a91"
+        URL(string: "https://github.com/kata-containers/kata-containers/releases/download/3.32.0/kata-static-3.32.0-arm64.tar.zst")!
+    public static let defaultDigest = "sha256:8736c054d9223974735394f822000823baef509e1c33405ec798240fa9b6e4b5"
 
     private enum CodingKeys: String, CodingKey {
         case binaryPath

--- a/Tests/IntegrationTests/System/TestCLIKernelSetSerial.swift
+++ b/Tests/IntegrationTests/System/TestCLIKernelSetSerial.swift
@@ -35,22 +35,25 @@ struct TestCLIKernelSetSerial {
 
     /// Kernel release string parsed from the binary filename.
     ///
-    /// The binary path is conventionally `vmlinux-{release}` — but Kata's distribution
-    /// appends a `-{buildNumber}` suffix to the file (e.g. `vmlinux-6.18.15-186`)
-    /// while `uname -r` in the guest only reports the upstream release (`6.18.15`).
-    /// We strip a trailing `-N` where N is all digits to match what the guest reports,
-    /// while preserving non-numeric suffixes like `-rc1` or `-rt` that ARE part of the
-    /// upstream release string.
+    /// Kata names artifacts `vmlinux-{release}-{build}[-{variant}]` (e.g.
+    /// `vmlinux-6.18.35-197-debug`) while `uname -r` in the guest reports only the
+    /// release (`6.18.35`). We drop the first all-digit component after the release
+    /// and everything past it, preserving non-numeric components like `-rc1` or `-rt`
+    /// that ARE part of the upstream release string. A name with no build number is
+    /// returned unchanged.
     private var expectedKernelRelease: String {
         let filename = URL(fileURLWithPath: defaultBinaryPath).lastPathComponent
         let prefix = "vmlinux-"
         let raw = filename.hasPrefix(prefix) ? String(filename.dropFirst(prefix.count)) : filename
-        if let dashIdx = raw.lastIndex(of: "-"),
-            raw[raw.index(after: dashIdx)...].allSatisfy({ $0.isNumber })
-        {
-            return String(raw[..<dashIdx])
+        let components = raw.split(separator: "-", omittingEmptySubsequences: false)
+        guard
+            let buildIndex = components.dropFirst().firstIndex(where: {
+                !$0.isEmpty && $0.allSatisfy(\.isNumber)
+            })
+        else {
+            return raw
         }
-        return raw
+        return components[..<buildIndex].joined(separator: "-")
     }
 
     // MARK: - Tests

--- a/docs/container-system-config.md
+++ b/docs/container-system-config.md
@@ -31,9 +31,9 @@ memory = "1gb"
 domain = "test"
 
 [kernel]
-binaryPath = "opt/kata/share/kata-containers/vmlinux-6.18.15-186"
-url = "https://github.com/kata-containers/kata-containers/releases/download/3.28.0/kata-static-3.28.0-arm64.tar.zst"
-digest = "sha256:f63d54507d1f18635d94475077e4c2330de4d8e05cedf25f7c38f063b0e66a91"
+binaryPath = "opt/kata/share/kata-containers/vmlinux-6.18.35-197-debug"
+url = "https://github.com/kata-containers/kata-containers/releases/download/3.32.0/kata-static-3.32.0-arm64.tar.zst"
+digest = "sha256:8736c054d9223974735394f822000823baef509e1c33405ec798240fa9b6e4b5"
 
 [network]
 
@@ -103,9 +103,9 @@ Guest kernel used when launching container VMs. Defaults change per release as k
 
 | Key          | Type      | Default                                                                                                | Description                                                                  |
 |--------------|-----------|--------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|
-| `binaryPath` | `String`  | `"opt/kata/share/kata-containers/vmlinux-6.18.15-186"`                                                 | Path **inside** the downloaded kernel archive that points to the kernel binary. |
-| `url`        | `URL`     | `"https://github.com/kata-containers/kata-containers/releases/download/3.28.0/kata-static-3.28.0-arm64.tar.zst"` | Archive to download when no kernel is installed. Encoded and decoded as a plain string in TOML. |
-| `digest`     | `String`  | `"sha256:f63d54507d1f18635d94475077e4c2330de4d8e05cedf25f7c38f063b0e66a91"`                             | Expected digest for the archive, for example `sha256:<hex>`. Required when configuring a custom `url`. |
+| `binaryPath` | `String`  | `"opt/kata/share/kata-containers/vmlinux-6.18.35-197-debug"`                                           | Path **inside** the downloaded kernel archive that points to the kernel binary. |
+| `url`        | `URL`     | `"https://github.com/kata-containers/kata-containers/releases/download/3.32.0/kata-static-3.32.0-arm64.tar.zst"` | Archive to download when no kernel is installed. Encoded and decoded as a plain string in TOML. |
+| `digest`     | `String`  | `"sha256:8736c054d9223974735394f822000823baef509e1c33405ec798240fa9b6e4b5"`                             | Expected digest for the archive, for example `sha256:<hex>`. Required when configuring a custom `url`. |
 
 ## `[network]`
 


### PR DESCRIPTION
Update default kernel to Kata Containers 3.32.0 debug build

Switch the default guest kernel from vmlinux-6.18.15-186 (kata-static-3.28.0) to vmlinux-6.18.35-197-debug (kata-static-3.32.0).
This updates the kernel to a newer version. The debug variant enables eBPF, kprobes, uprobes, ftrace and BTF (kata-containers/kata-containers#12567).

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

This updates the kernel to a newer version. The debug variant enables eBPF, kprobes, uprobes, ftrace and BTF (kata-containers/kata-containers#12567).


## Testing
- [x] Tested locally
- [x] Added/updated tests
- [x] Added/updated docs
