### PR TITLE
Fix compilation warnings

### DIFF
--- a/Sources/Plugins/NetworkVmnet/NetworkVmnetHelper+Start.swift
+++ b/Sources/Plugins/NetworkVmnet/NetworkVmnetHelper+Start.swift
@@ -26,6 +26,7 @@ import ContainerizationError
 import ContainerizationExtras
 import Foundation
 import Logging
+import SystemPackage
 
 enum Variant: String, ExpressibleByArgument {
     case reserved

--- a/Sources/Plugins/RuntimeLinux/RuntimeLinuxHelper+Start.swift
+++ b/Sources/Plugins/RuntimeLinux/RuntimeLinuxHelper+Start.swift
@@ -24,6 +24,7 @@ import ContainerXPC
 import Foundation
 import Logging
 import NIO
+import SystemPackage
 
 extension RuntimeLinuxHelper {
     struct Start: AsyncParsableCommand {


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context
Fix compilation warnings below. Similar to https://github.com/apple/container/pull/2119.
```
/Users/Dmitry/Apple/container/Sources/Plugins/NetworkVmnet/NetworkVmnetHelper+Start.swift:70:13: warning: cannot use struct 'FilePath' in a property declaration member of a type not marked '@_implementationOnly'; 'SystemPackage' was not imported by this file
 68 |         }()
 69 | 
 70 |         var logRoot = LogRoot.path
    |             `- warning: cannot use struct 'FilePath' in a property declaration member of a type not marked '@_implementationOnly'; 'SystemPackage' was not imported by this file
 71 | 
 72 |         func run() async throws {

SystemPackage.FilePath:2:15: note: struct declared here
1 | @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
2 | public struct FilePath : Sendable {
  |               `- note: struct declared here
3 |     public init()
4 | }
/Users/Dmitry/Apple/container/Sources/Plugins/RuntimeLinux/RuntimeLinuxHelper+Start.swift:46:13: warning: cannot use struct 'FilePath' in a property declaration member of a type not marked '@_implementationOnly'; 'SystemPackage' was not imported by this file
 44 |         var root: String
 45 | 
 46 |         var logRoot = LogRoot.path
    |             `- warning: cannot use struct 'FilePath' in a property declaration member of a type not marked '@_implementationOnly'; 'SystemPackage' was not imported by this file
 47 | 
 48 |         var machServiceLabel: String {

SystemPackage.FilePath:2:15: note: struct declared here
1 | @available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 9.0, visionOS 1.0, *)
2 | public struct FilePath : Sendable {
  |               `- note: struct declared here
3 |     public init()
4 | }
```

## Testing
- [x] Tested locally