### PR TITLE
docs: remove broken troubleshooting.md link in technical overview

### DIFF
--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -74,4 +74,4 @@ In macOS 15, all containers attach to the default vmnet network. The `container 
 
 In macOS 15, limitations in the vmnet framework mean that the container network can only be created when the first container starts. Since the network XPC helper provides IP addresses to containers, and the helper has to start before the first container, it is possible for the network helper and vmnet to disagree on the subnet address, resulting in containers that are completely cut off from the network.
 
-Normally, vmnet creates the container network using the CIDR address 192.168.64.1/24, and on macOS 15, `container` defaults to using this CIDR address in the network helper. If your containers have no network access on macOS 15, see [All networking fails on macOS 15](troubleshooting.md#all-networking-fails-on-macos-15) for diagnosis and remediation steps.
+Normally, vmnet creates the container network using the CIDR address 192.168.64.1/24, and on macOS 15, `container` defaults to using this CIDR address in the network helper.


### PR DESCRIPTION
## Type of Change
- [x] Documentation update

## Motivation and Context
`docs/technical-overview.md` links to `troubleshooting.md#all-networking-fails-on-macos-15`, but that file does not exist. This removes the sentence with the dead link and leaves the rest of the section as is.

Fixes #1604

## Testing
- [x] Tested locally
- [x] Added/updated docs