### PR TITLE
Add createDirectoryIfNeeded method to ApplicationRoot

### DIFF
--- a/Sources/ContainerPlugin/ApplicationRoot.swift
+++ b/Sources/ContainerPlugin/ApplicationRoot.swift
@@ -45,4 +45,18 @@ public struct ApplicationRoot {
 
     /// The pathname to the root directory
     public static let pathname = path.string
+
+    /// Ensures that the application root directory exists on disk, creating it and any intermediate directories if necessary.
+    @discardableResult
+    public static func createDirectoryIfNeeded() throws -> URL {
+        let url = URL(fileURLWithPath: pathname)
+        if !FileManager.default.fileExists(atPath: url.path) {
+            try FileManager.default.createDirectory(
+                at: url,
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+        }
+        return url
+    }
 }


### PR DESCRIPTION
 Implement a utility method to ensure the application root directory and any intermediate directories exist on disk.

Adds a utility method to ensure the application root directory exists on disk, preventing runtime path resolution errors. Related to issue #2215 
## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
[Why is this change needed?]

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
