### PR TITLE
Apply --ulimit in container exec and machine run

### DIFF
--- a/Sources/ContainerCommands/Container/ContainerExec.swift
+++ b/Sources/ContainerCommands/Container/ContainerExec.swift
@@ -77,6 +77,9 @@ extension Application {
                 gid: processFlags.gid, defaultUser: defaultUser)
             config.user = user
             config.supplementalGroups.append(contentsOf: additionalGroups)
+            if !self.processFlags.ulimits.isEmpty {
+                config.rlimits = try Parser.rlimits(self.processFlags.ulimits)
+            }
 
             do {
                 let io = try ProcessIO.create(tty: tty, interactive: stdin, detach: self.detach)

--- a/Sources/ContainerCommands/Machine/MachineRun.swift
+++ b/Sources/ContainerCommands/Machine/MachineRun.swift
@@ -111,7 +111,8 @@ extension Application {
                 workingDirectory: cwd,
                 terminal: tty,
                 user: user,
-                supplementalGroups: additionalGroups
+                supplementalGroups: additionalGroups,
+                rlimits: try Parser.rlimits(processFlags.ulimits)
             )
 
             let io = try ProcessIO.create(tty: tty, interactive: interactive, detach: detach)

--- a/Tests/IntegrationTests/Containers/TestCLIExecCommand.swift
+++ b/Tests/IntegrationTests/Containers/TestCLIExecCommand.swift
@@ -114,4 +114,21 @@ struct TestCLIExecCommand {
             _ = try f.getContainerStatus(name)
         }
     }
+
+    @Test func testExecUlimitNofile() async throws {
+        try await ContainerFixture.with { f in
+            let image = WarmupImage.alpine320.rawValue
+            let name = "\(f.testID)-c"
+            try f.doCreate(name: name, image: image)
+            f.addCleanup { try? f.doStop(name) }
+            try f.doStart(name)
+            try await f.waitForContainerRunning(name)
+
+            let nofile = try f.run(["exec", "--ulimit", "nofile=1024:2048", name, "sh", "-c", "ulimit -n"])
+                .check().output
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            #expect(nofile == "1024", "expected exec --ulimit to set the nofile soft limit, got \(nofile)")
+            try f.doStop(name)
+        }
+    }
 }

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -361,7 +361,7 @@ Executes a command inside a running container. It uses the same process flags as
 **Usage**
 
 ```bash
-container exec [--detach] [--env <env> ...] [--env-file <env-file> ...] [--gid <gid>] [--interactive] [--tty] [--user <user>] [--uid <uid>] [--workdir <dir>] [--debug] <container-id> <arguments> ...
+container exec [--detach] [--env <env> ...] [--env-file <env-file> ...] [--gid <gid>] [--interactive] [--tty] [--user <user>] [--uid <uid>] [--ulimit <limit>] [--workdir <dir>] [--debug] <container-id> <arguments> ...
 ```
 
 **Arguments**
@@ -382,6 +382,7 @@ container exec [--detach] [--env <env> ...] [--env-file <env-file> ...] [--gid <
 *   `-t, --tty`: Open a TTY with the process
 *   `-u, --user <user>`: Set the user for the process (format: name|uid[:gid])
 *   `--uid <uid>`: Set the user ID for the process
+*   `--ulimit <limit>`: Set resource limits (format: `<type>=<soft>[:<hard>]`)
 *   `-w, --workdir, --cwd <dir>`: Set the initial working directory inside the container
 
 ### `container export`
@@ -1168,6 +1169,7 @@ container machine run [<options>] [<executable>] [<arguments> ...]
 *   `-t, --tty`: Open a TTY with the process
 *   `-u, --user <user>`: Set the user for the process (format: name|uid[:gid])
 *   `--uid <uid>`: Set the user ID for the process
+*   `--ulimit <limit>`: Set resource limits (format: `<type>=<soft>[:<hard>]`)
 *   `-w, --workdir, --cwd <dir>`: Set the initial working directory inside the container
 
 **Examples**


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation update

## Motivation and Context
`container exec` and `container machine run` embed `Flags.Process`, so both print `--ulimit <limit>` in their help and accept the flag without error, but neither ever reads `processFlags.ulimits`; the only reader is `Parser.process` on the run/create path. Exec therefore keeps whatever rlimits the init process was started with and the value you passed is dropped with no warning, even though the guest already applies per-process rlimits on exec via `App.setRLimits(rlimits: process.rlimits)` in containerization's `vmexec/ExecCommand.swift`. #1129 added `--ulimit` to `Flags.Process` and wired it into run and create only, which is where the gap came from. This sets `config.rlimits` on exec when `--ulimit` is given, leaving the init process limits in place when it is not, and passes `rlimits:` into the `ProcessConfiguration` that `machine run` builds.

Fixes #2266

## Testing
- [ ] Tested locally
- [x] Added/updated tests
- [x] Added/updated docs

`swift build --product container` succeeds and `.build/debug/container exec --help | grep ulimit` still lists the flag, and `make swift-fmt` leaves the diff unchanged. The new `testExecUlimitNofile` in `TestCLIExecCommand` is compile-verified only: the integration suite needs an installed CLI and a running container system, which I could not run locally, so every test in that suite fails at fixture setup with `binaryNotFound` on my machine.
