### PR TITLE
Fix Kubernetes control-plane restart after IP rotation

### DIFF
--- a/Sources/ContainerK8s/Commands/K8sCreate.swift
+++ b/Sources/ContainerK8s/Commands/K8sCreate.swift
@@ -102,6 +102,10 @@ public struct K8sCreate: AsyncParsableCommand {
             try await K8sHelper.prepareNode(nodeID: name, client: client, log: log)
             try await K8sHelper.bootstrapControlPlane(
                 nodeID: name, apiServerSANs: sans, advertiseAddress: vmIP,
+                // All in-VM Kubernetes clients (including host-networked kube-proxy)
+                // can reach the single-node API through loopback. This endpoint is
+                // independent of the container's rotating vmnet address.
+                controlPlaneEndpoint: K8sHelper.nodeLocalControlPlaneEndpoint,
                 schedulable: provisioner.roles.contains(StandardRoles.worker),
                 client: client, log: log)
 

--- a/Sources/ContainerK8s/K8sHelper.swift
+++ b/Sources/ContainerK8s/K8sHelper.swift
@@ -51,6 +51,8 @@ public struct K8sHelper {
     static let proxyEnvVars = ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy"]
 
     public static let clusterContainerPort: UInt16 = 6443
+    /// Endpoint used by clients inside the single-node cluster container.
+    static let nodeLocalControlPlaneEndpoint = "127.0.0.1:\(clusterContainerPort)"
 
     // MARK: - Resource defaults
 

--- a/Sources/ContainerK8s/Support/K8sHelper+Bootstrap.swift
+++ b/Sources/ContainerK8s/Support/K8sHelper+Bootstrap.swift
@@ -35,12 +35,15 @@ extension K8sHelper {
 
     static func bootstrapControlPlane(
         nodeID: String, apiServerSANs: [String], advertiseAddress: String,
+        controlPlaneEndpoint: String,
         schedulable: Bool, client: ContainerClient, log: Logger
     ) async throws {
-        let configYAML = initConfigYAML(advertiseAddress: advertiseAddress, certSANs: apiServerSANs)
+        let configYAML = initConfigYAML(
+            advertiseAddress: advertiseAddress, certSANs: apiServerSANs,
+            controlPlaneEndpoint: controlPlaneEndpoint)
         var r = try await execCapture(
             containerId: nodeID, executable: "/bin/sh",
-            arguments: ["-c", "cat > /etc/kubernetes/kubeadm-config.yaml <<'EOF'\n\(configYAML)\nEOF"],
+            arguments: ["-c", "mkdir -p /kind && cat > /kind/kubeadm.conf <<'EOF'\n\(configYAML)\nEOF"],
             client: client)
         guard r.code == 0 else {
             throw ContainerizationError(.internalError, message: "write kubeadm config failed on \(nodeID): \(r.output)")
@@ -50,7 +53,7 @@ extension K8sHelper {
         r = try await execCapture(
             containerId: nodeID, executable: kubeadmPath,
             arguments: [
-                "init", "--config", "/etc/kubernetes/kubeadm-config.yaml",
+                "init", "--config", "/kind/kubeadm.conf",
                 "--ignore-preflight-errors", ignorePreflightErrors,
             ],
             client: client)
@@ -135,7 +138,9 @@ extension K8sHelper {
         """
     }
 
-    private static func initConfigYAML(advertiseAddress: String, certSANs: [String]) -> String {
+    static func initConfigYAML(
+        advertiseAddress: String, certSANs: [String], controlPlaneEndpoint: String
+    ) -> String {
         let sans = certSANs.map { "  - \($0)" }.joined(separator: "\n")
         return """
             apiVersion: kubeadm.k8s.io/v1beta4
@@ -148,6 +153,7 @@ extension K8sHelper {
             ---
             apiVersion: kubeadm.k8s.io/v1beta4
             kind: ClusterConfiguration
+            controlPlaneEndpoint: \(controlPlaneEndpoint)
             kubernetesVersion: \(kubernetesVersion())
             networking:
               podSubnet: \(podSubnet)

--- a/Tests/IntegrationTests/K8s/TestK8sRunSerial.swift
+++ b/Tests/IntegrationTests/K8s/TestK8sRunSerial.swift
@@ -115,4 +115,53 @@ struct TestK8sRunSerial {
             #expect(server1 != server2)
         }
     }
+
+    @Test func testRestartAfterAddressRotation() async throws {
+        try await ContainerFixture.with { f in
+            let name = "k8s-\(f.testID)"
+            let bumper = "\(name)-bumper"
+            f.addCleanup { try f.doRemoveIfExists(bumper, force: true, ignoreFailure: true) }
+            f.addCleanup { _ = try? f.run(["k8s", "delete", "--name", name]) }
+
+            try f.restoreWarmupImage(.kindestNodeV1_35_5)
+            try f.run(["k8s", "create", "--name", name]).check()
+
+            let originalAddress = try f.run(["exec", name, "cat", "/kind/old-ipv4"])
+            try originalAddress.check()
+            #expect(try f.run(["exec", name, "test", "-f", "/kind/kubeadm.conf"]).status == 0)
+            try f.run([
+                "exec", name, "grep", "-F", "controlPlaneEndpoint: 127.0.0.1:6443", "/kind/kubeadm.conf",
+            ]).check()
+
+            try f.run(["stop", name]).check()
+            // Advance the rotating allocator while the node is stopped so its
+            // restart cannot accidentally reuse the same address.
+            try f.restoreWarmupImage(.alpine320)
+            try f.run([
+                "run", "--name", bumper, "-d", WarmupImage.alpine320.rawValue,
+                "sleep", "infinity",
+            ]).check()
+
+            let restart = try f.run(["k8s", "start", "--name", name])
+            if restart.status != 0 {
+                print("[k8s-run] restart stderr: \(restart.error)")
+                f.dumpNodeDiagnostics(node: name)
+            }
+            try restart.check()
+
+            let rotatedAddress = try f.run(["exec", name, "cat", "/kind/old-ipv4"])
+            try rotatedAddress.check()
+            let originalIP = originalAddress.output.trimmingCharacters(in: .whitespacesAndNewlines)
+            let rotatedIP = rotatedAddress.output.trimmingCharacters(in: .whitespacesAndNewlines)
+            print("[k8s-run] restart rotated address \(originalIP) -> \(rotatedIP)")
+            #expect(originalIP != rotatedIP)
+            #expect(try f.getContainerStatus(name) == "running")
+            try f.run([
+                "exec", name, "grep", "-F", "advertiseAddress: \(rotatedIP)", "/kind/kubeadm.conf",
+            ]).check()
+            try f.run([
+                "exec", name, "kubectl", "wait", "--for=condition=Ready", "node", "--all", "--timeout=30s",
+            ]).check()
+        }
+    }
 }

--- a/Tests/K8sPluginTests/K8sBootstrapTests.swift
+++ b/Tests/K8sPluginTests/K8sBootstrapTests.swift
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Testing
+import Yams
+
+@testable import ContainerK8s
+
+@Suite("K8s bootstrap configuration")
+struct K8sBootstrapTests {
+    @Test func nodeLocalEndpointUsesClusterPort() {
+        #expect(K8sHelper.nodeLocalControlPlaneEndpoint == "127.0.0.1:6443")
+    }
+
+    @Test func nodeLocalControlPlaneEndpointIsRendered() {
+        let yaml = K8sHelper.initConfigYAML(
+            advertiseAddress: "192.168.64.2",
+            certSANs: ["127.0.0.1"],
+            controlPlaneEndpoint: K8sHelper.nodeLocalControlPlaneEndpoint)
+
+        #expect(yaml.contains("controlPlaneEndpoint: 127.0.0.1:6443"))
+        #expect(yaml.contains("advertiseAddress: 192.168.64.2"))
+        #expect(yaml.contains("  - 127.0.0.1"))
+        for document in yaml.components(separatedBy: "\n---\n") {
+            #expect((try? Yams.load(yaml: document)) != nil)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fix restart of newly created Kubernetes nodes after their container VM gets a
new IPv4 address.

Closes #2156.

## Bug before

On a clean 1.3.0 installation, with no workload or custom DNS:

```sh
container k8s create --name k8s-repro
container stop k8s-repro
container k8s start --name k8s-repro
```

The first restart changed `192.168.64.2 -> 192.168.64.3` and failed in the
kind entrypoint:

```text
INFO: detected IPv4 address: 192.168.64.3
INFO: detected old IPv4 address: 192.168.64.2
error: unable to read config from "/kind/kubeadm.conf":
open /kind/kubeadm.conf: no such file or directory
```

There are two independent causes:

1. The plugin ran kubeadm with `/etc/kubernetes/kubeadm-config.yaml`, but a
   kind node expects its provider to create `/kind/kubeadm.conf` for restart
   reconciliation. The file was never created; kubeadm did not consume it.
2. Without `controlPlaneEndpoint`, kubeadm persisted the current vmnet address
   in clients such as admin.conf and kube-proxy. Preserving only the kind file
   let kind repair the API server, but kube-proxy still dialed the retired
   address and CoreDNS stayed unready.

## Fix and behavior afterwards

- Write the generated configuration directly to `/kind/kubeadm.conf` and run
  kubeadm with that same file, matching kind's provider contract.
- Set `controlPlaneEndpoint` to `127.0.0.1:6443` for clients inside the current
  single-node control-plane/worker VM.

On restart, kind rewrites address-dependent advertise and certificate state to
the new VM address. Persistent in-VM clients keep using loopback, so they do not
retain a rotating vmnet address. The node still advertises its real current
address, and host kubeconfig generation remains unchanged.

This intentionally does not add sticky IP allocation, DNS setup, a proxy, or a
start-time reconciliation hook. Existing clusters created without
`/kind/kubeadm.conf` are not migrated by this change.

Loopback is appropriate for the plugin's current one-VM topology. Separate
workers or multiple control planes would require a stable shared DNS, VIP, or
load-balancer endpoint instead.

## Testing

- Built the rebased patch on current `main` with `make container`.
- `swift test --filter K8sBootstrapTests`: 2/2 passed.
- `TestK8sRunSerial.testRestartAfterAddressRotation` passed twice against the
  rebuilt daemon, including `192.168.64.5 -> 192.168.64.7` after the test used
  an intervening container to advance the rotating allocator.
- The regression verifies `/kind/kubeadm.conf`, the loopback endpoint, actual
  address rotation, kind's rewritten `advertiseAddress`, successful
  `k8s start`, and a Ready node. Cleanup removes both test containers.
- A separate restarted-cluster smoke test loaded local Caddy and Alpine images,
  resolved the Service through CoreDNS, and fetched it successfully.
- Strict Swift format lint and `git diff --check` passed.
