### PR TITLE
Reach a builder over ssh or tcp instead of the local vsock

### DIFF
--- a/Sources/ContainerCommands/BuildCommand+RemoteBuilder.swift
+++ b/Sources/ContainerCommands/BuildCommand+RemoteBuilder.swift
@@ -1,0 +1,123 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerizationError
+import ContainerizationOS
+import Darwin
+import Foundation
+
+extension Application.BuildCommand {
+    /// Where a build's builder lives when it is not this machine's.
+    ///
+    /// The address grammar is BUILDKIT_HOST's: an ssh address reaches a peer
+    /// whose sshd and container CLI are the whole of the requirement, the
+    /// ssh channel carrying the authentication and encryption, and a tcp
+    /// address reaches a listener directly.
+    /// https://github.com/moby/buildkit/blob/master/client/connhelper/ssh/ssh.go
+    enum RemoteBuilderAddress {
+        case ssh(user: String?, host: String, port: Int?)
+        case tcp(host: String, port: Int)
+
+        static func parse(_ address: String) throws -> RemoteBuilderAddress {
+            guard let url = URL(string: address), let scheme = url.scheme, let host = url.host else {
+                throw ContainerizationError(.invalidArgument, message: "invalid builder address \(address)")
+            }
+            switch scheme {
+            case "ssh":
+                return .ssh(user: url.user, host: host, port: url.port)
+            case "tcp":
+                guard let port = url.port else {
+                    throw ContainerizationError(.invalidArgument, message: "a tcp builder address names a port: \(address)")
+                }
+                return .tcp(host: host, port: port)
+            default:
+                throw ContainerizationError(.invalidArgument, message: "unsupported builder address scheme \(scheme); use ssh:// or tcp://")
+            }
+        }
+    }
+
+    /// A connection to a remote builder, held open for the build riding it.
+    ///
+    /// For ssh the connection is the standard streams of an ssh child
+    /// running the peer's `container builder dial-stdio`, one socketpair end
+    /// serving as both of the child's streams so the handle speaks both
+    /// ways, the way buildkit's connection helpers wrap a command's stdio.
+    /// The child lives as long as this value does.
+    struct RemoteBuilderConnection {
+        let handle: FileHandle
+        private let process: Command?
+
+        static func connect(_ address: RemoteBuilderAddress) throws -> RemoteBuilderConnection {
+            switch address {
+            case .ssh(let user, let host, let port):
+                var fds: [Int32] = [0, 0]
+                guard Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &fds) == 0 else {
+                    throw ContainerizationError(.internalError, message: "socketpair failed: errno \(errno)")
+                }
+                let parent = FileHandle(fileDescriptor: fds[0], closeOnDealloc: false)
+                let child = FileHandle(fileDescriptor: fds[1], closeOnDealloc: false)
+
+                var arguments = ["-T", "-o", "BatchMode=yes"]
+                if let port {
+                    arguments += ["-p", "\(port)"]
+                }
+                let destination = user.map { "\($0)@\(host)" } ?? host
+                arguments += ["--", destination, "container", "builder", "dial-stdio"]
+
+                var command = Command("/usr/bin/ssh", arguments: arguments)
+                command.stdin = child
+                command.stdout = child
+                do {
+                    try command.start()
+                } catch {
+                    try? parent.close()
+                    try? child.close()
+                    throw ContainerizationError(.internalError, message: "failed to start ssh to \(destination)", cause: error)
+                }
+                try? child.close()
+                return RemoteBuilderConnection(handle: parent, process: command)
+
+            case .tcp(let host, let port):
+                var hints = addrinfo()
+                hints.ai_family = AF_UNSPEC
+                hints.ai_socktype = SOCK_STREAM
+                var info: UnsafeMutablePointer<addrinfo>?
+                let rc = getaddrinfo(host, "\(port)", &hints, &info)
+                guard rc == 0, let first = info else {
+                    throw ContainerizationError(.internalError, message: "failed to resolve \(host): \(String(cString: gai_strerror(rc)))")
+                }
+                defer { freeaddrinfo(info) }
+
+                var lastErrno: Int32 = 0
+                var candidate = Optional(first)
+                while let ai = candidate {
+                    let fd = Darwin.socket(ai.pointee.ai_family, ai.pointee.ai_socktype, ai.pointee.ai_protocol)
+                    if fd >= 0 {
+                        if Darwin.connect(fd, ai.pointee.ai_addr, ai.pointee.ai_addrlen) == 0 {
+                            return RemoteBuilderConnection(handle: FileHandle(fileDescriptor: fd, closeOnDealloc: false), process: nil)
+                        }
+                        lastErrno = errno
+                        Darwin.close(fd)
+                    } else {
+                        lastErrno = errno
+                    }
+                    candidate = ai.pointee.ai_next
+                }
+                throw ContainerizationError(.internalError, message: "failed to connect to \(host):\(port): errno \(lastErrno)")
+            }
+        }
+    }
+}

