### PR TITLE
Test: add full payload JSON round-trip test in SystemStatusTests

### DIFF
--- a/Tests/ContainerCommandsTests/SystemStatusTests.swift
+++ b/Tests/ContainerCommandsTests/SystemStatusTests.swift
@@ -110,4 +110,17 @@ struct SystemStatusTests {
         let updated = Application.SystemStatus.withImageCount(resources, imageCount: nil)
         #expect(updated?.images == nil)
     }
+    @Test
+    func fullPayloadRoundTripsThroughJSON() throws {
+        let payload = makeRunningPayload(
+            paths: Application.PathInfo(appRoot: "/app", installRoot: "/install", logRoot: "/log"),
+            resources: Application.ResourceCounts(containersTotal: 10, containersRunning: 4)
+        )
+        let json = try Output.renderJSON(payload)
+        let decoded = try JSONDecoder().decode(Application.StatusPayload.self, from: Data(json.utf8))
+        
+        #expect(decoded.paths?.appRoot == "/app")
+        #expect(decoded.resources?.containersTotal == 10)
+        #expect(decoded.resources?.containersRunning == 4)
+    }
 }

--- a/Tests/ContainerCommandsTests/SystemStatusTests.swift
+++ b/Tests/ContainerCommandsTests/SystemStatusTests.swift
@@ -119,10 +119,9 @@ struct SystemStatusTests {
         )
         let json = try Output.renderJSON(payload)
         let decoded = try JSONDecoder().decode(Application.StatusPayload.self, from: Data(json.utf8))
-        
+
         #expect(decoded.paths?.appRoot == "/app")
         #expect(decoded.resources?.containersTotal == 10)
         #expect(decoded.resources?.containersRunning == 4)
     }
 }
-

--- a/Tests/ContainerCommandsTests/SystemStatusTests.swift
+++ b/Tests/ContainerCommandsTests/SystemStatusTests.swift
@@ -110,6 +110,7 @@ struct SystemStatusTests {
         let updated = Application.SystemStatus.withImageCount(resources, imageCount: nil)
         #expect(updated?.images == nil)
     }
+
     @Test
     func fullPayloadRoundTripsThroughJSON() throws {
         let payload = makeRunningPayload(

--- a/Tests/ContainerCommandsTests/SystemStatusTests.swift
+++ b/Tests/ContainerCommandsTests/SystemStatusTests.swift
@@ -125,3 +125,4 @@ struct SystemStatusTests {
         #expect(decoded.resources?.containersRunning == 4)
     }
 }
+


### PR DESCRIPTION
Adds a new unit test to verify that system status payloads with nested paths and resource counts correctly round-trip through JSON encoding and decoding.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
Adds comprehensive JSON round-trip unit test coverage for SystemStatusTests to ensure correct encoding/decoding of nested paths and resource counts.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs
