### PR TITLE
Skip unreadable entries in image list

### DIFF
--- a/Sources/ContainerCommands/Image/ImageList.swift
+++ b/Sources/ContainerCommands/Image/ImageList.swift
@@ -63,7 +63,16 @@ extension Application {
                 return
             }
 
-            let resources = try await Self.buildResources(images: images, containerSystemConfig: containerSystemConfig)
+            let resources = await Self.buildResources(
+                images: images,
+                containerSystemConfig: containerSystemConfig,
+                onError: { image, error in
+                    log.warning(
+                        "skipping unreadable image",
+                        metadata: ["image": "\(image.reference)", "error": "\(error)"]
+                    )
+                }
+            )
 
             try Output.render(payload: resources, format: format) {
                 if verbose {
@@ -81,14 +90,34 @@ extension Application {
 
         /// Builds the resource for each image, denormalizing the reference so the
         /// display name omits the default registry.
-        private static func buildResources(images: [ClientImage], containerSystemConfig: ContainerSystemConfig) async throws -> [ImageResource] {
-            var resources: [ImageResource] = []
-            for image in images {
-                resources.append(
+        private static func buildResources(
+            images: [ClientImage],
+            containerSystemConfig: ContainerSystemConfig,
+            onError: (ClientImage, any Error) -> Void
+        ) async -> [ImageResource] {
+            await collectReadableValues(
+                from: images,
+                resolve: { image in
                     try await image.toImageResource(containerSystemConfig: containerSystemConfig)
-                )
+                },
+                onError: onError
+            )
+        }
+
+        static func collectReadableValues<Input, Value>(
+            from inputs: [Input],
+            resolve: (Input) async throws -> Value,
+            onError: (Input, any Error) -> Void
+        ) async -> [Value] {
+            var values: [Value] = []
+            for input in inputs {
+                do {
+                    values.append(try await resolve(input))
+                } catch {
+                    onError(input, error)
+                }
             }
-            return resources
+            return values
         }
     }
 }

--- a/Tests/ContainerCommandsTests/ImageListTests.swift
+++ b/Tests/ContainerCommandsTests/ImageListTests.swift
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import ContainerCommands
+
+struct ImageListTests {
+    private enum TestError: Error {
+        case unreadable
+    }
+
+    @Test
+    func unreadableEntryDoesNotPreventOtherEntriesFromResolving() async {
+        let inputs = ["healthy-one", "unreadable", "healthy-two"]
+        var failures: [String] = []
+        var failureDescriptions: [String] = []
+
+        let values = await Application.ImageList.collectReadableValues(
+            from: inputs,
+            resolve: { input in
+                if input == "unreadable" {
+                    throw TestError.unreadable
+                }
+                return input.uppercased()
+            },
+            onError: { input, error in
+                failures.append(input)
+                failureDescriptions.append("\(error)")
+            }
+        )
+
+        #expect(values == ["HEALTHY-ONE", "HEALTHY-TWO"])
+        #expect(failures == ["unreadable"])
+        #expect(failureDescriptions == ["unreadable"])
+    }
+}


### PR DESCRIPTION
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

`container image list` currently fails completely when one image record references
an unreadable or missing content blob. Healthy images are not rendered, and
structured output such as JSON and YAML is unavailable.

This PR resolves each image independently:

- healthy images remain visible;
- unreadable images are reported as warnings;
- warnings are written to stderr;
- structured stdout remains valid;
- the command exits successfully when the listing can continue.

Fixes #2149.

## Reproduction

### Environment

- macOS 26, arm64
- one healthy image: `docker.io/library/alpine:latest`
- one broken image record: `example.invalid/broken:latest`
- the broken record contains a syntactically valid image descriptor, but its
  referenced root content blob is absent

I used an isolated application root so that the reproduction does not affect
the normal container state:

```bash
export APP_ROOT=/tmp/container-image-list-repro

container system start \
    --app-root "$APP_ROOT" \
    --disable-kernel-install

container image pull docker.io/library/alpine:latest
container system stop
```

I then added the following image record to `$APP_ROOT/state.json` without
creating its referenced content blob:

```json
{
  "example.invalid/broken:latest": {
    "digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
    "size": 1,
    "mediaType": "application/vnd.oci.image.index.v1+json"
  }
}
```

The following file was intentionally absent:

```text
$APP_ROOT/content/blobs/sha256/ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
```

## Behavior Before This PR

With container 1.3.0, before `apple/containerization#898`, the following
commands fail before rendering the healthy image:

```bash
container image list
container image list --format json
container image list --format yaml
container image list --verbose
```

Each command returns an error similar to:

```text
Error: content with digest sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
```

The command exits with status `1`.

`container image list -q` continues to work because quiet mode does not resolve
the image content:

```text
alpine:latest
example.invalid/broken:latest
```

## Verification Against `containerization#898`

I repeated the same reproduction with container 1.3.1, which includes the
changes from [apple/containerization#898](https://github.com/apple/containerization/pull/898).

The detailed listing commands still fail with the same missing-content-blob
error, while quiet mode remains successful.

This indicates that `containerization#898` does not cover this case: the image
store state record is readable, but the content blob referenced by the image
record is missing. The failure occurs later when `container image list` tries to
resolve the image content.

## Behavior With This PR

With this PR, the healthy image remains available and the broken image is
reported as a warning:

```text
skipping unreadable image: ["error": notFound: "content with digest sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", "image": example.invalid/broken:latest]
NAME    TAG     DIGEST
alpine  latest  28bd5fe8b56d
```

The same skip-and-warn behavior applies to table, verbose, JSON, and YAML
output.

For example, JSON output can be captured separately from the warning:

```bash
container image list --format json > images.json 2> warning.log
```

The result is:

- exit status: `0`;
- `images.json` contains the healthy image and remains valid JSON;
- `warning.log` identifies the skipped image and the underlying error.

The healthy image can be inspected from the JSON output:

```bash
jq length images.json
# 1

jq -r '.[0].configuration.name' images.json
# docker.io/library/alpine:latest
```

## Scope and Non-Goals

This PR changes image-listing behavior only.

It does not:

- repair the missing content blob;
- remove the broken image record;
- add an image repair or prune command;
- change the behavior of `container image inspect`, `pull`, or `run`;
- hide the underlying error from the user.

The broken image is still identified, and its error is written to stderr. The
change only prevents one unreadable entry from invalidating the entire listing
or corrupting structured stdout.

## Testing

- `make test`: 760 tests in 83 suites passed
- `make check`: formatting and license checks passed
- manually verified table output
- manually verified verbose output
- manually verified JSON output
- manually verified YAML output
- manually verified quiet output
- verified that warnings are written to stderr
- verified that structured stdout remains valid JSON
- verified that the healthy image remains listed when the broken image is
  encountered

## Summary

The underlying broken image resource remains unchanged, but `container image
list` can now provide useful results instead of failing completely because of a
single unreadable image entry.


---
I use Codex help write this description