### PR TITLE
forwarder: close backend channel immediately if frontend closes

### DIFF
--- a/Sources/SocketForwarder/ConnectHandler.swift
+++ b/Sources/SocketForwarder/ConnectHandler.swift
@@ -62,7 +62,7 @@ extension ConnectHandler {
                 case .success(let channel):
                     guard context.channel.isActive else {
                         self.log?.trace("backend - frontend channel closed, closing backend connection")
-                        context.channel.close(promise: nil)
+                        channel.close(promise: nil)
                         return
                     }
                     self.log?.trace("backend - connected")


### PR DESCRIPTION
When a peer closes their connection while we're establishing the backend connection, we must close the backend channel to release its file descriptors immediately. Previously, the code closed the peer channel (already closed anyway), leaving the backend channel orphaned until garbage collection.

Now we explicitly close the backend channel when the peer channel is no longer active, preventing delayed FD cleanup.

Fixes: #2261

> [!IMPORTANT]
> All commits must be signed and verified. Pull requests containing unsigned or unverified commits cannot be built or merged. See the [GitHub documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#about-commit-signature-verification) for instructions.
>
> For all but trivial fixes, make sure to first create a GitHub issue that concisely describes the bug or desired enhancement as justification for the change. Large PRs with no justifying issue will be closed.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
[Why is this change needed?]

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [ ] Added/updated docs
