### PR TITLE
Fix a compilation error

### DIFF
--- a/Sources/ContainerBuild/Builder.swift
+++ b/Sources/ContainerBuild/Builder.swift
@@ -108,7 +108,7 @@ public struct Builder: Sendable {
         }
 
         if let terminal = config.terminal {
-            Task {
+            _ = Task {
                 let winchHandler = AsyncSignalHandler.create(notify: [SIGWINCH])
                 let setWinch = { (rows: UInt16, cols: UInt16) in
                     var winch = ClientStream()


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context
Fixes a compilation error below. Similar to https://github.com/apple/container/pull/2119.
```
error: SwiftCompile normal arm64 /Users/Dmitry/Apple/container/Sources/ContainerBuild/Builder.swift failed with a nonzero exit code. Command line:     cd /Users/Dmitry/Apple
    builtin-SwiftPerFileCompile Builder.swift
/Users/Dmitry/Apple/container/Sources/ContainerBuild/Builder.swift:111:13: error: unstructured throwing task created by 'init(name:priority:operation:)' is not used, which may accidentally ignore errors thrown inside the task [#NoUseUnstructuredThrowingTask]
109 | 
110 |         if let terminal = config.terminal {
111 |             Task {
    |             |- error: unstructured throwing task created by 'init(name:priority:operation:)' is not used, which may accidentally ignore errors thrown inside the task [#NoUseUnstructuredThrowingTask]
    |             `- note: to silence this warning, handle the error inside the task, or store/discard the task value explicitly
112 |                 let winchHandler = AsyncSignalHandler.create(notify: [SIGWINCH])
113 |                 let setWinch = { (rows: UInt16, cols: UInt16) in
```

## Testing
- [x] Tested locally