### PR TITLE
Fix a compilation warning

### DIFF
--- a/Tests/ContainerOSTests/DirectoryWatcherTest.swift
+++ b/Tests/ContainerOSTests/DirectoryWatcherTest.swift
@@ -16,7 +16,6 @@
 
 import ContainerOS
 import ContainerizationError
-import DNSServer
 import Foundation
 import SystemPackage
 import Testing


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Motivation and Context
Fixes a compilation warning:
```
warning: 'ContainerOSTests-product' is missing a dependency on 'DNSServer' because dependency scan of Swift module 'ContainerOSTests' discovered a dependency on 'DNSServer'
```

## Testing
- [x] Tested locally
