### PR TITLE
feat(stats): report cpuPercent in the machine-readable formats

### DIFF
--- a/Sources/ContainerCommands/Container/ContainerStats.swift
+++ b/Sources/ContainerCommands/Container/ContainerStats.swift
@@ -153,58 +153,78 @@ extension Application {
             }
         }
 
-        private struct StatsSnapshot {
+        fileprivate struct StatsSnapshot {
             let container: ContainerSnapshot
             let stats1: ContainerResource.ContainerStats
             let stats2: ContainerResource.ContainerStats
+
+            /// Percent of one core, matching `top` and `docker stats`: 400% is four cores
+            /// saturated. Deliberately not divided by the container's CPU allocation.
+            var cpuPercent: Double? {
+                guard let first = stats1.cpuUsageUsec, let second = stats2.cpuUsageUsec else {
+                    return nil
+                }
+                return ContainerStats.calculateCPUPercent(
+                    cpuUsage1: .microseconds(first),
+                    cpuUsage2: .microseconds(second),
+                    timeInterval: ContainerStats.sampleInterval
+                )
+            }
         }
 
         /// `collectStats` sleeps for this between samples and the percentage divides by it,
         /// so the two must not drift apart.
-        private static let sampleInterval: Duration = .seconds(2)
+        static let sampleInterval: Duration = .seconds(2)
 
         /// The payload for the machine-readable formats: the second sample plus the CPU
         /// percentage derived from both.
         ///
         /// `ContainerResource.ContainerStats` models a single sample, and a rate is not a
         /// property of one sample, so the derived value lives here rather than widening that
-        /// type. Until now only `stats2` was rendered, which discarded both the percentage
-        /// the table computes and the earlier sample a consumer would need to compute it.
-        private struct StatsReport: Encodable {
-            let id: String
-            /// Percent of one core, matching `top` and `docker stats`: 400% is four cores
-            /// saturated. Deliberately not divided by the container's CPU allocation.
+        /// type. The sample is wrapped and flattened on encode so the stored shape stays
+        /// additive (`cpuPercent` only) without copying every sample field onto this type.
+        ///
+        /// Encoding goes through one keyed container. TOMLEncoder replaces `encoder.value`
+        /// on each `container(keyedBy:)` call, so `stats.encode(to:)` followed by a second
+        /// container would drop the sample fields.
+        struct StatsReport: Encodable {
+            let stats: ContainerResource.ContainerStats
             let cpuPercent: Double?
-            let cpuUsageUsec: UInt64?
-            let memoryUsageBytes: UInt64?
-            let memoryLimitBytes: UInt64?
-            let networkRxBytes: UInt64?
-            let networkTxBytes: UInt64?
-            let blockReadBytes: UInt64?
-            let blockWriteBytes: UInt64?
-            let numProcesses: UInt64?
 
-            init(snapshot: StatsSnapshot) {
-                let latest = snapshot.stats2
-                self.id = latest.id
-                self.cpuUsageUsec = latest.cpuUsageUsec
-                self.memoryUsageBytes = latest.memoryUsageBytes
-                self.memoryLimitBytes = latest.memoryLimitBytes
-                self.networkRxBytes = latest.networkRxBytes
-                self.networkTxBytes = latest.networkTxBytes
-                self.blockReadBytes = latest.blockReadBytes
-                self.blockWriteBytes = latest.blockWriteBytes
-                self.numProcesses = latest.numProcesses
+            fileprivate init(snapshot: StatsSnapshot) {
+                self.init(stats: snapshot.stats2, cpuPercent: snapshot.cpuPercent)
+            }
 
-                if let first = snapshot.stats1.cpuUsageUsec, let second = latest.cpuUsageUsec {
-                    self.cpuPercent = ContainerStats.calculateCPUPercent(
-                        cpuUsage1: .microseconds(first),
-                        cpuUsage2: .microseconds(second),
-                        timeInterval: ContainerStats.sampleInterval
-                    )
-                } else {
-                    self.cpuPercent = nil
-                }
+            init(stats: ContainerResource.ContainerStats, cpuPercent: Double?) {
+                self.stats = stats
+                self.cpuPercent = cpuPercent
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(stats.id, forKey: .id)
+                try container.encodeIfPresent(stats.cpuUsageUsec, forKey: .cpuUsageUsec)
+                try container.encodeIfPresent(stats.memoryUsageBytes, forKey: .memoryUsageBytes)
+                try container.encodeIfPresent(stats.memoryLimitBytes, forKey: .memoryLimitBytes)
+                try container.encodeIfPresent(stats.networkRxBytes, forKey: .networkRxBytes)
+                try container.encodeIfPresent(stats.networkTxBytes, forKey: .networkTxBytes)
+                try container.encodeIfPresent(stats.blockReadBytes, forKey: .blockReadBytes)
+                try container.encodeIfPresent(stats.blockWriteBytes, forKey: .blockWriteBytes)
+                try container.encodeIfPresent(stats.numProcesses, forKey: .numProcesses)
+                try container.encodeIfPresent(cpuPercent, forKey: .cpuPercent)
+            }
+
+            private enum CodingKeys: String, CodingKey {
+                case id
+                case cpuPercent
+                case cpuUsageUsec
+                case memoryUsageBytes
+                case memoryLimitBytes
+                case networkRxBytes
+                case networkTxBytes
+                case blockReadBytes
+                case blockWriteBytes
+                case numProcesses
             }
         }
 
@@ -248,9 +268,9 @@ extension Application {
 
         /// Calculate CPU percentage from two stat snapshots
         /// - Parameters:
-        ///   - cpuUsageUsec1: CPU usage in microseconds from first sample
-        ///   - cpuUsageUsec2: CPU usage in microseconds from second sample
-        ///   - timeDeltaUsec: Time delta between samples in microseconds
+        ///   - cpuUsage1: CPU usage from the first sample
+        ///   - cpuUsage2: CPU usage from the second sample
+        ///   - timeInterval: Wall-clock interval between samples
         /// - Returns: CPU percentage where 100% = one fully utilized core
         static func calculateCPUPercent(
             cpuUsage1: Duration,
@@ -287,17 +307,10 @@ extension Application {
 
             for snapshot in statsData {
                 var row = [snapshot.container.id]
-                let stats1 = snapshot.stats1
                 let stats2 = snapshot.stats2
 
-                if let cpuUsageUsec1 = stats1.cpuUsageUsec, let cpuUsageUsec2 = stats2.cpuUsageUsec {
-                    let cpuPercent = Self.calculateCPUPercent(
-                        cpuUsage1: .microseconds(cpuUsageUsec1),
-                        cpuUsage2: .microseconds(cpuUsageUsec2),
-                        timeInterval: Self.sampleInterval
-                    )
-                    let cpuStr = String(format: "%.2f%%", cpuPercent)
-                    row.append(cpuStr)
+                if let cpuPercent = snapshot.cpuPercent {
+                    row.append(String(format: "%.2f%%", cpuPercent))
                 } else {
                     row.append(notAvailable)
                 }

--- a/Sources/ContainerCommands/Container/ContainerStats.swift
+++ b/Sources/ContainerCommands/Container/ContainerStats.swift
@@ -102,7 +102,7 @@ extension Application {
 
             let statsData = try await Self.collectStats(client: client, for: containersToShow)
 
-            try Output.render(payload: statsData.map { $0.stats2 }, format: format) {
+            try Output.render(payload: statsData.map { StatsReport(snapshot: $0) }, format: format) {
                 Self.statsTable(statsData)
             }
         }
@@ -159,6 +159,55 @@ extension Application {
             let stats2: ContainerResource.ContainerStats
         }
 
+        /// `collectStats` sleeps for this between samples and the percentage divides by it,
+        /// so the two must not drift apart.
+        private static let sampleInterval: Duration = .seconds(2)
+
+        /// The payload for the machine-readable formats: the second sample plus the CPU
+        /// percentage derived from both.
+        ///
+        /// `ContainerResource.ContainerStats` models a single sample, and a rate is not a
+        /// property of one sample, so the derived value lives here rather than widening that
+        /// type. Until now only `stats2` was rendered, which discarded both the percentage
+        /// the table computes and the earlier sample a consumer would need to compute it.
+        private struct StatsReport: Encodable {
+            let id: String
+            /// Percent of one core, matching `top` and `docker stats`: 400% is four cores
+            /// saturated. Deliberately not divided by the container's CPU allocation.
+            let cpuPercent: Double?
+            let cpuUsageUsec: UInt64?
+            let memoryUsageBytes: UInt64?
+            let memoryLimitBytes: UInt64?
+            let networkRxBytes: UInt64?
+            let networkTxBytes: UInt64?
+            let blockReadBytes: UInt64?
+            let blockWriteBytes: UInt64?
+            let numProcesses: UInt64?
+
+            init(snapshot: StatsSnapshot) {
+                let latest = snapshot.stats2
+                self.id = latest.id
+                self.cpuUsageUsec = latest.cpuUsageUsec
+                self.memoryUsageBytes = latest.memoryUsageBytes
+                self.memoryLimitBytes = latest.memoryLimitBytes
+                self.networkRxBytes = latest.networkRxBytes
+                self.networkTxBytes = latest.networkTxBytes
+                self.blockReadBytes = latest.blockReadBytes
+                self.blockWriteBytes = latest.blockWriteBytes
+                self.numProcesses = latest.numProcesses
+
+                if let first = snapshot.stats1.cpuUsageUsec, let second = latest.cpuUsageUsec {
+                    self.cpuPercent = ContainerStats.calculateCPUPercent(
+                        cpuUsage1: .microseconds(first),
+                        cpuUsage2: .microseconds(second),
+                        timeInterval: ContainerStats.sampleInterval
+                    )
+                } else {
+                    self.cpuPercent = nil
+                }
+            }
+        }
+
         private static func collectStats(client: ContainerClient, for containers: [ContainerSnapshot]) async throws -> [StatsSnapshot] {
             var snapshots: [StatsSnapshot] = []
 
@@ -176,7 +225,7 @@ extension Application {
 
             // Wait 2 seconds for CPU delta calculation
             if !snapshots.isEmpty {
-                try await Task.sleep(for: .seconds(2))
+                try await Task.sleep(for: Self.sampleInterval)
 
                 // Second sample
                 for i in 0..<snapshots.count {
@@ -245,7 +294,7 @@ extension Application {
                     let cpuPercent = Self.calculateCPUPercent(
                         cpuUsage1: .microseconds(cpuUsageUsec1),
                         cpuUsage2: .microseconds(cpuUsageUsec2),
-                        timeInterval: .seconds(2)
+                        timeInterval: Self.sampleInterval
                     )
                     let cpuStr = String(format: "%.2f%%", cpuPercent)
                     row.append(cpuStr)

--- a/Tests/ContainerCommandsTests/StatsReportTests.swift
+++ b/Tests/ContainerCommandsTests/StatsReportTests.swift
@@ -1,0 +1,154 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerResource
+import Foundation
+import Testing
+
+@testable import ContainerCommands
+
+private func makeSampleStats(
+    id: String = "busy",
+    memoryUsageBytes: UInt64? = 1024,
+    memoryLimitBytes: UInt64? = 256 * 1024 * 1024,
+    cpuUsageUsec: UInt64? = 2_000_000,
+    networkRxBytes: UInt64? = 10,
+    networkTxBytes: UInt64? = 20,
+    blockReadBytes: UInt64? = 30,
+    blockWriteBytes: UInt64? = 40,
+    numProcesses: UInt64? = 1
+) -> ContainerResource.ContainerStats {
+    ContainerResource.ContainerStats(
+        id: id,
+        memoryUsageBytes: memoryUsageBytes,
+        memoryLimitBytes: memoryLimitBytes,
+        cpuUsageUsec: cpuUsageUsec,
+        networkRxBytes: networkRxBytes,
+        networkTxBytes: networkTxBytes,
+        blockReadBytes: blockReadBytes,
+        blockWriteBytes: blockWriteBytes,
+        numProcesses: numProcesses
+    )
+}
+
+private func jsonObject(from report: Application.ContainerStats.StatsReport) throws -> [String: Any] {
+    let data = try JSONEncoder().encode(report)
+    return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+}
+
+struct CalculateCPUPercentTests {
+    @Test
+    func oneCoreFullyUtilizedIs100Percent() {
+        let percent = Application.ContainerStats.calculateCPUPercent(
+            cpuUsage1: .seconds(0),
+            cpuUsage2: .seconds(2),
+            timeInterval: Application.ContainerStats.sampleInterval
+        )
+        #expect(percent == 100.0)
+    }
+
+    @Test
+    func fourCoresSaturatedIs400Percent() {
+        let percent = Application.ContainerStats.calculateCPUPercent(
+            cpuUsage1: .seconds(0),
+            cpuUsage2: .seconds(8),
+            timeInterval: Application.ContainerStats.sampleInterval
+        )
+        #expect(percent == 400.0)
+    }
+
+    @Test
+    func unchangedUsageIsZero() {
+        let percent = Application.ContainerStats.calculateCPUPercent(
+            cpuUsage1: .milliseconds(500),
+            cpuUsage2: .milliseconds(500),
+            timeInterval: Application.ContainerStats.sampleInterval
+        )
+        #expect(percent == 0.0)
+    }
+
+    @Test
+    func usageDecreaseIsTreatedAsZero() {
+        let percent = Application.ContainerStats.calculateCPUPercent(
+            cpuUsage1: .seconds(4),
+            cpuUsage2: .seconds(1),
+            timeInterval: Application.ContainerStats.sampleInterval
+        )
+        #expect(percent == 0.0)
+    }
+}
+
+struct StatsReportEncodingTests {
+    @Test
+    func jsonIncludesCpuPercentAndForwardsEverySampleField() throws {
+        let stats = makeSampleStats()
+        let report = Application.ContainerStats.StatsReport(stats: stats, cpuPercent: 42.5)
+        let sample = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(stats)) as? [String: Any]
+        )
+        let encoded = try jsonObject(from: report)
+
+        for key in sample.keys {
+            #expect(encoded[key] != nil, "StatsReport dropped sample field \(key)")
+        }
+        #expect(encoded["stats"] == nil, "sample should be flattened, not nested under stats")
+        #expect(encoded["cpuPercent"] as? Double == 42.5)
+        #expect(encoded["id"] as? String == "busy")
+
+        let decoded = try JSONDecoder().decode(
+            ContainerResource.ContainerStats.self,
+            from: JSONEncoder().encode(report)
+        )
+        #expect(decoded.id == stats.id)
+        #expect(decoded.memoryUsageBytes == stats.memoryUsageBytes)
+        #expect(decoded.cpuUsageUsec == stats.cpuUsageUsec)
+    }
+
+    @Test
+    func jsonOmitsNilCpuPercent() throws {
+        let report = Application.ContainerStats.StatsReport(stats: makeSampleStats(), cpuPercent: nil)
+        let encoded = try jsonObject(from: report)
+        #expect(encoded["cpuPercent"] == nil)
+        #expect(encoded["id"] as? String == "busy")
+    }
+
+    @Test
+    func renderJSONIncludesCpuPercent() throws {
+        let report = Application.ContainerStats.StatsReport(stats: makeSampleStats(), cpuPercent: 12.25)
+        let json = try Output.renderJSON([report])
+        #expect(json.contains("\"cpuPercent\":12.25"))
+        #expect(json.contains("\"id\":\"busy\""))
+    }
+
+    @Test
+    func renderYAMLIncludesCpuPercent() throws {
+        let report = Application.ContainerStats.StatsReport(stats: makeSampleStats(), cpuPercent: 12.25)
+        let yaml = try Output.renderYAML([report])
+        #expect(yaml.contains("cpuPercent"))
+        #expect(yaml.contains("busy"))
+        #expect(yaml.contains("memoryUsageBytes"))
+    }
+
+    @Test
+    func renderTOMLIncludesCpuPercent() throws {
+        let report = Application.ContainerStats.StatsReport(stats: makeSampleStats(), cpuPercent: 12.25)
+        let toml = try Output.renderTOML([report])
+        #expect(toml.contains("cpuPercent"))
+        #expect(toml.contains("12.25"))
+        #expect(toml.contains("busy"))
+        #expect(toml.contains("memoryUsageBytes"))
+    }
+}

--- a/Tests/IntegrationTests/Containers/TestCLIStatsCommand.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIStatsCommand.swift
@@ -14,10 +14,18 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import ContainerResource
 import ContainerTestSupport
 import Foundation
 import Testing
+
+/// Machine-readable stats payload, including the derived `cpuPercent` that
+/// `ContainerResource.ContainerStats` does not carry.
+private struct StatsJSON: Decodable {
+    let id: String
+    let cpuPercent: Double?
+    let memoryUsageBytes: UInt64?
+    let numProcesses: UInt64?
+}
 
 @Suite
 struct TestCLIStatsCommand {
@@ -26,13 +34,15 @@ struct TestCLIStatsCommand {
             let image = WarmupImage.alpine320.rawValue
             try await f.withContainer(image: image) { name in
                 let result = try f.run(["stats", "--format", "json", "--no-stream", name]).check()
-                let stats = try JSONDecoder().decode([ContainerStats].self, from: result.outputData)
+                let stats = try JSONDecoder().decode([StatsJSON].self, from: result.outputData)
                 #expect(stats.count == 1, "expected stats for one container")
                 #expect(stats[0].id == name, "container ID should match")
                 let memoryUsageBytes = try #require(stats[0].memoryUsageBytes)
                 let numProcesses = try #require(stats[0].numProcesses)
+                let cpuPercent = try #require(stats[0].cpuPercent, "json should include cpuPercent")
                 #expect(memoryUsageBytes > 0, "memory usage should be non-zero")
                 #expect(numProcesses >= 1, "should have at least one process")
+                #expect(cpuPercent >= 0, "cpuPercent should be non-negative, got \(cpuPercent)")
             }
         }
     }
@@ -94,11 +104,15 @@ struct TestCLIStatsCommand {
             try await f.withContainer(image: image, tag: "c1") { name1 in
                 try await f.withContainer(image: image, tag: "c2") { name2 in
                     let result = try f.run(["stats", "--format", "json", "--no-stream"]).check()
-                    let stats = try JSONDecoder().decode([ContainerStats].self, from: result.outputData)
+                    let stats = try JSONDecoder().decode([StatsJSON].self, from: result.outputData)
                     try #require(stats.count >= 2, "should have stats for at least 2 containers")
                     let ids = stats.map { $0.id }
                     #expect(ids.contains(name1), "should include first container")
                     #expect(ids.contains(name2), "should include second container")
+                    for row in stats where ids.contains(row.id) {
+                        let cpuPercent = try #require(row.cpuPercent, "json should include cpuPercent for \(row.id)")
+                        #expect(cpuPercent >= 0, "cpuPercent should be non-negative, got \(cpuPercent)")
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #2144

`container stats` already samples twice, sleeping two seconds between samples, and computes a CPU percentage from the pair for its table. `Output.render` received only `stats2`, so `json`, `yaml` and `toml` consumers paid that latency and got back neither the percentage nor the earlier sample needed to derive it. Obtaining a CPU percentage from the CLI meant invoking the command twice and diffing `cpuUsageUsec` by hand — four seconds of sleeping for a number the tool already had after two.

## Change

A `StatsReport` payload for the non-table formats: the latest sample plus the derived percentage.

`ContainerResource.ContainerStats` is documented as modelling a single sample, and a rate is not a property of one sample, so the derived value lives in the command rather than widening that type. That also keeps the wire shape of the existing fields unchanged — `cpuPercent` is additive.

The two-second interval becomes a single `sampleInterval` constant. `collectStats` sleeps for it and `calculateCPUPercent` divides by it, so the two have to agree; they were separate `.seconds(2)` literals before, one in `collectStats` and one in `statsTable`.

## Verification, end to end with this build

Table (unchanged) and json side by side, same runtime, four containers — one of them a `while :; do :; done` loop allocated a single CPU:

```
$ .build/debug/container stats --no-stream
Container ID  Cpu %    Memory Usage            Pids
cs-spin       101.49%  2.69 MiB / 256.00 MiB   1
cs-mem        0.00%    66.96 MiB / 512.00 MiB  1
arango        0.65%    5.64 GiB / 6.00 GiB     61
cs-idle       0.00%    2.60 MiB / 2.00 GiB     1

$ .build/debug/container stats --no-stream --format json
fields: [blockReadBytes, blockWriteBytes, cpuPercent, cpuUsageUsec, id,
         memoryLimitBytes, memoryUsageBytes, networkRxBytes, networkTxBytes, numProcesses]

cs-spin    cpuPercent = 107.43
cs-mem     cpuPercent = 0
arango     cpuPercent = 0.7456
cs-idle    cpuPercent = 0
```

The percentages agree with the table across independent samplings, and the single-CPU spin loop reads ~100% as expected.

`yaml` and `toml` carry the field too, including through TOML's `[[items]]` wrapper for top-level arrays:

```
- id: cs-spin
  cpuPercent: 1.045919e+2

[[items]]
cpuPercent = 102.27360000000002
```

`swift build --product container` succeeds; `swift test --filter ContainerCommandsTests` → 29 tests in 10 suites passed.

## Two things I left for your call

1. **Units in the name.** `calculateCPUPercent` documents "100% = one fully utilized core", matching `top` and `docker stats`. I noted that on the field, because I made the opposite mistake against this API before checking `container stats` as ground truth — dividing by the container's CPU allocation, which understates a 4-CPU container fourfold. Happy to rename to something like `cpuPercentOfOneCore` if you would prefer the convention in the name.
2. **`stats1` is still dropped.** Emitting both samples would let a consumer compute other rates (network and block I/O per second) the same way. I kept this PR to the one number the table already shows; say the word if the fuller shape is preferable.

Environment: macOS 27.0 (Tahoe), Apple silicon, Swift 6.4.

Per CONTRIBUTING: I used AI assistance while investigating and drafting this, and I can explain and justify every line — the change moves an already-computed value into the rendered payload and de-duplicates one interval literal.
