### PR TITLE
Avoid escaping slashes in JSON output

### DIFF
--- a/Sources/ContainerCommands/Machine/MachineList.swift
+++ b/Sources/ContainerCommands/Machine/MachineList.swift
@@ -61,10 +61,8 @@ extension Application {
                 let printables = machines.map {
                     PrintableMachine($0, isDefault: $0.id == defaultMachine)
                 }
-                let encoder = JSONEncoder()
-                encoder.dateEncodingStrategy = .iso8601
-                let data = try encoder.encode(printables)
-                print(String(decoding: data, as: UTF8.self))
+                let options = JSONOptions(dateEncodingStrategy: .iso8601)
+                try Output.emit(Output.renderJSON(printables, options: options))
                 return
             }
 

--- a/Sources/ContainerCommands/OutputRendering.swift
+++ b/Sources/ContainerCommands/OutputRendering.swift
@@ -44,7 +44,7 @@ public enum Output {
     /// Renders an `Encodable` value as a JSON string.
     public static func renderJSON<T: Encodable>(_ value: T, options: JSONOptions = .compact) throws -> String {
         let encoder = JSONEncoder()
-        encoder.outputFormatting = options.outputFormatting
+        encoder.outputFormatting = options.outputFormatting.union(.withoutEscapingSlashes)
         encoder.dateEncodingStrategy = options.dateEncodingStrategy
         let data = try encoder.encode(value)
         return String(decoding: data, as: UTF8.self)

--- a/Tests/ContainerCommandsTests/ListFormattingTests.swift
+++ b/Tests/ContainerCommandsTests/ListFormattingTests.swift
@@ -164,6 +164,15 @@ struct RenderJSONTests {
     }
 
     @Test
+    func doesNotEscapeSlashes() throws {
+        let item = TestItem(id: "/foo/bar", name: "https://example.com/path")
+        let json = try Output.renderJSON(item)
+        #expect(json.contains("/foo/bar"))
+        #expect(json.contains("https://example.com/path"))
+        #expect(!json.contains("\\/"))
+    }
+
+    @Test
     func prettyIsMultiLine() throws {
         let items = [TestItem(id: "a", name: "b")]
         let json = try Output.renderJSON(items, options: .pretty)


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Fixes #2204.

Swift's default `JSONEncoder` output escapes forward slashes, which makes CLI JSON paths and URLs harder to read and copy. This change makes the shared CLI JSON renderer always use `.withoutEscapingSlashes` and routes `machine list --format json` through that renderer while preserving its ISO-8601 date encoding.

OpenAI Codex assisted with investigation, implementation, and verification. The final change is limited to JSON rendering behavior and focused regression coverage.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

- `swift test --filter RenderJSONTests` — 7 tests passed
- `swift test --filter ContainerCommandsTests` — 30 tests passed
- `make test` — 763 tests passed
- strict `swift format lint` passed for all changed files
