### PR TITLE
Stop the API server even when it cannot say what it is running

### DIFF
--- a/Sources/ContainerCommands/System/SystemStop.swift
+++ b/Sources/ContainerCommands/System/SystemStop.swift
@@ -49,8 +49,7 @@ extension Application {
                 }
             )
 
-            let launchdDomainString = try ServiceManager.getDomainString()
-            let fullLabel = "\(launchdDomainString)/\(prefix)apiserver"
+            let apiserverLabel = "\(prefix)apiserver"
 
             var running = true
             do {
@@ -88,32 +87,44 @@ extension Application {
                 } catch {
                     log.warning("failed to wait for all containers", metadata: ["error": "\(error)"])
                 }
-
-                // Stopping the services is what this command is for, so it
-                // happens whether or not the containers could be waited for.
-                // Asking the API server about its containers is asking the
-                // service being stopped, and it is when that service is in a
-                // bad way that stopping it matters most: leaving it running
-                // because it could not answer leaves the one process that
-                // needed stopping.
-                log.info("stopping service", metadata: ["label": "\(fullLabel)"])
-                do {
-                    try ServiceManager.deregister(fullServiceLabel: fullLabel)
-                } catch {
-                    log.warning("failed to stop service", metadata: ["label": "\(fullLabel)", "error": "\(error)"])
-                }
             }
 
-            // Note: The assumption here is that we would have registered the launchd services
-            // in the same domain as `launchdDomainString`. This is a fairly sane assumption since
-            // if somehow the launchd domain changed, XPC interactions would not be possible.
+            // Stopping the services is what this command is for, so it
+            // happens whether or not the containers could be waited for, and
+            // whether or not the API server answered its health check at all.
+            // Asking the API server about its containers is asking the
+            // service being stopped, and it is when that service is in a
+            // bad way that stopping it matters most: leaving it running
+            // because it could not answer leaves the one process that
+            // needed stopping.
+            log.info("stopping service", metadata: ["label": "\(apiserverLabel)"])
+            do {
+                if try !ServiceManager.deregisterAnyDomain(serviceLabel: apiserverLabel) {
+                    log.warning(
+                        "failed to stop service",
+                        metadata: ["label": "\(apiserverLabel)", "error": "no launchd domain holds it"])
+                }
+            } catch {
+                log.warning("failed to stop service", metadata: ["label": "\(apiserverLabel)", "error": "\(error)"])
+            }
+
+            // The domain a service was registered in is the one belonging to
+            // the session that started it, which is not necessarily this one:
+            // a system brought up from a terminal no window server owns sits
+            // in `user/<uid>`, and this command run from a login session looks
+            // in `gui/<uid>`. Either session can drive the other's services,
+            // so a mismatch does not announce itself as a failure to reach
+            // them; it announces itself as a stop that says it stopped
+            // everything while every service it named is still running.
             try ServiceManager.enumerate()
                 .filter { $0.hasPrefix(prefix) }
-                .filter { $0 != fullLabel }
-                .map { "\(launchdDomainString)/\($0)" }
+                .filter { $0 != apiserverLabel }
                 .forEach {
                     log.info("stopping service", metadata: ["label": "\($0)"])
-                    try? ServiceManager.deregister(fullServiceLabel: $0)
+                    let stopped = (try? ServiceManager.deregisterAnyDomain(serviceLabel: $0)) ?? false
+                    if !stopped {
+                        log.warning("failed to stop service", metadata: ["label": "\($0)"])
+                    }
                 }
         }
     }

--- a/Sources/ContainerCommands/System/SystemStop.swift
+++ b/Sources/ContainerCommands/System/SystemStop.swift
@@ -85,11 +85,22 @@ extension Application {
                         }
                         try await Task.sleep(for: .seconds(1))
                     }
-
-                    log.info("stopping service", metadata: ["label": "\(fullLabel)"])
-                    try ServiceManager.deregister(fullServiceLabel: fullLabel)
                 } catch {
                     log.warning("failed to wait for all containers", metadata: ["error": "\(error)"])
+                }
+
+                // Stopping the services is what this command is for, so it
+                // happens whether or not the containers could be waited for.
+                // Asking the API server about its containers is asking the
+                // service being stopped, and it is when that service is in a
+                // bad way that stopping it matters most: leaving it running
+                // because it could not answer leaves the one process that
+                // needed stopping.
+                log.info("stopping service", metadata: ["label": "\(fullLabel)"])
+                do {
+                    try ServiceManager.deregister(fullServiceLabel: fullLabel)
+                } catch {
+                    log.warning("failed to stop service", metadata: ["label": "\(fullLabel)", "error": "\(error)"])
                 }
             }
 

