### PR TITLE
Remove the images a fixture's builds register

### DIFF
--- a/Sources/ContainerTestSupport/BuildFixture.swift
+++ b/Sources/ContainerTestSupport/BuildFixture.swift
@@ -244,6 +244,14 @@ extension ContainerFixture {
             throw CommandError.executionFailed(
                 "build failed: stdout=\(result.output) stderr=\(result.error)")
         }
+        // An image this build registered is a resource the scope created, so
+        // its removal is registered like any other. When no tag was supplied
+        // the runtime generated one and printed it, and that printed name is
+        // the one to remove.
+        let builtTags = tags.isEmpty ? [result.output.trimmingCharacters(in: .whitespacesAndNewlines)].filter { !$0.isEmpty } : tags
+        for tag in builtTags {
+            addCleanup { _ = try? self.run(["image", "rm", tag]) }
+        }
         return result.output
     }
 
@@ -266,6 +274,10 @@ extension ContainerFixture {
         guard result.status == 0 else {
             throw CommandError.executionFailed(
                 "build failed: stdout=\(result.output) stderr=\(result.error)")
+        }
+        let builtTags = tags.isEmpty ? [result.output.trimmingCharacters(in: .whitespacesAndNewlines)].filter { !$0.isEmpty } : tags
+        for tag in builtTags {
+            addCleanup { _ = try? self.run(["image", "rm", tag]) }
         }
         return result.output
     }
@@ -294,6 +306,9 @@ extension ContainerFixture {
             throw CommandError.executionFailed(
                 "build failed: stdout=\(result.output) stderr=\(result.error)")
         }
+        // The local exporter can leave the tag unregistered in the store;
+        // the removal tolerates that.
+        addCleanup { _ = try? self.run(["image", "rm", tag]) }
         return result.output
     }
 }


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

The fixture's contract is that every resource created during a test's scope is torn down when the scope exits. The build helpers registered images in the store and left no removal behind, so an integration run accumulated one set of uniquely tagged build products per run, held beyond the run by nothing.

Removal is registered for every tag a successful build lands, including the runtime generated tag a tagless build prints, and tolerates a tag the local exporter never registered.

Test support only; no product code changes. Related to the disk pressure catalogued in #2164, which this contributes to and does not fix by itself: the images this leaves behind each hold an unpacked snapshot that the leaks in that issue then keep.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

An integration run that previously left one image per build per run now leaves none.

Integration suite: 397 passed. Unit suite: 772 passed. `make fmt`, `make check` clean.
