### PR TITLE
Keep fractional memory sizes intact when a configuration is persisted

### DIFF
--- a/Sources/ContainerPersistence/MemorySize.swift
+++ b/Sources/ContainerPersistence/MemorySize.swift
@@ -39,19 +39,31 @@ public struct MemorySize: Codable, Sendable, Equatable, CustomStringConvertible 
         try container.encode(formatted)
     }
 
-    private static let unitLabels: [UnitInformationStorage: String] = [
-        .bytes: "b",
-        .kibibytes: "kb",
-        .mebibytes: "mb",
-        .gibibytes: "gb",
-        .tebibytes: "tb",
-        .pebibytes: "pb",
+    /// Unit labels ordered largest first, so that a size can be stepped down to the
+    /// largest unit that still expresses it as a whole number.
+    private static let unitLabels: [(unit: UnitInformationStorage, label: String)] = [
+        (.pebibytes, "pb"),
+        (.tebibytes, "tb"),
+        (.gibibytes, "gb"),
+        (.mebibytes, "mb"),
+        (.kibibytes, "kb"),
+        (.bytes, "b"),
     ]
 
     public var formatted: String {
-        let value = Int64(measurement.value)
-        let label = Self.unitLabels[measurement.unit] ?? "unknown"
-        return "\(value)\(label)"
+        // This is what `encode(to:)` writes, so it has to parse back into the same size.
+        // A whole value keeps the unit it was given; a fractional one steps down to a
+        // smaller unit, because truncating it here shrinks the persisted configuration.
+        guard let start = Self.unitLabels.firstIndex(where: { $0.unit == measurement.unit }) else {
+            return "\(Int64(measurement.value))unknown"
+        }
+        for entry in Self.unitLabels[start...] {
+            let value = measurement.converted(to: entry.unit).value
+            if value == value.rounded() {
+                return "\(Int64(value))\(entry.label)"
+            }
+        }
+        return "\(Int64(measurement.converted(to: .bytes).value.rounded()))b"
     }
 }
 

--- a/Tests/ContainerAPIClientTests/MemorySizeTests.swift
+++ b/Tests/ContainerAPIClientTests/MemorySizeTests.swift
@@ -61,6 +61,25 @@ struct MemorySizeTests {
         #expect(original == decoded)
     }
 
+    @Test(
+        arguments: [
+            ("1.5gb", "1536mb"),
+            ("0.5tb", "512gb"),
+            ("2.5kb", "2560b"),
+        ] as [(String, String)])
+    func testFractionalFormattedOutput(input: String, expected: String) throws {
+        let size = try MemorySize(input)
+        #expect(size.formatted == expected)
+    }
+
+    @Test(arguments: ["1gb", "2048mb", "1.5gb", "0.5tb"])
+    func testRoundTripPreservesSize(input: String) throws {
+        let original = try MemorySize(input)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(MemorySize.self, from: data)
+        #expect(decoded.toUInt64(unit: .bytes) == original.toUInt64(unit: .bytes))
+    }
+
     @Test func testDecodingFromString() throws {
         let json = Data("\"512kb\"".utf8)
         let decoded = try JSONDecoder().decode(MemorySize.self, from: json)


### PR DESCRIPTION
> [!IMPORTANT]
> All commits must be signed and verified. Pull requests containing unsigned or unverified commits cannot be built or merged. See the [GitHub documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#about-commit-signature-verification) for instructions.
>
> For all but trivial fixes, make sure to first create a GitHub issue that concisely describes the bug or desired enhancement as justification for the change. Large PRs with no justifying issue will be closed.

Fixes #2262.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context

`MemorySize.encode(to:)` writes `formatted`, and `formatted` truncated the measurement to `Int64` in whatever unit it had been parsed in. `Measurement.parse` accepts a decimal point on purpose, so a fractional size is valid input — but it shrank every time the configuration holding it was written to disk.

I noticed this while reading `MachineConfig`, which persists its `memory` field through `Codable`. Encoding and decoding a few values through the type as it stands on `main`:

| input | bytes before encoding | encoded | bytes after decoding |
| --- | --- | --- | --- |
| `1gb` | 1073741824 | `"1gb"` | 1073741824 |
| `1.5gb` | 1610612736 | `"1gb"` | 1073741824 |
| `0.5tb` | 549755813888 | `"0tb"` | 0 |

So `container machine create --memory 1.5g` stores 1 GiB, and the machine boots with 1 GiB, because `MachinesService` reads `bootConfig.memory.toUInt64(unit: .bytes)` back out of the store. Worse, a size below 1 in its own unit encodes to `0<unit>`: `MachineConfig.init(from:)` calls `validate()`, which refuses anything under 1 GiB, so a machine created with `--memory 0.5t` ends up with a configuration that no longer decodes.

The fix renders the value in the largest unit that still expresses it as a whole number, so the string `encode(to:)` writes parses back to the same number of bytes. A whole value keeps the unit it was given, so `1gb`, `2048mb`, `512kb`, `1024b` and `4tb` all render exactly as before and no stored configuration changes meaning. The only visible difference is for a fractional size, which now reads `1536mb` instead of `1gb` — that is the point of the change.

I kept the fix to the rendering itself. `formatted` and `toUInt64` also trap on a size large enough to overflow `Int64`/`UInt64`, which is a separate problem and not something this change addresses.

## Testing
- [x] Tested locally
- [x] Added/updated tests
- [ ] Added/updated docs

I don't have a macOS host to run the CLI on, so I built `Sources/ContainerPersistence/MemorySize.swift` and `Measurement+Parse.swift` as a standalone module with Swift 6.2 and ran the updated `MemorySizeTests` against it. With the fix reverted, the two new cases fail with five issues (`"1.5gb"` formats as `1gb`, `"0.5tb"` as `0tb`, and both round-trips lose bytes); with the fix, all 11 tests in the suite pass, including the eight that were already there. `swift format lint --strict` with the repository configuration is clean on both changed files.

AI tools used