--- a/Sources/ContainerPlugin/ServiceManager.swift
+++ b/Sources/ContainerPlugin/ServiceManager.swift
@@ -49,6 +49,30 @@ public struct ServiceManager {
         status = try runLaunchctlCommand(args: ["bootout", label])
     }
 
+    /// Deregister a service by its bare label, from whichever domain holds it.
+    ///
+    /// The domain a service sits in belongs to the session that registered it,
+    /// not to the session asking about it now: `register` bootstraps into the
+    /// domain of whoever called it, so a system started from a terminal no
+    /// window server owns lands in `user/<uid>`, and the same command from a
+    /// login session lands in `gui/<uid>`. Either one can drive the other's
+    /// services afterwards, because reaching them is a matter of the Mach
+    /// namespace rather than of the domain they were bootstrapped into.
+    ///
+    /// Returns whether a domain gave the service up, so that a caller looking
+    /// in the wrong place is told so rather than left to assume it was heard.
+    @discardableResult
+    public static func deregisterAnyDomain(serviceLabel label: String) throws -> Bool {
+        for domain in try Self.getDomainStrings() {
+            var status: Int32 = -1
+            try Self.deregister(fullServiceLabel: "\(domain)/\(label)", status: &status)
+            if status == 0 {
+                return true
+            }
+        }
+        return false
+    }
+
     /// Restart a service by a launchd label.
     public static func kickstart(fullServiceLabel label: String) throws {
         _ = try runLaunchctlCommand(args: ["kickstart", "-k", label])
@@ -119,6 +143,14 @@ public struct ServiceManager {
             throw ContainerizationError(.internalError, message: "could not decode output of command `launchctl managername`")
         }
         return outputText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Every launchd domain a service of this user's could be registered in,
+    /// the caller's own first so that the common case is answered first.
+    public static func getDomainStrings() throws -> [String] {
+        let own = try Self.getDomainString()
+        let userDomains = ["user/\(getuid())", "gui/\(getuid())"]
+        return [own] + userDomains.filter { $0 != own }
     }
 
     public static func getDomainString() throws -> String {


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Closes #2166.

Two independent ways `container system stop` reports success while leaving the services running.

**The bootout rides in the failing wait's `do` block.** Stopping the services waits for the containers to exit first, and asks the API server which of them are still running to do it. Both the wait and the bootout of that server sat in one `do` block, so a server that could not answer took the bootout with it into the `catch`: the command reported that it failed to wait for containers, said nothing about the server, and left it running.

That is the case where stopping matters most. A server that cannot list its containers is the one process that needs to go, and the command that exists to stop it is the one that gives up. Waiting is best effort now, and the services are stopped either way. What made this hard to see is that stop reported success while every service kept running, so binaries built since were never the ones executed.

**The domain a service sits in belongs to the session that registered it.** `register` bootstraps into the domain of whoever called it, so a system started from a terminal no window server owns lands in `user/<uid>` and the same command from a login session lands in `gui/<uid>`; stop looked only in the caller's own. Deregistration now tries each domain a service of this user's could be in, the caller's own first, and reports whether any domain gave the service up, so a caller looking in the wrong place is told rather than left to assume it was heard.

### Relation to #2050

#2050 addresses the same disagreement from the registration side, by making `getDomainString()` always answer `user/<uid>` so that start and stop compute the same domain from any shell. The two changes are compatible and the swallowed-bootout-failure half above is needed either way.

One thing worth checking before #2050 lands on its own: a service bootstrapped into `gui/<uid>` by an earlier build stays in `gui/<uid>`, and I do not know whether `launchctl bootout user/<uid>/<label>` reaches a service registered in the `gui` subdomain. If it does not, existing installs would need a one-time manual `bootout` from `gui/` that neither `system stop` nor an upgrade performs. Searching the domains, as here, does not have that question. I could only probe the `user` half directly: over ssh, `launchctl managername` reports `Background`, the services are registered in and found under `user/501`, and `gui/501` does not hold them.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

With the API server running, `container system stop` leaves no `container-apiserver` process and `container system start` brings one back. Verified from an ssh session (`Background`), which is the domain-mismatch case that motivated the second commit.

Integration suite: 397 passed. Unit suite: 772 passed. `make fmt`, `make check` clean.
