### PR TITLE
fix(k8s): use the node's configured iptables backend for node prep

### DIFF
--- a/Sources/ContainerK8s/Support/K8sHelper+Bootstrap.swift
+++ b/Sources/ContainerK8s/Support/K8sHelper+Bootstrap.swift
@@ -130,8 +130,8 @@ extension K8sHelper {
         sysctl -w net.bridge.bridge-nf-call-ip6tables=1 2>/dev/null || true
         systemctl restart containerd
         ctr -n k8s.io images tag registry.k8s.io/pause:3.10 registry.k8s.io/pause:3.10.1 2>/dev/null || true
-        /usr/sbin/iptables-nft -t mangle -A OUTPUT  -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1220
-        /usr/sbin/iptables-nft -t mangle -A FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1220
+        /usr/sbin/iptables -t mangle -A OUTPUT  -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1220
+        /usr/sbin/iptables -t mangle -A FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1220
         """
     }
 


### PR DESCRIPTION
Fixes https://github.com/apple/container/issues/2120

## Summary

Use the node image's configured `iptables` alternative for the two TCP MSS clamping rules instead of hard-coding `iptables-nft`.

The original failure is specific to installations that still boot a kernel without nftables support. Container upgrades can retain an existing pre-1.0 guest kernel because `container system start` does not replace a kernel that is already installed. On the retained `vmlinux-6.12.28-153` kernel, node preparation aborts when the hard-coded `iptables-nft` commands fail.

The current recommended Kata 3.32.0 kernel (`vmlinux-6.18.35-197-debug`) has `CONFIG_NF_TABLES=y`; with that kernel, the existing `iptables-nft` commands work and an unmodified Container 1.4.1 completes `container k8s create`. This corrects the earlier interpretation that the failure was a Container 1.3.1 regression.

## Why this change is still useful

`kindest/node` selects an iptables backend during its entrypoint and updates `/etc/alternatives/iptables` before node preparation runs. On the retained kernel, it selects `iptables-legacy`, which works. Calling `/usr/sbin/iptables` respects that node-image decision and lets node preparation work with retained or deliberately selected kernels rather than assuming nftables is available.

Appending `|| true` would also prevent the abort, but it would silently omit the MSS clamping rules. This change keeps the rules and only removes the backend assumption.

The separate upgrade-path improvement discussed in https://github.com/apple/container/issues/2120 would be to detect an outdated Container-managed default kernel and notify or prompt the user without silently replacing a deliberately selected custom kernel.

## Evidence

On Container 1.4.1 with the retained `vmlinux-6.12.28-153` kernel:

```text
$ /usr/sbin/iptables-nft -t mangle -S
iptables v1.8.11 (nf_tables): Could not fetch rule set generation id: Invalid argument

$ /usr/sbin/iptables --version
iptables v1.8.11 (legacy)
```

Both TCPMSS rules apply successfully through `/usr/sbin/iptables`.

After installing the recommended kernel:

```text
$ container system kernel set --recommended --force
vmlinux-6.18.35-197-debug
```

`kindest/node:v1.35.5` reports `CONFIG_NF_TABLES=y`, `iptables-nft -t mangle -S` succeeds, and an unmodified `container k8s create --cpus 2 --memory 4g` completes successfully.

## Verification

- `swift build --product container`
- `swift build --target k8s`
- The changed node-prep commands apply both TCPMSS rules on the retained kernel through its configured legacy alternative.
- End-to-end `container k8s create` was reproduced failing on the retained kernel and succeeding after switching to the recommended kernel.

Environment: macOS 27.0, Apple silicon, Container 1.4.1, node image `docker.io/kindest/node:v1.35.5`.