### PR TITLE
Boot a machine even when its container logs cannot be opened

### DIFF
--- a/Sources/Services/MachineAPIService/Server/MachinesService.swift
+++ b/Sources/Services/MachineAPIService/Server/MachinesService.swift
@@ -393,7 +393,18 @@ public actor MachinesService {
                     id: cid, stdio: [nil, nil, nil], dynamicEnv: dynamicEnv)
                 try await process.start()
 
-                try fhs.append(contentsOf: await self.client.logs(id: cid))
+                // The machine's log files mirror the container's, and the
+                // mirroring is diagnostics: a container whose logs cannot be
+                // opened boots without the mirror rather than failing the
+                // boot on its reporting, which would also bury whatever
+                // stopped the logs from existing.
+                do {
+                    try fhs.append(contentsOf: await self.client.logs(id: cid))
+                } catch {
+                    self.log.warning(
+                        "machine boots without log streaming",
+                        metadata: ["id": "\(state.id)", "error": "\(error)"])
+                }
 
                 try bundle.createLogFiles()
                 let stdioLog = try FileHandle(forWritingTo: URL(filePath: bundle.stdioLog.string))
@@ -401,8 +412,7 @@ public actor MachinesService {
 
                 state.logger = Task<Void, Never> { [log = self.log, id = state.id, fhs] in
                     defer {
-                        try? fhs[0].close()
-                        try? fhs[1].close()
+                        fhs.forEach { try? $0.close() }
 
                         try? stdioLog.close()
                         try? bootLog.close()


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Closes #2170.

The machine's log files mirror its container's, and the mirroring is diagnostics. A boot that failed on opening the source logs reported the missing file as the boot's own failure, burying whatever stopped the logs from existing; the mirror degrades to a warning now and the boot succeeds or fails on the boot itself.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

A machine whose container log files are absent starts, with the mirroring failure in the log.

Integration suite: 397 passed. Unit suite: 772 passed. `make fmt`, `make check` clean.
