### PR TITLE
Test against the init and builder images the checkout builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ test_results/
 *.profraw
 coverage-reports/
 
+# The integration tests' default scratch root.
+.test-scratch/
+
 # API docs for local preview only.
 _site/
 _serve/

--- a/Makefile
+++ b/Makefile
@@ -278,6 +278,10 @@ PRESERVE_KERNELS ?= false
 # Override with SCRATCH_ROOT=/your/path on the command line.
 SCRATCH_ROOT ?= $(ROOT_DIR)/.test-scratch
 
+# init-block loads the freshly built init image before the data directory is
+# cleared here, so the recipe lands bin/init.tar again after its own system
+# start, into the store the tests actually see. Absent the tar (a version
+# pinned containerization), the runtime pulls its default init image.
 define RUN_INTEGRATION
 	@echo Ensuring apiserver stopped before the CLI integration tests...
 	@bin/container system stop && sleep 3 && scripts/ensure-container-stopped.sh
@@ -298,6 +302,10 @@ define RUN_INTEGRATION
 		CLITEST_LOG_ROOT=$(LOG_ROOT) && export CLITEST_LOG_ROOT ; \
 		CLITEST_SCRATCH_ROOT=$(SCRATCH_ROOT) && export CLITEST_SCRATCH_ROOT ; \
 		CONTAINER_CLI_PATH=$(ROOT_DIR)/bin/container && export CONTAINER_CLI_PATH ; \
+		if [ -f bin/init.tar ]; then \
+			echo "==> Loading the built init image" && \
+			bin/container i load -i bin/init.tar ; \
+		fi && \
 		echo "==> Starting warmup tests" && \
 		$(SWIFT) test $(INTEGRATION_SWIFT_EXTRA) -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter "$(WARMUP_FILTER)" && \
 		echo "==> Starting $(words $(CONCURRENT_TEST_SUITES)) test suites concurrently (width=$(PARALLEL_WIDTH))" && \

--- a/Makefile
+++ b/Makefile
@@ -278,10 +278,11 @@ PRESERVE_KERNELS ?= false
 # Override with SCRATCH_ROOT=/your/path on the command line.
 SCRATCH_ROOT ?= $(ROOT_DIR)/.test-scratch
 
-# init-block loads the freshly built init image before the data directory is
-# cleared here, so the recipe lands bin/init.tar again after its own system
-# start, into the store the tests actually see. Absent the tar (a version
-# pinned containerization), the runtime pulls its default init image.
+# An editable build's images exist in no registry: init-block builds the
+# init image before the data directory is cleared here, and a locally built
+# builder image is in the same position. The recipe lands the tars from bin/
+# after its own system start, into the store the tests actually see; absent
+# a tar, the runtime pulls its documented default instead.
 define RUN_INTEGRATION
 	@echo Ensuring apiserver stopped before the CLI integration tests...
 	@bin/container system stop && sleep 3 && scripts/ensure-container-stopped.sh
@@ -305,6 +306,10 @@ define RUN_INTEGRATION
 		if [ -f bin/init.tar ]; then \
 			echo "==> Loading the built init image" && \
 			bin/container i load -i bin/init.tar ; \
+		fi && \
+		if [ -f bin/builder.tar ]; then \
+			echo "==> Loading the built builder image" && \
+			bin/container i load -i bin/builder.tar ; \
 		fi && \
 		echo "==> Starting warmup tests" && \
 		$(SWIFT) test $(INTEGRATION_SWIFT_EXTRA) -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter "$(WARMUP_FILTER)" && \

