### PR TITLE
docs: use an existing kindest/node tag in the k8s node image example

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -147,7 +147,7 @@ container k8s load-image --platform linux/amd64 my-app:latest
 By default, clusters use `kindest/node:v1.35.5`, a Kubernetes-in-Docker image optimized for local development. You can use a different node image when creating a cluster:
 
 ```bash
-container k8s create --node-image docker.io/kindest/node:v1.34.4
+container k8s create --node-image docker.io/kindest/node:v1.34.11
 ```
 
 ## Cluster cleanup


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context

`kindest/node:v1.34.4` does not exist on Docker Hub, so the example in docs/kubernetes.md fails with a 404 on the manifest. The 1.34 tags available are v1.34.0, .2, .3, .8 and .11. This switches the example to v1.34.11.

## Testing
- [x] Tested locally: `container run docker.io/kindest/node:v1.34.4` fails with `404 Not Found` on the manifest; `docker.io/kindest/node:v1.34.11` pulls and boots.
- [ ] Added/updated tests
- [x] Added/updated docs
