### PR TITLE
Mount volumes with the runtime's discard and the record's own options

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/Utility.swift
+++ b/Sources/Services/ContainerAPIService/Client/Utility.swift
@@ -174,12 +174,22 @@ public struct Utility {
                 resolvedMounts.append(fs)
             case .volume(let parsed):
                 let volume = try await getOrCreateVolume(parsed: parsed, log: log)
+                // The record's driver options carry the local driver's `o`
+                // key, a comma separated mount option list the way docker's
+                // local driver spells it, split the way the attachment's own
+                // option suffix is, so the options a volume was created with
+                // mount everywhere it attaches.
+                // https://docs.docker.com/engine/storage/volumes/#create-a-volume-with-the-local-driver
+                var options = parsed.options
+                if let o = volume.options["o"] {
+                    options.append(contentsOf: o.split(separator: ",").map(String.init))
+                }
                 let volumeMount = Filesystem.volume(
                     name: parsed.name,
                     format: volume.format,
                     source: volume.source,
                     destination: parsed.destination,
-                    options: parsed.options
+                    options: options
                 )
                 resolvedMounts.append(volumeMount)
             }

--- a/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
+++ b/Sources/Services/RuntimeLinux/Server/RuntimeService.swift
@@ -1453,11 +1453,21 @@ extension Filesystem {
                 ],
             )
         case .volume(_, let format, let cacheMode, let syncMode):
+            // A volume's ext4 sits on a sparse host file, so it mounts with
+            // continuous discard and blocks the workload frees return to the
+            // host as it runs; a read only mount parses the option as a
+            // no-op. The runtime owns this the way it owns the caching and
+            // sync modes beside it; the user's own options ride in from the
+            // volume record and the attachment untouched.
+            var options = self.options
+            if format == "ext4" {
+                options.append("discard")
+            }
             return .block(
                 format: format,
                 source: self.source,
                 destination: self.destination,
-                options: self.options,
+                options: options,
                 runtimeOptions: [
                     "\(Filesystem.CacheMode.vzRuntimeOptionKey)=\(cacheMode.asVZRuntimeOption)",
                     "\(Filesystem.SyncMode.vzRuntimeOptionKey)=\(syncMode.asVZRuntimeOption)",

--- a/Tests/IntegrationTests/Volumes/TestCLIVolumeMountOptions.swift
+++ b/Tests/IntegrationTests/Volumes/TestCLIVolumeMountOptions.swift
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerTestSupport
+import Foundation
+import Testing
+
+@Suite
+struct TestCLIVolumeMountOptions {
+    private let alpine = WarmupImage.alpine320.rawValue
+
+    /// The mount line for a destination inside a running container.
+    private func mountLine(_ f: ContainerFixture, container: String, destination: String) throws -> String {
+        let mounts = try f.doExec(container, cmd: ["cat", "/proc/mounts"])
+        guard let line = mounts.split(separator: "\n").first(where: { $0.contains(" \(destination) ") }) else {
+            throw CommandError.executionFailed("no mount line for \(destination) in: \(mounts)")
+        }
+        return String(line)
+    }
+
+    @Test func testVolumeMountsWithDiscardByDefault() async throws {
+        try await ContainerFixture.with { f in
+            let vol = "\(f.testID)-vol"
+            let c = "\(f.testID)-c"
+            f.addCleanup {
+                try? f.doRemoveIfExists(c, force: true, ignoreFailure: true)
+                f.doVolumeDeleteIfExists(vol)
+            }
+
+            try f.doVolumeCreate(vol)
+            try await f.doLongRun(name: c, image: alpine, args: ["-v", "\(vol):/data"], autoRemove: false, waitUntilRunning: true)
+            let line = try mountLine(f, container: c, destination: "/data")
+            #expect(line.contains("discard"), "an ext4 volume mounts with continuous discard: \(line)")
+            try f.doStop(c)
+        }
+    }
+
+    @Test func testVolumeRecordOptionsRideEveryAttachment() async throws {
+        try await ContainerFixture.with { f in
+            let vol = "\(f.testID)-vol"
+            let c = "\(f.testID)-c"
+            f.addCleanup {
+                try? f.doRemoveIfExists(c, force: true, ignoreFailure: true)
+                f.doVolumeDeleteIfExists(vol)
+            }
+
+            try f.run(["volume", "create", "--opt", "o=noatime", vol]).check()
+            try await f.doLongRun(name: c, image: alpine, args: ["-v", "\(vol):/data"], autoRemove: false, waitUntilRunning: true)
+            let line = try mountLine(f, container: c, destination: "/data")
+            #expect(line.contains("noatime"), "the record's o options mount with the volume: \(line)")
+            #expect(line.contains("discard"), "the runtime's discard rides regardless of the record: \(line)")
+            try f.doStop(c)
+        }
+    }
+}


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Closes #2168.

A volume's ext4 sits on a sparse host file the service created, so the blocks a workload frees belong back on the host as it runs. That is the runtime's concern, owned where the mount is assembled beside the caching and sync modes the runtime already sets there: ext4 volumes mount with continuous discard on every attachment, and a read-only mount parses the option as a no-op.

`volume create --opt` also stored driver options the mount path never read back. The local driver's spelling for a volume's own mount options is the `o` key, a comma separated list the way docker's local driver takes it, and docker never injects defaults into it: everything in `o` is what the caller named. `o` resolves into each attachment's options now, split the way the attachment's own option suffix already is, so what a volume was created with rides along everywhere it attaches, and the user's list stays exactly the user's.

Adjacent: #2021 reports the analogous non-release of freed space for virtio-fs bind mounts, which this does not address; #1940 asks for the supported `--volume` options to be documented.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

New integration coverage reads `/proc/mounts` inside the container: an ext4 volume's line holds `discard` on a plain-created volume, and a volume created with `--opt o=noatime` mounts with its record's option beside the runtime's discard.

Integration suite: 397 passed. Unit suite: 772 passed. `make fmt`, `make check` clean.
