### PR TITLE
Add `container restart` command to stop and start one or more containers

### DIFF
--- a/Sources/ContainerCommands/Application.swift
+++ b/Sources/ContainerCommands/Application.swift
@@ -67,6 +67,7 @@ public struct Application: AsyncLoggableCommand {
                     ContainerStart.self,
                     ContainerStats.self,
                     ContainerStop.self,
+                    ContainerRestart.self,
                     ContainerPrune.self,
                 ]
             ),

--- a/Sources/ContainerCommands/Container/ContainerRestart.swift
+++ b/Sources/ContainerCommands/Container/ContainerRestart.swift
@@ -1,0 +1,114 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+import ContainerAPIClient
+import ContainerResource
+import ContainerizationError
+import Foundation
+
+extension Application {
+    public struct ContainerRestart: AsyncLoggableCommand {
+        public init() {}
+
+        public static let configuration = CommandConfiguration(
+            commandName: "restart",
+            abstract: "Restart one or more containers")
+
+        @Flag(name: .shortAndLong, help: "Restart all non-machine containers")
+        var all = false
+
+        @Option(name: .shortAndLong, help: "Signal to send to the containers during stop")
+        var signal: String?
+
+        @Option(name: .shortAndLong, help: "Seconds to wait before killing the containers during stop")
+        var time: Int32 = 5
+
+        @OptionGroup
+        public var logOptions: Flags.Logging
+
+        @Argument(help: "Container IDs")
+        var containerIds: [String] = []
+
+        public func validate() throws {
+            if containerIds.count == 0 && !all {
+                throw ContainerizationError(.invalidArgument, message: "no containers specified and --all not supplied")
+            }
+            if containerIds.count > 0 && all {
+                throw ContainerizationError(.invalidArgument, message: "explicitly supplied container IDs conflict with the --all flag")
+            }
+        }
+
+        public mutating func run() async throws {
+            let client = ContainerClient()
+
+            let containers: [String]
+            if self.all {
+                let filters = ContainerListFilters().withoutMachines()
+                containers = try await client.list(filters: filters).map { $0.id }
+            } else {
+                containers = containerIds
+            }
+
+            let stopOpts = ContainerStopOptions(
+                timeoutInSeconds: self.time,
+                signal: self.signal
+            )
+
+            var errors: [any Error] = []
+            for container in containers {
+                do {
+                    try await restartContainer(client: client, id: container, stopOptions: stopOpts)
+                    print(container)
+                } catch {
+                    errors.append(error)
+                }
+            }
+
+            if !errors.isEmpty {
+                throw AggregateError(errors)
+            }
+        }
+
+        private func restartContainer(client: ContainerClient, id: String, stopOptions: ContainerStopOptions) async throws {
+            let snapshot = try await client.get(id: id)
+
+            // Stop the container if it is currently running.
+            if snapshot.status == .running {
+                try await client.stop(id: id, opts: stopOptions)
+            }
+
+            // Start the container in detached mode.
+            let io = try ProcessIO.create(
+                tty: snapshot.configuration.initProcess.terminal,
+                interactive: false,
+                detach: true
+            )
+            defer {
+                try? io.close()
+            }
+
+            var env: [String: String] = [:]
+            if let sshAuthSock = ProcessInfo.processInfo.environment["SSH_AUTH_SOCK"] {
+                env["SSH_AUTH_SOCK"] = sshAuthSock
+            }
+
+            let process = try await client.bootstrap(id: id, stdio: io.stdio, dynamicEnv: env)
+            try await process.start()
+            try io.closeAfterStart()
+        }
+    }
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -300,6 +300,42 @@ container stop [--all] [--signal <signal>] [--time <time>] [--debug] [<container
 *   `-s, --signal <signal>`: Signal to send to the containers (default: SIGTERM)
 *   `-t, --time <time>`: Seconds to wait before killing the containers (default: 5)
 
+### `container restart`
+
+Restarts one or more containers by stopping them gracefully and then starting them again. If a container is already stopped, it is simply started. The container always restarts in detached mode.
+
+**Usage**
+
+```bash
+container restart [--all] [--signal <signal>] [--time <time>] [--debug] [<container-ids> ...]
+```
+
+**Arguments**
+
+*   `<container-ids>`: Container IDs
+
+**Options**
+
+*   `-a, --all`: Restart all non-machine containers
+*   `-s, --signal <signal>`: Signal to send to the containers during stop
+*   `-t, --time <time>`: Seconds to wait before killing the containers during stop (default: 5)
+
+**Examples**
+
+```bash
+# restart a single container
+container restart my-web-server
+
+# restart multiple containers
+container restart web-server api-server worker
+
+# restart all containers
+container restart --all
+
+# restart with a longer timeout for graceful shutdown
+container restart --time 30 my-web-server
+```
+
 ### `container kill`
 
 Immediately kills running containers by sending a signal (defaults to `KILL`). Use with caution: it does not allow for graceful shutdown.


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

closes #2219 

## Motivation and Context
Right now there's no way to restart a container without running `container stop` and then `container start` separately. Every other container tool (Docker, Podman, nerdctl) has a `restart` command, so it felt like a natural thing to add. I kept hitting this myself when iterating on containers and wanted a single command to do it.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [x] Added/updated docs

Built the `ContainerCommands` target locally and confirmed it compiles cleanly. Added a `container restart` section to `command-reference.md` with usage and examples.

