### PR TITLE
Reclaim the snapshot a record stops naming

### DIFF
--- a/Sources/Services/ContainerImagesService/Server/ImagesService.swift
+++ b/Sources/Services/ContainerImagesService/Server/ImagesService.swift
@@ -73,12 +73,13 @@ public actor ImagesService {
 
     /// Sweep the snapshot directories no current image claims.
     ///
-    /// Registering an image over an existing reference replaces the record
-    /// and leaves the replaced generation's unpacked snapshot owned by no
-    /// image. Only the store sees the replacement happen, so every path that
-    /// lands records runs this sweep afterwards. The sweep is housekeeping:
-    /// its failure is loud in the log and never fails the operation that
-    /// carried it.
+    /// An unpacked snapshot is owned by the record that names it, so a record
+    /// that stops naming it leaves it owned by nobody: registering an image
+    /// over an existing reference replaces the record, and removing a
+    /// reference takes it away. Only the store sees either happen, so every
+    /// path that lands or removes records runs this sweep afterwards. The
+    /// sweep is housekeeping: its failure is loud in the log and never fails
+    /// the operation that carried it.
     private func sweepReplacedSnapshots(after function: String = #function) async {
         do {
             let kept = try await self._list()
@@ -256,6 +257,7 @@ public actor ImagesService {
         }
 
         try await self.imageStore.delete(reference: reference, performCleanup: garbageCollect)
+        await self.sweepReplacedSnapshots()
     }
 
     public func save(references: [String], out: URL, platform: Platform?) async throws {

--- a/Sources/Services/ContainerImagesService/Server/ImagesService.swift
+++ b/Sources/Services/ContainerImagesService/Server/ImagesService.swift
@@ -60,6 +60,38 @@ public actor ImagesService {
         return exists
     }
 
+    /// Sweep the snapshot directories no current image claims.
+    ///
+    /// Registering an image over an existing reference replaces the record
+    /// and leaves the replaced generation's unpacked snapshot owned by no
+    /// image. Only the store sees the replacement happen, so every path that
+    /// lands records runs this sweep afterwards. The sweep is housekeeping:
+    /// its failure is loud in the log and never fails the operation that
+    /// carried it.
+    private func sweepReplacedSnapshots(after function: String = #function) async {
+        do {
+            let kept = try await self._list()
+            let freedSnapshotBytes = try await self.snapshotStore.clean(keepingSnapshotsFor: kept)
+            if freedSnapshotBytes > 0 {
+                self.log.debug(
+                    "ImagesService: swept snapshots of replaced images",
+                    metadata: [
+                        "func": "\(function)",
+                        "freedBytes": "\(freedSnapshotBytes)",
+                    ]
+                )
+            }
+        } catch {
+            self.log.warning(
+                "ImagesService: snapshot sweep failed",
+                metadata: [
+                    "func": "\(function)",
+                    "error": "\(error)",
+                ]
+            )
+        }
+    }
+
     public func list() async throws -> [ImageDescription] {
         self.log.debug(
             "ImagesService: enter",
@@ -111,6 +143,7 @@ public actor ImagesService {
         guard let img else {
             throw ContainerizationError(.internalError, message: "failed to pull image \(reference)")
         }
+        await self.sweepReplacedSnapshots()
         return img.description.fromCZ
     }
 
@@ -244,6 +277,7 @@ public actor ImagesService {
         }
 
         let loaded = try await self.imageStore.load(from: tempDir)
+        await self.sweepReplacedSnapshots()
         var images: [ImageDescription] = []
         for image in loaded {
             images.append(image.description.fromCZ)

--- a/Sources/Services/ContainerImagesService/Server/ImagesService.swift
+++ b/Sources/Services/ContainerImagesService/Server/ImagesService.swift
@@ -32,6 +32,17 @@ public actor ImagesService {
     private let imageStore: ImageStore
     private let snapshotStore: SnapshotStore
 
+    /// One landing, removal, or sweep at a time. The store operations
+    /// suspend mid-flight, and the actor admits other calls at every
+    /// suspension, so a garbage collection overlapping a landing computes
+    /// its keep set without the arriving image and prunes blobs and
+    /// snapshots the landing is about to reference. The lock is held
+    /// across each whole mutating operation, the way PodsService holds
+    /// its lock across lifecycle operations; containerd guards the same
+    /// window with leases.
+    /// https://github.com/containerd/containerd/blob/main/docs/garbage-collection.md
+    private let lock = AsyncLock()
+
     public init(
         contentStore: ContentStore,
         imageStore: ImageStore,
@@ -114,6 +125,16 @@ public actor ImagesService {
     public func pull(reference: String, platform: Platform?, insecure: Bool, progressUpdate: ProgressUpdateHandler?, maxConcurrentDownloads: Int = 3) async throws
         -> ImageDescription
     {
+        try await lock.withLock { _ in
+            try await self._pull(
+                reference: reference, platform: platform, insecure: insecure,
+                progressUpdate: progressUpdate, maxConcurrentDownloads: maxConcurrentDownloads)
+        }
+    }
+
+    private func _pull(reference: String, platform: Platform?, insecure: Bool, progressUpdate: ProgressUpdateHandler?, maxConcurrentDownloads: Int) async throws
+        -> ImageDescription
+    {
         self.log.debug(
             "ImagesService: enter",
             metadata: [
@@ -148,6 +169,12 @@ public actor ImagesService {
     }
 
     public func push(reference: String, platform: Platform?, insecure: Bool, progressUpdate: ProgressUpdateHandler?) async throws {
+        try await lock.withLock { _ in
+            try await self._push(reference: reference, platform: platform, insecure: insecure, progressUpdate: progressUpdate)
+        }
+    }
+
+    private func _push(reference: String, platform: Platform?, insecure: Bool, progressUpdate: ProgressUpdateHandler?) async throws {
         self.log.debug(
             "ImagesService: enter",
             metadata: [
@@ -175,6 +202,12 @@ public actor ImagesService {
     }
 
     public func tag(old: String, new: String) async throws -> ImageDescription {
+        try await lock.withLock { _ in
+            try await self._tag(old: old, new: new)
+        }
+    }
+
+    private func _tag(old: String, new: String) async throws -> ImageDescription {
         self.log.debug(
             "ImagesService: enter",
             metadata: [
@@ -199,6 +232,12 @@ public actor ImagesService {
     }
 
     public func delete(reference: String, garbageCollect: Bool) async throws {
+        try await lock.withLock { _ in
+            try await self._delete(reference: reference, garbageCollect: garbageCollect)
+        }
+    }
+
+    private func _delete(reference: String, garbageCollect: Bool) async throws {
         self.log.debug(
             "ImagesService: enter",
             metadata: [
@@ -220,6 +259,12 @@ public actor ImagesService {
     }
 
     public func save(references: [String], out: URL, platform: Platform?) async throws {
+        try await lock.withLock { _ in
+            try await self._save(references: references, out: out, platform: platform)
+        }
+    }
+
+    private func _save(references: [String], out: URL, platform: Platform?) async throws {
         self.log.debug(
             "ImagesService: enter",
             metadata: [
@@ -248,6 +293,12 @@ public actor ImagesService {
     }
 
     public func load(from tarFile: URL, force: Bool) async throws -> ([ImageDescription], [String]) {
+        try await lock.withLock { _ in
+            try await self._load(from: tarFile, force: force)
+        }
+    }
+
+    private func _load(from tarFile: URL, force: Bool) async throws -> ([ImageDescription], [String]) {
         let archivePathname = tarFile.absolutePath()
         self.log.debug(
             "ImagesService: enter",
@@ -286,6 +337,12 @@ public actor ImagesService {
     }
 
     public func cleanUpOrphanedBlobs() async throws -> ([String], UInt64) {
+        try await lock.withLock { _ in
+            try await self._cleanUpOrphanedBlobs()
+        }
+    }
+
+    private func _cleanUpOrphanedBlobs() async throws -> ([String], UInt64) {
         self.log.debug(
             "ImagesService: enter",
             metadata: [
@@ -370,6 +427,12 @@ public actor ImagesService {
 
 extension ImagesService {
     public func unpack(description: ImageDescription, platform: Platform?, progressUpdate: ProgressUpdateHandler?) async throws {
+        try await lock.withLock { _ in
+            try await self._unpack(description: description, platform: platform, progressUpdate: progressUpdate)
+        }
+    }
+
+    private func _unpack(description: ImageDescription, platform: Platform?, progressUpdate: ProgressUpdateHandler?) async throws {
         self.log.debug(
             "ImagesService: enter",
             metadata: [
@@ -394,6 +457,12 @@ extension ImagesService {
     }
 
     public func deleteImageSnapshot(description: ImageDescription, platform: Platform?) async throws {
+        try await lock.withLock { _ in
+            try await self._deleteImageSnapshot(description: description, platform: platform)
+        }
+    }
+
+    private func _deleteImageSnapshot(description: ImageDescription, platform: Platform?) async throws {
         self.log.debug(
             "ImagesService: enter",
             metadata: [
@@ -418,6 +487,12 @@ extension ImagesService {
     }
 
     public func getImageSnapshot(description: ImageDescription, platform: Platform) async throws -> Filesystem {
+        try await lock.withLock { _ in
+            try await self._getImageSnapshot(description: description, platform: platform)
+        }
+    }
+
+    private func _getImageSnapshot(description: ImageDescription, platform: Platform) async throws -> Filesystem {
         self.log.debug(
             "ImagesService: enter",
             metadata: [

--- a/Sources/Services/ContainerImagesService/Server/SnapshotStore.swift
+++ b/Sources/Services/ContainerImagesService/Server/SnapshotStore.swift
@@ -168,12 +168,32 @@ public actor SnapshotStore {
     public func clean(keepingSnapshotsFor images: [Containerization.Image] = []) async throws -> UInt64 {
         var toKeep: [String] = [Self.ingestDirName]
         for image in images {
-            for manifest in try await image.index().manifests {
-                guard let platform = manifest.platform else {
-                    continue
+            // An image is read to learn which snapshot it claims, and reading
+            // one whose content the store no longer holds fails. That is a
+            // fact about that image and not about the others, so it costs the
+            // sweep that image rather than the whole pass: a single record
+            // left behind by an interrupted pull would otherwise stop every
+            // snapshot from ever being reclaimed again, and the store fills
+            // with the unpacked filesystems of images nothing names. An image
+            // the store cannot read is one it cannot unpack or run either, so
+            // the snapshot that image would have claimed is not worth keeping
+            // the store full for.
+            do {
+                for manifest in try await image.index().manifests {
+                    guard let platform = manifest.platform else {
+                        continue
+                    }
+                    let desc = try await image.descriptor(for: platform)
+                    toKeep.append(desc.digest.trimmingDigestPrefix)
                 }
-                let desc = try await image.descriptor(for: platform)
-                toKeep.append(desc.digest.trimmingDigestPrefix)
+            } catch {
+                self.log?.warning(
+                    "snapshot sweep read no manifests for an image; its snapshots are not kept",
+                    metadata: [
+                        "image": "\(image.reference)",
+                        "error": "\(error)",
+                    ]
+                )
             }
         }
         let all = try self.fm.contentsOfDirectory(at: self.path, includingPropertiesForKeys: [.totalFileAllocatedSizeKey]).map {
@@ -186,8 +206,24 @@ public actor SnapshotStore {
             guard self.fm.fileExists(atPath: unpackedPath.absolutePath()) else {
                 continue
             }
-            deletedBytes += self.fm.allocatedSize(of: unpackedPath)
-            try self.fm.removeItem(at: unpackedPath)
+            let size = self.fm.allocatedSize(of: unpackedPath)
+            // A snapshot the store cannot remove costs one snapshot's worth of
+            // space, and every other snapshot in the set is still owed to the
+            // caller, as are the bytes already freed. The removal that failed
+            // is what the caller needs to act on, so the error goes to the log
+            // with the snapshot that raised it.
+            do {
+                try self.fm.removeItem(at: unpackedPath)
+                deletedBytes += size
+            } catch {
+                self.log?.warning(
+                    "snapshot sweep could not remove a snapshot",
+                    metadata: [
+                        "snapshot": "\(dir)",
+                        "error": "\(error)",
+                    ]
+                )
+            }
         }
         return deletedBytes
     }


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Closes #2164.

A snapshot is owned by the record that names it, so a record that stops naming one leaves it owned by nobody. Three paths let that happen and one of them disables the collector.

**Registration that replaces a reference.** Pulling or loading a reference that already exists replaces its record and leaves the replaced generation's unpacked snapshot owned by no image. Nothing collects those outside the delete and prune commands, so a machine that rebuilds or refreshes the same tags accumulates dead snapshots indefinitely; a week of image rebuilds on one machine held 28G this way, invisible to every per-run cleanup. The sweep now runs after every operation that lands records, using the same keep set the prune path uses, and its failure warns rather than failing the pull or load that carried it.

**Removal.** Registration over an existing reference was swept and removal was not, so every deleted image left its unpacked snapshot behind. That penalises the tidy caller: an integration run that deletes each image its builds register leaves a snapshot per build, and a suite of them fills a disk that the same suite without the tidying would not have.

**One bad item stopping the pass.** The sweep reads every image to learn which snapshot it claims, then removes the snapshots no image claims, and a failure anywhere in either loop abandoned the whole pass. One record from an interrupted pull, whose content the store no longer holds, stopped every snapshot from ever being reclaimed again for as long as that record existed; and one snapshot that would not remove abandoned the rest of the set and discarded the bytes already freed, so the caller was told nothing had been reclaimed when some of it had. Each image is read and each snapshot removed on its own terms now, with the error logged against the item that raised it. An image the store cannot read is one it cannot unpack or run either, so the snapshot that image would have claimed is not worth keeping the store full for.

**Serialization.** The service is an actor, and every `await` inside a store operation admits the next call, so a collection can overlap an in-flight landing: its keep set is computed without the arriving image, and the cleanup prunes blobs the landing is about to reference and sweeps the snapshot a container is about to attach. A lock held across each whole mutating operation admits one at a time, the way `PodsService` holds its lock across lifecycle operations. containerd guards the same window with leases: https://github.com/containerd/containerd/blob/main/docs/garbage-collection.md

An integration run here left 21G of unpacked filesystems for images nothing named, and the control plane then failed on the disk they took.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

Integration suite: 397 passed. Unit suite: 772 passed. `make fmt`, `make check` clean.