--- a/Sources/ContainerTestSupport/WarmupImage.swift
+++ b/Sources/ContainerTestSupport/WarmupImage.swift
@@ -23,6 +23,7 @@ public enum WarmupImage: String, CaseIterable, Sendable {
     case alpine320 = "ghcr.io/linuxcontainers/alpine:3.20"
     case alpine318 = "ghcr.io/linuxcontainers/alpine:3.18"
     case busybox136 = "ghcr.io/containerd/busybox:1.36"
+    case pythonAlpine = "docker.io/library/python:alpine"
     case kindestNodeV1_35_5 = "docker.io/kindest/node:v1.35.5@sha256:ce977ae6d65918d0b58a5f8b5e940429c2ce42fa3a5619ec2bbc60b949c0ac95"
 
     /// Directory under app-root holding OCI tar archives of each warmup image.

--- a/scripts/install-init.sh
+++ b/scripts/install-init.sh
@@ -77,7 +77,11 @@ if [ "${CONTAINERIZATION_VERSION}" == "unspecified" ] ; then
 	# Sleep because commands after stop and start are racy.
 	bin/container system stop
     sleep 3
-	bin/container --debug system start "${START_ARGS[@]}"
+	# A start against a data directory with no configured kernel asks on
+	# stdin whether to install one, and this runs from make with no
+	# terminal, so the flag answers instead of a prompt, the way the
+	# integration recipe's own start does.
+	bin/container --debug system start --enable-kernel-install "${START_ARGS[@]}"
 	sleep 3
 	bin/container i load -i bin/init.tar
 fi

--- a/scripts/install-init.sh
+++ b/scripts/install-init.sh
@@ -70,13 +70,14 @@ if [ "${CONTAINERIZATION_VERSION}" == "unspecified" ] ; then
 	fi
 	echo "Creating InitImage"
 	make -C ${CONTAINERIZATION_PATH} init
-	${CONTAINERIZATION_PATH}/bin/cctl images save -o /tmp/init.tar ${IMAGE_NAME}
+	# The tar stays in bin/ so the integration recipe can land the image
+	# again into whichever store the tests run against.
+	${CONTAINERIZATION_PATH}/bin/cctl images save -o bin/init.tar ${IMAGE_NAME}
 
 	# Sleep because commands after stop and start are racy.
 	bin/container system stop
     sleep 3
 	bin/container --debug system start "${START_ARGS[@]}"
 	sleep 3
-	bin/container i load -i /tmp/init.tar
-	rm /tmp/init.tar
+	bin/container i load -i bin/init.tar
 fi


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Five defects in `make integration`, all of which let a run report a pass about something other than what the checkout built.

**The built init image is cleared before the tests see it.** `make integration` clears the application data directory after `init-block` has already loaded the freshly built init image, so a run against a dedicated `APP_ROOT` tested the runtime's default init image instead of the one the editable containerization checkout produced. Features that live in the guest agent then fail their tests with no hint that the guest under test was the wrong one. The saved tar stays in the repository's `bin` directory and the integration recipe loads it after its own system start, once the data directory clearing is behind it; `init-block` keeps its own load so building the init image alone still refreshes the running store.

**`init-block` cannot answer the kernel prompt.** `install-init.sh` starts the system to load the init image it built, and a start against a data directory with no configured kernel asks on stdin whether to install one. The integration path runs this from `make` with no terminal, so the question fails the read and `init-block` exits before a single test begins. It passes `--enable-kernel-install` the way the integration recipe's own start already does, so the answer is the flag instead of a prompt.

**A locally built builder image exists in no registry**, the position the editable init image is in, so the recipe lands `bin/builder.tar` into the store the tests see the same way it lands `bin/init.tar`, and a fixture's `builder start` finds the image the configuration names instead of reaching for a registry that does not carry it.

**The network suite pulls mid-run.** It runs a python `http.server`, and pulling that image from Docker Hub in the middle of the concurrent pass put a registry round trip and its rate limits inside the test's readiness window. It is warmed with the other suite images now, so the pull happens once, before the load.

**The default scratch root was not ignored.** The integration recipe defaults `SCRATCH_ROOT` to `.test-scratch` under the repository so the builder can reach build contexts, and nothing ignored it, so an interrupted run's scratch trees were one `git add` away from a commit.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

`make integration` against a dedicated `APP_ROOT` runs the built init image, starts without a terminal, and finds the built builder image. Integration suite: 397 passed. Unit suite: 772 passed. `make fmt`, `make check` clean.