--- a/Sources/ContainerCommands/BuildCommand.swift
+++ b/Sources/ContainerCommands/BuildCommand.swift
@@ -142,6 +142,13 @@ extension Application {
         @Option(name: .long, help: ArgumentHelp("Builder shim vsock port", valueName: "port"))
         var vsockPort: UInt32 = 8088
 
+        @Option(
+            name: .customLong("builder"),
+            help: ArgumentHelp(
+                "Builder address (ssh://user@host[:port] or tcp://host:port); defaults to CONTAINER_BUILD_REMOTE, then build.remote in the configuration, then this machine's builder [environment: CONTAINER_BUILD_REMOTE]",
+                valueName: "address"))
+        var builderAddress: String?
+
         @OptionGroup
         public var logOptions: Flags.Logging
 
@@ -173,24 +180,46 @@ extension Application {
                 let dnsNameservers = self.dns.nameservers
 
                 // Ensure the builder is started (or restarted) with the correct SSH configuration
-                // before attempting to dial. This handles the case where the builder is already
-                // running but was not started with SSH forwarding enabled.
-                try await BuilderStart.start(
-                    cpus: cpus,
-                    memory: memory,
-                    log: log,
-                    ssh: ssh == "default",
-                    dnsNameservers: dnsNameservers,
-                    progressUpdate: progress.handler,
-                    containerSystemConfig: containerSystemConfig,
-                )
+                // A remote builder is dialed as it stands: its lifecycle is
+                // its machine's, so nothing here starts or restarts it. The
+                // address grammar is BUILDKIT_HOST's, and the precedence is
+                // the flag, then the environment, then the configuration,
+                // the way buildctl's --addr rides over BUILDKIT_HOST and the
+                // way CONTAINER_DEFAULT_PLATFORM slots between flag and
+                // default here.
+                let remoteAddress = try
+                    (self.builderAddress
+                    ?? ProcessInfo.processInfo.environment["CONTAINER_BUILD_REMOTE"]
+                    ?? containerSystemConfig.build.remote)
+                    .map(RemoteBuilderAddress.parse)
 
-                let builder: Builder? = try await withThrowingTaskGroup(of: Builder.self) { [vsockPort, cpus, memory, dnsNameservers, ssh] group in
+                if remoteAddress == nil {
+                    // before attempting to dial. This handles the case where the builder is already
+                    // running but was not started with SSH forwarding enabled.
+                    try await BuilderStart.start(
+                        cpus: cpus,
+                        memory: memory,
+                        log: log,
+                        ssh: ssh == "default",
+                        dnsNameservers: dnsNameservers,
+                        progressUpdate: progress.handler,
+                        containerSystemConfig: containerSystemConfig,
+                    )
+                }
+
+                let builder: Builder? = try await withThrowingTaskGroup(of: Builder.self) { [vsockPort, cpus, memory, dnsNameservers, ssh, remoteAddress] group in
                     defer {
                         group.cancelAll()
                     }
 
-                    group.addTask { [vsockPort, cpus, memory, log, dnsNameservers, ssh] in
+                    group.addTask { [vsockPort, cpus, memory, log, dnsNameservers, ssh, remoteAddress] in
+                        if let remoteAddress {
+                            let connection = try RemoteBuilderConnection.connect(remoteAddress)
+                            let threadGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+                            let b = try await Builder(socket: connection.handle, group: threadGroup, logger: log)
+                            let _ = try await b.info()
+                            return b
+                        }
                         let client = ContainerClient()
                         while true {
                             do {

--- a/Sources/ContainerCommands/Builder/Builder.swift
+++ b/Sources/ContainerCommands/Builder/Builder.swift
@@ -28,6 +28,7 @@ extension Application {
             subcommands: [
                 BuilderStart.self,
                 BuilderStatus.self,
+                BuilderDialStdio.self,
                 BuilderStop.self,
                 BuilderDelete.self,
             ])

--- a/Sources/ContainerCommands/Builder/BuilderDialStdio.swift
+++ b/Sources/ContainerCommands/Builder/BuilderDialStdio.swift
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ContainerAPIClient
+import Dispatch
+import Foundation
+
+extension Application {
+    /// The stdio side of a remote builder connection, the way buildctl's
+    /// dial-stdio is for buildkitd: a peer runs this over ssh and speaks to
+    /// the builder through it, so a remote machine needs no listener beyond
+    /// sshd and no verbs beyond the ones already here.
+    /// https://github.com/moby/buildkit/blob/master/client/connhelper/ssh/ssh.go
+    public struct BuilderDialStdio: AsyncLoggableCommand {
+        public static var configuration: CommandConfiguration {
+            var config = CommandConfiguration()
+            config.commandName = "dial-stdio"
+            config.abstract = "Proxy the standard streams to the builder"
+            return config
+        }
+
+        @Option(name: .long, help: ArgumentHelp("Builder shim vsock port", valueName: "port"))
+        var vsockPort: UInt32 = 8088
+
+        @OptionGroup
+        public var logOptions: Flags.Logging
+
+        public init() {}
+
+        public func run() async throws {
+            let client = ContainerClient()
+            let builder = try await client.dial(id: "buildkit", port: vsockPort)
+
+            // Two blocking copy loops, one per direction; the proxy is over
+            // when either side stops, since a half-closed conversation with
+            // a builder has nothing left to say.
+            let done = DispatchSemaphore(value: 0)
+            let stdin = FileHandle.standardInput
+            let stdout = FileHandle.standardOutput
+
+            DispatchQueue.global().async {
+                while let data = try? stdin.read(upToCount: 1 << 16), !data.isEmpty {
+                    do {
+                        try builder.write(contentsOf: data)
+                    } catch {
+                        break
+                    }
+                }
+                done.signal()
+            }
+            DispatchQueue.global().async {
+                while let data = try? builder.read(upToCount: 1 << 16), !data.isEmpty {
+                    do {
+                        try stdout.write(contentsOf: data)
+                    } catch {
+                        break
+                    }
+                }
+                done.signal()
+            }
+
+            await withCheckedContinuation { continuation in
+                DispatchQueue.global().async {
+                    done.wait()
+                    continuation.resume()
+                }
+            }
+            try? builder.close()
+        }
+    }
+}

--- a/Sources/ContainerPersistence/ContainerSystemConfig.swift
+++ b/Sources/ContainerPersistence/ContainerSystemConfig.swift
@@ -90,17 +90,22 @@ final public class BuildConfig: Codable, Sendable {
     public let cpus: Int
     public let memory: MemorySize
     public let image: String
+    /// The builder builds ride, when it is not this machine's: an ssh or
+    /// tcp address in BUILDKIT_HOST's grammar, unset for the local builder.
+    public let remote: String?
 
     public init(
         rosetta: Bool = defaultRosetta,
         cpus: Int = defaultCPUs,
         memory: MemorySize = defaultMemory,
-        image: String = defaultImage
+        image: String = defaultImage,
+        remote: String? = nil
     ) {
         self.rosetta = rosetta
         self.cpus = cpus
         self.memory = memory
         self.image = image
+        self.remote = remote
     }
 
     public init(from decoder: any Decoder) throws {
@@ -109,6 +114,7 @@ final public class BuildConfig: Codable, Sendable {
         self.cpus = try container.decodeIfPresent(Int.self, forKey: .cpus) ?? Self.defaultCPUs
         self.memory = try container.decodeIfPresent(MemorySize.self, forKey: .memory) ?? Self.defaultMemory
         self.image = try container.decodeIfPresent(String.self, forKey: .image) ?? Self.defaultImage
+        self.remote = try container.decodeIfPresent(String.self, forKey: .remote)
     }
 }
 


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Closes #2189.

The build command's builder is hardwired to this machine's: the only acquisition dials the local builder's vsock and starts one when the dial fails. A second machine with disk and cycles to spare could hold the builder, but nothing could reach it.

buildkit reaches remote daemons through `BUILDKIT_HOST`, whose ssh helper executes `buildctl dial-stdio` on the peer and speaks over the command's standard streams, the ssh channel carrying authentication and encryption with no TLS in the path; tcp reaches a listener directly, where mTLS is the hardening buildkitd documents. https://github.com/moby/buildkit/blob/master/client/connhelper/ssh/ssh.go

`builder dial-stdio` is that command for this CLI: it proxies the standard streams to the builder's vsock, so a peer needs sshd and this CLI and nothing else. The build command resolves the address from `--builder`, then the `CONTAINER_BUILD_REMOTE` environment variable, then `build.remote` in the configuration, the way `buildctl`'s `--addr` rides over `BUILDKIT_HOST`, in the same address grammar: ssh addresses spawn ssh running the peer's `dial-stdio` with a socketpair end as both of the child's streams, tcp addresses connect directly, and the connection feeds the same `Builder` the vsock path feeds.

A remote builder's lifecycle is its machine's, so the local start and retry paths stay local.

Complementary to #2188, which publishes the local daemon's socket for a client on the same machine; this is the half that crosses machines and speaks this CLI's own protocol rather than buildkit's.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs

A build driven against a second Mac over `ssh://` runs on that machine's builder, with the context served from the invoking machine as usual; a `tcp://` address reaches a listener directly. With no address configured, the local vsock path is unchanged, including its start-on-failure behaviour.

Integration suite: 397 passed. Unit suite: 772 passed. `make fmt`, `make check` clean.
