### PR TITLE
Say which half of the CNI manifest lookup failed

### DIFF
--- a/Sources/ContainerK8s/Support/K8sHelper+Bootstrap.swift
+++ b/Sources/ContainerK8s/Support/K8sHelper+Bootstrap.swift
@@ -105,10 +105,19 @@ extension K8sHelper {
 
     private static func loadKindnetManifest(log: Logger) async throws -> String {
         let pluginLoader = try await Utility.createPluginLoader(log: log)
-        guard let plugin = pluginLoader.findPlugin(forExecutable: CommandLine.executablePath),
-            let resourceURL = plugin.resourceURL
-        else {
-            throw ContainerizationError(.internalError, message: "unable to locate k8s plugin installation or resources")
+        let executable = CommandLine.executablePath
+        guard let plugin = pluginLoader.findPlugin(forExecutable: executable) else {
+            let installed = pluginLoader.findPlugins().map(\.name).sorted()
+            throw ContainerizationError(
+                .internalError,
+                message: "no installed plugin runs \(executable); installed plugins: \(installed.isEmpty ? "none" : installed.joined(separator: ", "))"
+            )
+        }
+        guard let resourceURL = plugin.resourceURL else {
+            throw ContainerizationError(
+                .internalError,
+                message: "the \(plugin.name) plugin installed at \(plugin.binaryURL.path) carries no resources directory"
+            )
         }
         let url = resourceURL.appendingPathComponent("kindnet.yaml")
         guard let contents = try? String(contentsOf: url, encoding: .utf8) else {


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context

The CNI manifest ships beside the plugin binary, so finding it needs both the plugin that the running executable belongs to and the resources directory of that installation. One message covered the absence of either, naming neither the executable it looked for nor what was installed, and a run that hit it left nothing to tell the two apart: an installation missing its resources and a binary running from outside any installation produce the same sentence.

Each half reports what it was looking for now.

Diagnostics only; no behaviour changes.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

Both halves exercised by running the k8s path from an executable outside an installation, and from an installation with its resources directory removed.

Integration suite: 397 passed. Unit suite: 772 passed. `make fmt`, `make check` clean.
