### PR TITLE
perf(machine): fetch machines and default status concurrently in machine list

### DIFF
--- a/Sources/ContainerCommands/Machine/MachineList.swift
+++ b/Sources/ContainerCommands/Machine/MachineList.swift
@@ -41,14 +41,18 @@ extension Application {
 
         public func run() async throws {
             let client = MachineClient()
-            let machines = try await client.list()
+
+            async let machinesTask = client.list()
+            async let defaultMachineTask = client.getDefault()
+
+            let machines = try await machinesTask
 
             if self.quiet {
                 machines.forEach { print($0.id) }
                 return
             }
 
-            let defaultMachine = try await client.getDefault()
+            let defaultMachine = try await defaultMachineTask
             try printMachines(machines: machines, format: format, defaultMachine: defaultMachine)
         }
 


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Resolves #2212

In `Sources/ContainerCommands/Machine/MachineList.swift`, the `run()` method was previously fetching the list of machines (`client.list()`) and the default machine (`client.getDefault()`) sequentially.

Using Swift's concurrency (`async let`), these two asynchronous operations are now executed in parallel to improve command performance and reduce latency.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs