### PR TITLE
Sync command reference with current CLI options

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -56,6 +56,7 @@ container run [<options>] <image> [<arguments> ...]
 *   `--init`: Run an init process inside the container that forwards signals and reaps processes
 *   `--init-image <image>`: Use a custom init image instead of the default. This allows customizing boot-time behavior before the OCI container starts, such as running VM-level daemons, configuring eBPF filters, or debugging the init process.
 *   `-k, --kernel <path>`: Set a custom kernel path
+*   `--kernel-arg <arg>`: Append a raw boot argument to the kernel command line (repeatable).
 *   `-l, --label <label>`: Add a key=value label to the container
 *   `--masked-path <path>`: **Experimental.** Hide a path inside the container, in addition to the runtime defaults (or `NONE` to clear prior values and the defaults)
 *   `--mount <mount>`: Add a mount to the container (format: type=<>,source=<>,target=<>,readonly)
@@ -79,19 +80,7 @@ container run [<options>] <image> [<arguments> ...]
 
 **Registry Options**
 
-*   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https, auto) (default: auto)
-
-    * **Behavior of `auto`**
-
-        When `auto` is selected, the target registry is considered **internal/local** if the registry host matches any of these criteria:
-        - The host is a loopback address (e.g., `localhost`, `127.*`)
-        - The host is within the `RFC1918` private IP ranges:
-            - `10.*.*.*`
-            - `192.168.*.*`
-            - `172.16.*.*` through `172.31.*.*`
-        - The host ends with the machine's default container DNS domain (as defined in `DNSConfig.defaultDomain`, located [here](../Sources/ContainerPersistence/ContainerSystemConfig.swift))
-
-        For internal/local registries, the client uses **HTTP**. Otherwise, it uses **HTTPS**.
+*   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https) (default: https)
 
 **Progress Options**
 
@@ -232,6 +221,7 @@ container create [<options>] <image> [<arguments> ...]
 *   `--init`: Run an init process inside the container that forwards signals and reaps processes
 *   `--init-image <image>`: Use a custom init image instead of the default. This allows customizing boot-time behavior before the OCI container starts, such as running VM-level daemons, configuring eBPF filters, or debugging the init process.
 *   `-k, --kernel <path>`: Set a custom kernel path
+*   `--kernel-arg <arg>`: Append a raw boot argument to the kernel command line (repeatable).
 *   `-l, --label <label>`: Add a key=value label to the container
 *   `--masked-path <path>`: **Experimental.** Hide a path inside the container, in addition to the runtime defaults (or `NONE` to clear prior values and the defaults)
 *   `--mount <mount>`: Add a mount to the container (format: type=<>,source=<>,target=<>,readonly)
@@ -255,7 +245,7 @@ container create [<options>] <image> [<arguments> ...]
 
 **Registry Options**
 
-*   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https, auto) (default: auto)
+*   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https) (default: https)
 
 **Image Fetch Options**
 
@@ -591,7 +581,7 @@ container image pull [--scheme <scheme>] [--progress <type>] [--max-concurrent-d
 
 **Options**
 
-*   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https, auto) (default: auto)
+*   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https) (default: https)
 *   `--progress <type>`: Progress type (format: auto|none|ansi|plain|color) (default: auto)
 *   `--max-concurrent-downloads <max-concurrent-downloads>`: Maximum number of concurrent downloads (default: 3)
 *   `-a, --arch <arch>`: Limit the pull to the specified architecture
@@ -614,7 +604,7 @@ container image push [--scheme <scheme>] [--progress <type>] [--arch <arch>] [--
 
 **Options**
 
-*   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https, auto) (default: auto)
+*   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https) (default: https)
 *   `--progress <type>`: Progress type (format: auto|none|ansi|plain|color) (default: auto)
 *   `-a, --arch <arch>`: Limit the push to the specified architecture
 *   `--os <os>`: Limit the push to the specified OS
@@ -1038,7 +1028,7 @@ container registry login [--scheme <scheme>] [--password-stdin] [--username <use
 
 **Options**
 
-*   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https, auto) (default: auto)
+*   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https) (default: https)
 *   `--password-stdin`: Take the password from stdin
 *   `-u, --username <username>`: Registry user name
 
@@ -1112,7 +1102,7 @@ container machine create [<options>] <image>
 
 **Registry Options**
 
-*   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https, auto) (default: auto)
+*   `--scheme <scheme>`: Scheme to use when connecting to the container registry. One of (http, https) (default: https)
 
 **Progress Options**
 
@@ -1626,7 +1616,7 @@ container k8s create [--name <name>] [--node-image <image>] [--rm] [<resource op
 
 **Registry Options**
 
-*   `--scheme <scheme>`: Scheme for the container registry (values: http, https, auto; default: auto)
+*   `--scheme <scheme>`: Scheme for the container registry (values: http, https; default: https)
 
 **Image Fetch Options**
 

--- a/docs/shell-completions.md
+++ b/docs/shell-completions.md
@@ -7,7 +7,7 @@ Generate and install completion scripts for `zsh`, `bash`, and `fish`.
 The `container --generate-completion-script [zsh|bash|fish]` command generates completion scripts for the provided shell. Below is a detailed guide on how to install the completion scripts.
 
 > [!NOTE]
-> See the [swift-argument-parser documentation](https://apple.github.io/swift-argument-parser/documentation/argumentparser/installingcompletionscripts/#Installing-Zsh-Completions) for more information about generating and installing shell completion scripts.
+> See the [swift-argument-parser documentation](https://github.com/apple/swift-argument-parser/blob/main/Sources/ArgumentParser/Documentation.docc/Articles/InstallingCompletionScripts.md#installing-zsh-completions) for more information about generating and installing shell completion scripts.
 
 ## Installing `zsh` completions
 


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context

The command reference still documents a registry scheme value the CLI no longer accepts. #2100 removed the `auto` scheme in code only, so all seven `--scheme` lines and the "Behavior of `auto`" block under `container run` disagree with `container run --help`, which prints `One of (http, https) (default: https)`. #1744 added `--kernel-arg` to `container run` and `container create` without a reference entry, so `grep -rn kernel-arg docs` finds nothing. The shell completions note links to apple.github.io/swift-argument-parser, which now returns 404 for every path including its root, so it now points at the article's source in apple/swift-argument-parser, which returns 200. #1571 proposed a CI check to keep this file in sync with `--help` but was closed unmerged, so the drift is still here.

## Testing
- [x] Tested locally
- [ ] Added/updated tests
- [x] Added/updated docs

Docs only. Compared each edited line against `--help` for `run`, `create`, `image pull`, `image push`, `registry login`, and `machine create` from a build of main, then checked `grep -n "https, auto" docs/command-reference.md` (no output), `grep -c "default: https)" docs/command-reference.md` (7), and `grep -c "kernel-arg" docs/command-reference.md` (2). `container k8s create` uses the same `Flags.Registry` group (ContainerK8s/Commands/K8sCreate.swift), so its line follows.
