### PR TITLE
fix(dns): avoid global resolver search domains

### DIFF
--- a/Sources/Services/ContainerAPIService/Client/HostDNSResolver.swift
+++ b/Sources/Services/ContainerAPIService/Client/HostDNSResolver.swift
@@ -66,7 +66,6 @@ public struct HostDNSResolver {
             } ?? ""
         let resolverText = """
             domain \(name)
-            search \(name)
             nameserver 127.0.0.1
             port \(dnsPort)
             \(options)

--- a/Tests/ContainerAPIClientTests/HostDNSResolverTest.swift
+++ b/Tests/ContainerAPIClientTests/HostDNSResolverTest.swift
@@ -42,13 +42,13 @@ struct HostDNSResolverTest {
         let actualText = try String(contentsOfFile: resolverConfigPath.string, encoding: .utf8)
         let expectedText = """
             domain foo.bar
-            search foo.bar
             nameserver 127.0.0.1
             port 2053
 
             """
 
         #expect(actualText == expectedText)
+        #expect(!actualText.split(separator: "\n").contains { $0.hasPrefix("search ") })
 
         try resolver.createDomain(name: try! DNSName("bar.foo"))
         let domains = resolver.listDomains()


### PR DESCRIPTION
> [!IMPORTANT]
> The commit is signed and verified.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

Closes #1917.

Scoped files under `/etc/resolver` only need the domain, nameserver, and port. Removing the `search` directive prevents unrelated single-label hostnames from being expanded through a stopped container DNS server.

This supersedes #2129, which was closed after its fork branch was deleted; it is refreshed as one signed commit on current `main` (`eee7ad097079cc3b02d5309ec10160143f2d0c6a`).

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

- `swift test --filter HostDNSResolverTest`: 5 tests passed.
- `git diff --check`: passed.
